### PR TITLE
Defect fix - raid 279

### DIFF
--- a/raid-agency-app/package-lock.json
+++ b/raid-agency-app/package-lock.json
@@ -40,6 +40,7 @@
         "zod": "3.22.4"
       },
       "devDependencies": {
+        "@hookform/devtools": "^4.4.0",
         "@types/node": "20.14.10",
         "@types/trusted-types": "2.0.7",
         "@typescript-eslint/eslint-plugin": "6.21.0",
@@ -1050,6 +1051,27 @@
       "version": "5.0.20",
       "resolved": "https://registry.npmjs.org/@fontsource/figtree/-/figtree-5.0.20.tgz",
       "integrity": "sha512-Rn0xoiHUxSwAcpwPSoxGk0UVYKh+mnXODCRV94NnfRv/PCBPmzUsdfOL3oSU4/AfkicesejgQ1DZZ85WY4CSVA=="
+    },
+    "node_modules/@hookform/devtools": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/devtools/-/devtools-4.4.0.tgz",
+      "integrity": "sha512-Mtlic+uigoYBPXlfvPBfiYYUZuyMrD3pTjDpVIhL6eCZTvQkHsKBSKeZCvXWUZr8fqrkzDg27N+ZuazLKq6Vmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/react": "^11.1.5",
+        "@emotion/styled": "^11.3.0",
+        "@types/lodash": "^4.14.168",
+        "little-state-machine": "^4.1.0",
+        "lodash": "^4.17.21",
+        "react-simple-animate": "^3.3.12",
+        "use-deep-compare-effect": "^1.8.1",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "3.3.4",
@@ -2273,6 +2295,13 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.17.tgz",
+      "integrity": "sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -4827,6 +4856,16 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/little-state-machine": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/little-state-machine/-/little-state-machine-4.8.1.tgz",
+      "integrity": "sha512-liPHqaWMQ7rzZryQUDnbZ1Gclnnai3dIyaJ0nAgwZRXMzqbYrydrlCI0NDojRUbE5VYh5vu6hygEUZiH77nQkQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -8706,6 +8745,16 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-simple-animate": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/react-simple-animate/-/react-simple-animate-3.5.3.tgz",
+      "integrity": "sha512-Ob+SmB5J1tXDEZyOe2Hf950K4M8VaWBBmQ3cS2BUnTORqHjhK0iKG8fB+bo47ZL15t8d3g/Y0roiqH05UBjG7A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -9548,6 +9597,34 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-deep-compare-effect": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
+      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "dequal": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vfile": {

--- a/raid-agency-app/src/entities/alternate-identifier/forms/alternate-identifier-details-form/AlternateIdentifierDetailsForm.tsx
+++ b/raid-agency-app/src/entities/alternate-identifier/forms/alternate-identifier-details-form/AlternateIdentifierDetailsForm.tsx
@@ -70,10 +70,8 @@ export function AlternateIdentifierDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${getValues(
-                    `${key}.${index}.text`
-                  )}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/alternate-url/forms/alternate-url-details-form/AlternateUrlDetailsForm.tsx
+++ b/raid-agency-app/src/entities/alternate-url/forms/alternate-url-details-form/AlternateUrlDetailsForm.tsx
@@ -66,7 +66,7 @@ export function AlternateUrlDetailsForm({
               if (
                 window.confirm(
                   `Are you sure you want to delete ${label} # ${index + 1} ?`
-                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
+                )//ShortTerm Fix: Display the title of the item and its corresponding sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/alternate-url/forms/alternate-url-details-form/AlternateUrlDetailsForm.tsx
+++ b/raid-agency-app/src/entities/alternate-url/forms/alternate-url-details-form/AlternateUrlDetailsForm.tsx
@@ -65,10 +65,8 @@ export function AlternateUrlDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${getValues(
-                    `${key}.${index}.text`
-                  )}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/contributor-position/forms/contributor-position-details-form/ContributorPositionDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor-position/forms/contributor-position-details-form/ContributorPositionDetailsForm.tsx
@@ -94,8 +94,8 @@ export function ContributorPositionDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${currentValue}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the segment and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/contributor-position/forms/contributor-position-details-form/ContributorPositionDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor-position/forms/contributor-position-details-form/ContributorPositionDetailsForm.tsx
@@ -95,7 +95,7 @@ export function ContributorPositionDetailsForm({
               if (
                 window.confirm(
                   `Are you sure you want to delete ${label} # ${index + 1} ?`
-                )//ShortTerm Fix: Display the title of the segment and its sequence number in the confirmation dialog
+                )//ShortTerm Fix: Display the title of the item and its corresponding sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/contributor-role/forms/contributor-role-details-form/ContributorRoleDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor-role/forms/contributor-role-details-form/ContributorRoleDetailsForm.tsx
@@ -81,8 +81,8 @@ export function ContributorRoleDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${currentValue}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/contributor-role/forms/contributor-role-details-form/ContributorRoleDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor-role/forms/contributor-role-details-form/ContributorRoleDetailsForm.tsx
@@ -82,7 +82,7 @@ export function ContributorRoleDetailsForm({
               if (
                 window.confirm(
                   `Are you sure you want to delete ${label} # ${index + 1} ?`
-                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
+                )//ShortTerm Fix: Display the title of the item and its corresponding sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
@@ -84,10 +84,8 @@ export function ContributorDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${getValues(
-                    `${key}.${index}.text`
-                  )}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
@@ -85,7 +85,7 @@ export function ContributorDetailsForm({
               if (
                 window.confirm(
                   `Are you sure you want to delete ${label} # ${index + 1} ?`
-                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
+                )//ShortTerm Fix: Display the title of the item and its corresponding sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/organisation-role/forms/organisation-role-details-form/OrganisationRoleDetailsForm.tsx
+++ b/raid-agency-app/src/entities/organisation-role/forms/organisation-role-details-form/OrganisationRoleDetailsForm.tsx
@@ -99,7 +99,7 @@ export function OrganisationRoleDetailsForm({
               if (
                 window.confirm(
                   `Are you sure you want to delete ${label} # ${index + 1} ?`
-                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
+                )//ShortTerm Fix: Display the title of the item and its corresponding sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/organisation-role/forms/organisation-role-details-form/OrganisationRoleDetailsForm.tsx
+++ b/raid-agency-app/src/entities/organisation-role/forms/organisation-role-details-form/OrganisationRoleDetailsForm.tsx
@@ -98,8 +98,8 @@ export function OrganisationRoleDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${currentValue}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/organisation/forms/organisation-details-form/OrganisationDetailsForm.tsx
+++ b/raid-agency-app/src/entities/organisation/forms/organisation-details-form/OrganisationDetailsForm.tsx
@@ -107,10 +107,8 @@ export function OrganisationDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${getValues(
-                    `${key}.${index}.text`
-                  )}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/organisation/forms/organisation-details-form/OrganisationDetailsForm.tsx
+++ b/raid-agency-app/src/entities/organisation/forms/organisation-details-form/OrganisationDetailsForm.tsx
@@ -108,7 +108,7 @@ export function OrganisationDetailsForm({
               if (
                 window.confirm(
                   `Are you sure you want to delete ${label} # ${index + 1} ?`
-                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
+                )//ShortTerm Fix: Display the title of the item and its corresponding sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/related-object-category/forms/related-object-category-details-form/RelatedObjectCategoryDetailsForm.tsx
+++ b/raid-agency-app/src/entities/related-object-category/forms/related-object-category-details-form/RelatedObjectCategoryDetailsForm.tsx
@@ -83,7 +83,7 @@ export function RelatedObjectCategoryDetailsForm({
               if (
                 window.confirm(
                   `Are you sure you want to delete ${label} # ${index + 1} ?`
-                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
+                )//ShortTerm Fix: Display the title of the item and its corresponding sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/related-object-category/forms/related-object-category-details-form/RelatedObjectCategoryDetailsForm.tsx
+++ b/raid-agency-app/src/entities/related-object-category/forms/related-object-category-details-form/RelatedObjectCategoryDetailsForm.tsx
@@ -82,8 +82,8 @@ export function RelatedObjectCategoryDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${currentValue}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/related-object/forms/related-object-details-form/RelatedObjectDetailsForm.tsx
+++ b/raid-agency-app/src/entities/related-object/forms/related-object-details-form/RelatedObjectDetailsForm.tsx
@@ -84,10 +84,8 @@ export function RelatedObjectDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${getValues(
-                    `${key}.${index}.text`
-                  )}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/related-object/forms/related-object-details-form/RelatedObjectDetailsForm.tsx
+++ b/raid-agency-app/src/entities/related-object/forms/related-object-details-form/RelatedObjectDetailsForm.tsx
@@ -85,7 +85,7 @@ export function RelatedObjectDetailsForm({
               if (
                 window.confirm(
                   `Are you sure you want to delete ${label} # ${index + 1} ?`
-                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
+                )//ShortTerm Fix: Display the title of the item and its corresponding sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/related-raid/forms/related-raid-details-form/RelatedRaidDetailsForm.tsx
+++ b/raid-agency-app/src/entities/related-raid/forms/related-raid-details-form/RelatedRaidDetailsForm.tsx
@@ -108,7 +108,7 @@ export function RelatedRaidDetailsForm({
               if (
                 window.confirm(
                   `Are you sure you want to delete ${label} # ${index + 1} ?`
-                )//ShortTerm Fix: Display the title of the segment and its sequence number in the confirmation dialog
+                )//ShortTerm Fix: Display the title of the item and its corresponding sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/related-raid/forms/related-raid-details-form/RelatedRaidDetailsForm.tsx
+++ b/raid-agency-app/src/entities/related-raid/forms/related-raid-details-form/RelatedRaidDetailsForm.tsx
@@ -107,10 +107,8 @@ export function RelatedRaidDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${getValues(
-                    `${key}.${index}.text`
-                  )}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the segment and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/spatial-coverage/forms/spatial-coverage-details-form/SpatialCoverageDetailsForm.tsx
+++ b/raid-agency-app/src/entities/spatial-coverage/forms/spatial-coverage-details-form/SpatialCoverageDetailsForm.tsx
@@ -65,10 +65,8 @@ export function SpatialCoverageDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${getValues(
-                    `${key}.${index}.text`
-                  )}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the segment and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/spatial-coverage/forms/spatial-coverage-details-form/SpatialCoverageDetailsForm.tsx
+++ b/raid-agency-app/src/entities/spatial-coverage/forms/spatial-coverage-details-form/SpatialCoverageDetailsForm.tsx
@@ -66,7 +66,7 @@ export function SpatialCoverageDetailsForm({
               if (
                 window.confirm(
                   `Are you sure you want to delete ${label} # ${index + 1} ?`
-                )//ShortTerm Fix: Display the title of the segment and its sequence number in the confirmation dialog
+                )//ShortTerm Fix: Display the title of the item and its corresponding sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/subject/forms/subject-details-form/SubjectDetailsForm.tsx
+++ b/raid-agency-app/src/entities/subject/forms/subject-details-form/SubjectDetailsForm.tsx
@@ -73,7 +73,7 @@ export function SubjectDetailsForm({
               if (
                 window.confirm(
                   `Are you sure you want to delete ${label} # ${index + 1} ?`
-                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
+                )//ShortTerm Fix: Display the title of the item and its corresponding sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }

--- a/raid-agency-app/src/entities/subject/forms/subject-details-form/SubjectDetailsForm.tsx
+++ b/raid-agency-app/src/entities/subject/forms/subject-details-form/SubjectDetailsForm.tsx
@@ -72,10 +72,8 @@ export function SubjectDetailsForm({
             onClick={() => {
               if (
                 window.confirm(
-                  `Are you sure you want to delete ${label} "${getValues(
-                    `${key}.${index}.text`
-                  )}"?`
-                )
+                  `Are you sure you want to delete ${label} # ${index + 1} ?`
+                )//ShortTerm Fix: Display the title of the item and its sequence number in the confirmation dialog
               ) {
                 handleRemoveItem(index);
               }


### PR DESCRIPTION
Jira: https://ardc.atlassian.net/browse/RAID-279

**Root Cause:**
Segments in Raid are based on text and categories. For instance, segments like Title, Description, and Subject Name contain text in their responses. In contrast, other segments response contain various types of keys such as ID, role, status, etc.

The current functionality uses getValues(`${key}.text`) function(useFormContext) attempts to retrieve values based on text responses. Since segments like Title and Description have text content, the function works correctly for them. However, it fails to find relevant text in the other segments, resulting in the display of _'undefined_'.

Below are the two solutions proposed by Shawn:

**Short-Term Solution:**
Display the segment title and its corresponding sequence number in the confirmation dialog.
Example:
"Are you sure you want to delete Contributors Role # 1?"

**Long-Term Solution:**
Display a human-readable message (specific to the segment's property) in the confirmation dialog.

Related Story: https://ardc.atlassian.net/browse/RAID-281

I have fixed the defect with the Short Term Solution.