### PR TITLE
RAiD-324 - Fixed React hook form warning 

### DIFF
--- a/raid-agency-app/src/components/fields/TextInputField.tsx
+++ b/raid-agency-app/src/components/fields/TextInputField.tsx
@@ -48,6 +48,7 @@ const TextInputField = memo(function TextInputField({
     <Grid item xs={width}>
       <TextField
         {...field}
+        id={field.name || `field-${Date.now()}`}
         size="small"
         error={Boolean(errorMessage)}
         fullWidth

--- a/raid-agency-app/src/components/fields/TextSelectField.tsx
+++ b/raid-agency-app/src/components/fields/TextSelectField.tsx
@@ -17,6 +17,7 @@ interface TextSelectFieldProps {
   required: boolean;
   multiline?: boolean;
   width?: number;
+  id?: string;
 }
 
 export function TextSelectField({
@@ -52,11 +53,12 @@ export function TextSelectField({
     <Grid item xs={width}>
       <TextField
         {...field}
+        id={field.name || `field-${Date.now()}`}
         error={Boolean(errorMessage)}
         fullWidth
         helperText={getDisplayHelperText()}
         label={label}
-        placeholder={label}
+        placeholder={placeholder || label}
         required={required}
         select
         size="small"

--- a/raid-agency-app/src/pages/raid-edit/RaidEdit.tsx
+++ b/raid-agency-app/src/pages/raid-edit/RaidEdit.tsx
@@ -22,6 +22,7 @@ import {useNavigate, useParams} from "react-router-dom";
 import {raidService} from "@/services/raid-service.ts";
 import { useSnackbar } from "@/components/snackbar/hooks/useSnackbar";
 import {messages} from "@/constants/messages";
+import { addMissingEndDateInPlace } from "./TransformResponseData";
 
 function createEditRaidPageBreadcrumbs({
   prefix,
@@ -56,7 +57,7 @@ function createEditRaidPageBreadcrumbs({
 
 export const RaidEdit = () => {
   const { openErrorDialog } = useErrorDialog();
-  const { authenticated, isInitialized, token, tokenParsed } = useKeycloak();
+  const { authenticated, isInitialized, token } = useKeycloak();
   const navigate = useNavigate();
   const snackbar = useSnackbar();
 
@@ -140,7 +141,7 @@ export const RaidEdit = () => {
     return <ErrorAlertComponent error="Service points could not be fetched" />;
   }
 
-  let contributors: (Contributor & { email?: string | undefined })[] = [];
+  const contributors: (Contributor & { email?: string | undefined })[] = [];
 
   for (const contributor of query.data?.contributor ?? []) {
     const updatedContributor = {
@@ -150,10 +151,8 @@ export const RaidEdit = () => {
     contributors.push(updatedContributor);
   }
 
-  let raidData: RaidDto | RaidCreateRequest;
-
-  raidData = {
-    ...query.data,
+  const raidData: RaidDto | RaidCreateRequest = {
+    ...(addMissingEndDateInPlace(query.data) as RaidDto),
     contributor: contributors,
   };
 

--- a/raid-agency-app/src/pages/raid-edit/TransformResponseData.ts
+++ b/raid-agency-app/src/pages/raid-edit/TransformResponseData.ts
@@ -1,0 +1,92 @@
+
+
+export const addMissingEndDate = (jsonObj: unknown): unknown => {
+    /**
+     * Recursively traverses a JSON object and adds empty endDate ("") 
+     * to any object that has startDate but no endDate
+     * 
+     * @param {Object|Array} jsonObj - The JSON object/array to process
+     * @returns {Object|Array} - The modified JSON with missing endDates added
+     */
+    
+    // Handle null or undefined
+    if (jsonObj === null || jsonObj === undefined) {
+        return jsonObj;
+    }
+    
+    // Handle arrays
+    if (Array.isArray(jsonObj)) {
+        return jsonObj.map(item => addMissingEndDate(item));
+    }
+    
+    // Handle objects
+    if (typeof jsonObj === 'object') {
+        const result: Record<string, unknown> = {};
+        
+        // Copy all properties and recursively process nested objects/arrays
+        for (const key in jsonObj) {
+            if (Object.prototype.hasOwnProperty.call(jsonObj, key)) {
+                result[key] = addMissingEndDate((jsonObj as Record<string, unknown>)[key]);
+            }
+        }
+        
+        // Check if this object has startDate but no endDate
+        if (Object.prototype.hasOwnProperty.call(result, 'startDate') && !Object.prototype.hasOwnProperty.call(result, 'endDate')) {
+            result.endDate = "";
+        }
+        
+        return result;
+    }
+    
+    // Return primitive values as-is
+    return jsonObj;
+}
+
+// Alternative function that modifies the original object in-place
+interface JsonObject {
+    [key: string]: JsonValue;
+}
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
+interface JsonArray extends Array<JsonValue> {}
+
+export function addMissingEndDateInPlace(jsonObj: unknown): unknown {
+    /**
+     * Modifies the original JSON object in-place, adding empty endDate ("") 
+     * to any object that has startDate but no endDate
+     * 
+     * @param {Object|Array} jsonObj - The JSON object/array to modify
+     * @returns {Object|Array} - Reference to the modified original object
+     */
+    
+    // Handle null or undefined
+    if (jsonObj === null || jsonObj === undefined) {
+        return jsonObj;
+    }
+    
+    // Handle arrays
+    if (Array.isArray(jsonObj)) {
+        jsonObj.forEach(item => addMissingEndDateInPlace(item));
+        return jsonObj;
+    }
+    
+    // Handle objects
+    if (typeof jsonObj === 'object') {
+        // Recursively process nested objects/arrays
+        for (const key in jsonObj as Record<string, unknown>) {
+            if (Object.prototype.hasOwnProperty.call(jsonObj, key)) {
+                const value = (jsonObj as Record<string, unknown>)[key];
+                if (typeof value === 'object' && value !== null) {
+                    addMissingEndDateInPlace(value);
+                }
+            }
+        }
+        
+        // Check if this object has startDate but no endDate
+        if (Object.prototype.hasOwnProperty.call(jsonObj, 'startDate') && !Object.prototype.hasOwnProperty.call(jsonObj, 'endDate')) {
+            (jsonObj as Record<string, unknown>).endDate = "";
+        }
+    }
+    
+    return jsonObj;
+}

--- a/raid-agency-app/src/shared/hooks/business-rules/useEnableAddFields.ts
+++ b/raid-agency-app/src/shared/hooks/business-rules/useEnableAddFields.ts
@@ -28,7 +28,6 @@ export type SubSections = SubSection[][];
 
 export const useEnableAddFields = (subSection: SubSections, isDirty: boolean): boolean | undefined => {
     return useMemo(() => {
-        if (!isDirty || !subSection.length) return false;
         const lastField = subSection[subSection.length - 1];
          // Enable if no fields in the last section
         if (!lastField?.length) return false;
@@ -36,8 +35,9 @@ export const useEnableAddFields = (subSection: SubSections, isDirty: boolean): b
         const lastSubSections = lastField[lastField.length - 1];
 
         // If endDate is missing, disable the button
-        if (!lastSubSections?.endDate) return true;
+        if (!isDirty && !lastSubSections?.endDate) return true;
 
+        if (!isDirty || !subSection.length) return false;
         const regex = /^\d{4}-(0[1-9]|1[0-2])(-([0-2]\d|3[01]))?$/; // YYYY-MM-DD format
         // If endDate is not a string, disable the button
         const endDateStr = lastSubSections.endDate as string;


### PR DESCRIPTION
Jira: https://ardc.atlassian.net/browse/RAID-324

This issue arose while a user is trying to enter value to the endDates in a Raid Edit mode.

**_Root Cause:_** When a user creates a new Raid with empty endDate, the endDate is set as undefined and the API removes fields with undefined values (as Java doesn't understand undefined). When the user later tries to edit the same Raid, we fetch the form data from the API (which returns JSON data without the endDate field). This causes the endDate field in React to become uncontrolled. When a user tries to enter the endDate, React attempts to make it controlled, causing the controlled/uncontrolled component warning.

**_Solution:_** This issue can be resolved by mocking the endDate whenever there is a startDate but no endDate, and adding it to the form data before rendering.