### PR TITLE
Added param to titleDataGenerator function

### DIFF
--- a/raid-agency-app/src/utils/data-utils/data-utils.ts
+++ b/raid-agency-app/src/utils/data-utils/data-utils.ts
@@ -161,7 +161,7 @@ export const raidRequest = (data: RaidDto): RaidDto => {
  * for creating a new RAID, with generated default values for required fields.
  */
 export const newRaid: RaidCreateRequest = {
-  title: [titleDataGenerator()],
+  title: [titleDataGenerator([{} as Title])],
   date: dateDataGenerator(),
   access: accessDataGenerator(),
   organisation: [],


### PR DESCRIPTION
Root Cause: titleDataGenerator function was failing as it is expecting the fields as param.

Solution: Passing empty array as param while creating a new RAiD.
