### PR TITLE
defect/RAiD-308 - Populated ROR name whenever user selects a new ROR from the org list

### DIFF
--- a/raid-agency-app/src/containers/organisation-lookup/OrganisationLookupDialog.tsx
+++ b/raid-agency-app/src/containers/organisation-lookup/OrganisationLookupDialog.tsx
@@ -33,7 +33,7 @@ export function OrganisationLookupDialog({
 }: {
   open: boolean;
   setOpen: (open: boolean) => void;
-  setSelectedValue: (value: string | null) => void;
+  setSelectedValue: (value: { id: string; name?: string }) => void;
 }) {
   const [query, setQuery] = useState("");
   const searchMutation = useMutation({
@@ -49,9 +49,9 @@ export function OrganisationLookupDialog({
     searchMutation.mutate(query);
   };
 
-  const handleListItemClick = (item: any) => {
+  const handleListItemClick = (item: { id: string; name?: string }) => {
     setOpen(false);
-    setSelectedValue(item.id);
+    setSelectedValue(item);
   };
 
   return (

--- a/raid-agency-app/src/entities/organisation/forms/organisation-details-form/OrganisationDetailsForm.tsx
+++ b/raid-agency-app/src/entities/organisation/forms/organisation-details-form/OrganisationDetailsForm.tsx
@@ -15,12 +15,12 @@ function FieldGrid({
   isRowHighlighted: boolean;
 }) {
   const [open, setOpen] = useState(false);
-  const [selectedValue, setSelectedValue] = useState<string | null>(null);
+  const [selectedValue, setSelectedValue] = useState<{ id: string; name?: string } | null>(null);
   const { setValue, getValues } = useFormContext();
 
   useEffect(() => {
     if (selectedValue) {
-      setValue(`organisation.${index}.id`, selectedValue, {
+      setValue(`organisation.${index}.id`, selectedValue.id, {
         shouldValidate: true,
       });
     }
@@ -45,7 +45,7 @@ function FieldGrid({
           Current value:{" "}
           {organisationNames?.size &&
             organisationNames?.get(getValues(`organisation.${index}.id`))
-              ?.value}
+              ?.value || selectedValue?.name}
         </Typography>
         <Stack direction="row" spacing={2} alignItems="center">
           <TextInputField


### PR DESCRIPTION
Jira: https://ardc.atlassian.net/browse/RAID-308

Change Log:
1. Populate the whole selected ROR object.
2. De-structured id and name from the ror Object.

Before:
![image](https://github.com/user-attachments/assets/108cf5f0-7925-4d3a-864c-a9ecd61b445d)

After populating ROR name:
![image](https://github.com/user-attachments/assets/27206fcd-2be1-43a5-96ba-afee1d0ac2ed)
