### PR TITLE
Fix/google analytics and removed invite route and page

### DIFF
--- a/raid-agency-app/src/containers/header/NavigationDrawer.tsx
+++ b/raid-agency-app/src/containers/header/NavigationDrawer.tsx
@@ -61,12 +61,12 @@ function CombinedMenu() {
       icon: <KeyIcon />,
       isNavLink: true,
     },
-    {
+    /* {
       label: "Your received invites",
       link: "/invites",
       icon: <GroupWorkIcon />,
       isNavLink: false,
-    },
+    }, */
     {
       label: "Cache Manager",
       link: "/cache-manager",

--- a/raid-agency-app/src/routes/other-routes.tsx
+++ b/raid-agency-app/src/routes/other-routes.tsx
@@ -77,7 +77,7 @@ export const otherRoutes: RouteObject[] = [
       },
     ],
   },
-  {
+  /* {
     path: ROUTES.INVITES,
     // ProtectedRoute ensures that only authenticated users can access this page
     element: <ProtectedRoute />,
@@ -88,7 +88,7 @@ export const otherRoutes: RouteObject[] = [
         element: <Invites />,
       },
     ],
-  },
+  }, */
   {
     path: ROUTES.CACHE_MANAGER,
     // ProtectedRoute ensures that only authenticated users can access this page

--- a/raid-agency-app/src/shared/hooks/google-analytics/useGoogleAnalytics.tsx
+++ b/raid-agency-app/src/shared/hooks/google-analytics/useGoogleAnalytics.tsx
@@ -23,7 +23,7 @@ export const useGoogleAnalytics = () => {
       gaId = null;
     }
 
-    // Only proceed if we have GA ID (mirror Astro condition)
+    // Only proceed if we have GA ID and in prod/demo
     if (!((isProduction || isDemo) && gaId)) return;
     // Check if GA already loaded
     if (document.querySelector(`script[src*="gtag/js?id=${gaId}"]`)) {

--- a/raid-agency-app/src/shared/hooks/google-analytics/useGoogleAnalytics.tsx
+++ b/raid-agency-app/src/shared/hooks/google-analytics/useGoogleAnalytics.tsx
@@ -29,8 +29,7 @@ export const useGoogleAnalytics = () => {
     if (document.querySelector(`script[src*="gtag/js?id=${gaId}"]`)) {
       return;
     }
-
-    // Create the exact same script structure as Astro
+    // Create the gtag script tag
     const gtagScript = document.createElement('script');
     gtagScript.async = true;
     gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;


### PR DESCRIPTION


1. Updated the useGoogleAnalytics hook to add the gtags directly to the header and run the inline script to avoid repeated tagging.
2. Removed invite from the menu bar and disabled the route to the invite page