### PR TITLE
Feature/RAiD-282

### DIFF
--- a/raid-agency-app/src/components/display-card/DisplayCard.tsx
+++ b/raid-agency-app/src/components/display-card/DisplayCard.tsx
@@ -1,4 +1,5 @@
 import { SnackbarContextInterface, useSnackbar } from "@/components/snackbar";
+import { copyToClipboardWithNotification } from "@/utils/copy-utils/copyWithNotify";
 import { downloadJson } from "@/utils/file-utils/file-utils";
 import {
   ContentCopy as ContentCopyIcon,
@@ -13,11 +14,6 @@ import {
 } from "@mui/material";
 import { memo } from "react";
 import { useParams } from "react-router-dom";
-
-const copyJson = (data: any, snackbar: SnackbarContextInterface | null) => {
-  navigator.clipboard.writeText(JSON.stringify(data, null, 2));
-  snackbar?.openSnackbar(`✅ Copied raw JSON data to clipboard`);
-};
 
 /**
  * Reusable card component for displaying data sections
@@ -52,7 +48,14 @@ export const DisplayCard = memo(
               <Tooltip title="Copy raw JSON" placement="top">
                 <IconButton
                   aria-label="copy-json"
-                  onClick={() => copyJson(data, snackbar)}
+                  onClick={async () => {
+                      await copyToClipboardWithNotification(
+                        JSON.stringify(data, null, 2),
+                        "✅ Copied raw JSON data to clipboard",
+                        snackbar as SnackbarContextInterface
+                      )
+                    }
+                  }
                 >
                   <ContentCopyIcon />
                 </IconButton>

--- a/raid-agency-app/src/containers/header/UserDropdown.tsx
+++ b/raid-agency-app/src/containers/header/UserDropdown.tsx
@@ -1,9 +1,10 @@
 import { ErrorAlertComponent } from "@/components/error-alert-component";
-import { useSnackbar } from "@/components/snackbar";
+import { SnackbarContextInterface, useSnackbar } from "@/components/snackbar";
 import { useKeycloak } from "@/contexts/keycloak-context";
 import { Loading } from "@/pages/loading";
 import { fetchCurrentUserKeycloakGroups } from "@/services/keycloak-groups";
 import { KeycloakGroup } from "@/types";
+import { copyToClipboardWithNotification } from "@/utils/copy-utils/copyWithNotify";
 import {
   AccountCircle as AccountCircleIcon,
   ExitToApp as ExitToAppIcon,
@@ -129,10 +130,15 @@ export function UserDropdown() {
             <MenuList dense>
               {tokenParsed?.email && (
                 <MenuItem
-                  onClick={() => {
-                    navigator.clipboard.writeText(tokenParsed?.email || "");
-                    snackbar?.openSnackbar(`✅ Copied value to clipboard`);
-                  }}
+                  onClick={async () => {
+                      await copyToClipboardWithNotification(
+                        tokenParsed?.email || "",
+                        "✅ Copied email to clipboard",
+                        snackbar as SnackbarContextInterface
+                      );
+                    handleAccountMenuClose();
+                    }
+                  }
                 >
                   <ListItemText
                     primary="Email"
@@ -141,10 +147,15 @@ export function UserDropdown() {
                 </MenuItem>
               )}
               <MenuItem
-                onClick={() => {
-                  navigator.clipboard.writeText(tokenParsed?.sub || "");
-                  snackbar?.openSnackbar(`✅ Copied value to clipboard`);
-                }}
+                onClick={async () => {
+                    await copyToClipboardWithNotification(
+                      tokenParsed?.sub || "",
+                      "✅ Copied identity to clipboard",
+                      snackbar as SnackbarContextInterface
+                    );
+                  handleAccountMenuClose();
+                  }
+                }
               >
                 <ListItemText primary="Identity" secondary={tokenParsed?.sub} />
               </MenuItem>

--- a/raid-agency-app/src/pages/raid-display/components/RawDataDisplay.tsx
+++ b/raid-agency-app/src/pages/raid-display/components/RawDataDisplay.tsx
@@ -1,5 +1,6 @@
 import { SnackbarContextInterface, useSnackbar } from "@/components/snackbar";
 import { RaidDto } from "@/generated/raid";
+import { copyToClipboardWithNotification } from "@/utils/copy-utils/copyWithNotify";
 import { downloadJson } from "@/utils/file-utils/file-utils";
 import {
   ContentCopy as ContentCopyIcon,
@@ -16,12 +17,8 @@ import { useParams } from "react-router-dom";
 
 export const RawDataDisplay = ({ raidData }: { raidData: RaidDto }) => {
   const snackbar = useSnackbar();
-
   const { prefix, suffix } = useParams();
-  const copyJson = (data: any, snackbar: SnackbarContextInterface) => {
-    navigator.clipboard.writeText(JSON.stringify(data, null, 2));
-    snackbar.openSnackbar(`✅ Copied raw JSON data to clipboard`);
-  };
+
   return (
     <Card>
       {/* <CardHeader title="Raw Data" /> */}
@@ -31,7 +28,14 @@ export const RawDataDisplay = ({ raidData }: { raidData: RaidDto }) => {
             <Tooltip title="Copy raw JSON" placement="top">
               <IconButton
                 aria-label="copy-json"
-                onClick={() => copyJson(raidData, snackbar)}
+                onClick={async () => {
+                    await copyToClipboardWithNotification(
+                      JSON.stringify(raidData, null, 2),
+                      "✅ Copied raw JSON data to clipboard",
+                      snackbar as SnackbarContextInterface
+                    )
+                  }
+                }
               >
                 <ContentCopyIcon />
               </IconButton>

--- a/raid-agency-app/src/pages/raid-table/components/RaidTableRowContextMenu.tsx
+++ b/raid-agency-app/src/pages/raid-table/components/RaidTableRowContextMenu.tsx
@@ -7,7 +7,7 @@ import {
   Menu as MenuIcon,
   Visibility as VisibilityIcon,
 } from "@mui/icons-material";
-
+import { SnackbarContextInterface, useSnackbar } from "@/components/snackbar";
 import ContentCopy from "@mui/icons-material/ContentCopy";
 import {
   IconButton,
@@ -18,11 +18,13 @@ import {
 } from "@mui/material";
 import Divider from "@mui/material/Divider";
 import { Link } from "react-router-dom";
+import { copyToClipboardWithNotification } from "@/utils/copy-utils/copyWithNotify";
+
 
 export const RaidTableRowContextMenu = ({ row }: { row: RaidDto }) => {
   const [prefix, setPrefix] = React.useState<string>("");
   const [suffix, setSuffix] = React.useState<string>("");
-
+  const snackbar = useSnackbar();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleContextMenuClick = (
@@ -44,13 +46,33 @@ export const RaidTableRowContextMenu = ({ row }: { row: RaidDto }) => {
       setSuffix("");
     }, 500);
   };
-
+       
   return (
     <>
       <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
         <MenuItem
           onClick={async () => {
-            navigator.clipboard.writeText(`${suffix}`);
+            await copyToClipboardWithNotification(
+              JSON.stringify(row, null, 2),
+              "✅ Copied raw JSON data to clipboard",
+              snackbar as SnackbarContextInterface
+            );
+            handleClose();
+            }
+          }
+        >
+          <ListItemIcon>
+            <ContentCopy fontSize="small" />
+          </ListItemIcon>
+          <ListItemText primary="Copy raw JSON" secondary={"RAW Data"}/>
+        </MenuItem>
+        <MenuItem
+          onClick={async () => {
+            await copyToClipboardWithNotification(
+              `${suffix}`,
+              "✅ Copied Suffix to clipboard",
+              snackbar as SnackbarContextInterface
+            );
             handleClose();
           }}
         >
@@ -61,7 +83,11 @@ export const RaidTableRowContextMenu = ({ row }: { row: RaidDto }) => {
         </MenuItem>
         <MenuItem
           onClick={async () => {
-            navigator.clipboard.writeText(`${prefix}/${suffix}`);
+            await copyToClipboardWithNotification(
+              `${prefix}/${suffix}`,
+              "✅ Copied Identifier to clipboard",
+              snackbar as SnackbarContextInterface
+            );
             handleClose();
           }}
         >
@@ -75,9 +101,10 @@ export const RaidTableRowContextMenu = ({ row }: { row: RaidDto }) => {
         </MenuItem>
         <MenuItem
           onClick={async () => {
-            // await copy(`https://raid.org/${prefix}/${suffix}`);
-            navigator.clipboard.writeText(
-              `https://raid.org/${prefix}/${suffix}`
+            await copyToClipboardWithNotification(
+              `https://raid.org/${prefix}/${suffix}`,
+              "✅ Copied URL to clipboard",
+              snackbar as SnackbarContextInterface
             );
             handleClose();
           }}

--- a/raid-agency-app/src/pages/raid-table/index.tsx
+++ b/raid-agency-app/src/pages/raid-table/index.tsx
@@ -19,7 +19,7 @@ export const RaidTable = ({ title }: { title?: string }) => {
 
   const raidQuery = useQuery({
     queryKey: ["listRaids"],
-    queryFn: () => raidService.fetchAll(["identifier", "title", "date"]),
+    queryFn: () => raidService.fetchAll([]),
     enabled: isInitialized && authenticated,
   });
 

--- a/raid-agency-app/src/utils/copy-utils/copyWithNotify.test.ts
+++ b/raid-agency-app/src/utils/copy-utils/copyWithNotify.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { copyToClipboardWithNotification } from "./copyWithNotify";
+
+// Define a mock snackbar type matching the function's expected interface
+interface MockSnackbar {
+  openSnackbar: (msg: string) => void;
+}
+
+describe("copyToClipboardWithNotification", () => {
+  let mockSnackbar: MockSnackbar;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Create a mock snackbar
+    mockSnackbar = {
+      openSnackbar: vi.fn(),
+    };
+
+    // Mock navigator.clipboard.writeText
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: vi.fn(),
+      },
+      writable: true,
+    });
+  });
+
+  it("SUCCESS: should copy data to clipboard and show success snackbar", async () => {
+    const testData = "Test data";
+    const successMessage = "✅ Copied!";
+    (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined);
+
+    await copyToClipboardWithNotification(testData, successMessage, mockSnackbar);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(testData);
+    expect(mockSnackbar.openSnackbar).toHaveBeenCalledWith(successMessage);
+  });
+
+  it("FAILURE: should show error snackbar if clipboard write fails", async () => {
+    const testError = new Error("Copy to Clipboard failed");
+    (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mockRejectedValueOnce(testError);
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await copyToClipboardWithNotification("data", "Copying...", mockSnackbar);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    expect(mockSnackbar.openSnackbar).toHaveBeenCalledWith("❌ Failed to copy data to clipboard");
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to copy to clipboard:", testError);
+  });
+});

--- a/raid-agency-app/src/utils/copy-utils/copyWithNotify.ts
+++ b/raid-agency-app/src/utils/copy-utils/copyWithNotify.ts
@@ -1,0 +1,23 @@
+import { SnackbarContextInterface } from "@/components/snackbar";
+
+/**
+ * Copy to Clipboard with Notification Module
+ *
+ * This module provides utility function to copy to Clipboard and show a notification
+ * message using a snackbar. It handles the clipboard operation and displays 
+ * a success(✅) popup/snackbar or Failure(❌) popup/snackbar in case
+ * of error. 
+ */
+export const copyToClipboardWithNotification = async (
+    data: string,
+    message: string,
+    snackbar: { openSnackbar: (msg: string) => void } | SnackbarContextInterface
+) => {
+    try {
+      await navigator.clipboard.writeText(data);
+      snackbar.openSnackbar(message);
+    } catch (error) {
+      console.error("Failed to copy to clipboard:", error);
+      snackbar.openSnackbar("❌ Failed to copy data to clipboard");
+    }
+};


### PR DESCRIPTION
Jire: https://ardc.atlassian.net/browse/RAID-282

_Changelog:_
1. Created a Copy to Clipboard with Notification Module
2. Added a button to copy raw JSON data menuItem to the RaidTable row
3. Replaced the local function(copy data to clipboard) with Utility Module.
4. Added unit test cases to the new utility module.
5. Changed the _listRaids_ query to fetch all data(removed include fields) to copy raw data instead of making a new call

These changes will be pushed to TEST env for QA to test the functionality. Once this is tested and signed off from Shawn, will be deploying to the other required environments.