### PR TITLE
Removed resetting of the ref to avoid infinite loop in case of 404 Not found error

### DIFF
--- a/raid-agency-app/src/entities/related-object/views/related-objects-view/RelatedObjectsView.tsx
+++ b/raid-agency-app/src/entities/related-object/views/related-objects-view/RelatedObjectsView.tsx
@@ -123,12 +123,10 @@ const RelatedObjectsView = memo(({ data }: { data: RelatedObject[] }) => {
       );
       queryClient.setQueryData(["relatedObjectCitations"], newNames);
       setDoiLoadingStates({});
-      hasFetchedRef.current = false;
     },
     onError: (error) => {
       console.error('❌ Batch DOI fetch failed:', error);
       setDoiLoadingStates({});
-      hasFetchedRef.current = false;
     }
   });
 
@@ -150,7 +148,8 @@ const RelatedObjectsView = memo(({ data }: { data: RelatedObject[] }) => {
         downloadMutation.mutate(orgsToDownload); 
       }
     }
-  }, [data, downloadMutation, relatedObjectCitations]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, relatedObjectCitations]);
 
   return (
     <DisplayCard


### PR DESCRIPTION
Root Cause: Infinite Loop (404 error)
The 404 case is special because it's a "successful failure" - the HTTP request succeeds, but no data is available, leaving cache in the same state as before the fetch, which triggers useEffect into thinking it needs to fetch again causing infinite fetch loop.

Solution:
Removed the hasFetched ref reset after onSuccess or onError,
which means the mutation will only get triggered once per component lifecycle.
