### PR TITLE
Fixed the issue with deleting and adding contributors

### DIFF
--- a/raid-agency-app/src/entities/contributor/forms/contributors-form/ContributorsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributors-form/ContributorsForm.tsx
@@ -51,6 +51,12 @@ export function ContributorsForm({
     append(generator());
     trigger(key);
   };
+
+  const removeHandler = (index: number) => {
+    data.splice(index, 1); // Also remove from data array to keep in sync with form state
+    remove(index);
+  };
+
   const metadata = useContext(MetadataContext);
   const tooltip = metadata?.[key]?.tooltip;
   return (
@@ -95,7 +101,7 @@ export function ContributorsForm({
               <Fragment key={field.id}>
                 <DetailsForm
                   key={field.id}
-                  handleRemoveItem={() => remove(index)}
+                  handleRemoveItem={() => removeHandler(index)}
                   index={index}
                   data={data}
                 />


### PR DESCRIPTION
Jira: https://ardc.atlassian.net/browse/RAID-351

**_The Problem_**
Form loads(edit mode) with API data → Contributors field populated
User deletes contributor → Removed from display, but original API data still exists in local state
User tries to add new contributor → Form accidentally pulls from the original API data instead of current state

**_Root Cause_**
The form is referencing the original API response data rather than the current modified state after deletions.

**_Solution:_**
Remove deleted contributors from both the display state and the underlying local state to prevent stale data from pre-populating new contributor forms.

