### PR TITLE
Feature/RAiD-329 create service point

### DIFF
--- a/raid-agency-app/src/constants/messages.ts
+++ b/raid-agency-app/src/constants/messages.ts
@@ -60,4 +60,7 @@ export const messages = {
     servicePointUpdated: "Service point updated successfully",
     servicePointDeleted: "Service point deleted successfully",
     servicePointNotFound: "Service point not found",
+    servicePointCreationFailed: "Service point creation failed",
+    servicePointUpdateFailed: "Service point update failed",
+    servicePointDeletionFailed: "Service point deletion failed",
 }

--- a/raid-agency-app/src/constants/messages.ts
+++ b/raid-agency-app/src/constants/messages.ts
@@ -54,4 +54,10 @@ export const messages = {
     apiBadRequest: "Bad request, please check your input",
     apiUnauthorized: "Unauthorized access, please log in",
     apiForbidden: "You do not have permission to access this resource",
+
+    // Service Point messages
+    servicePointCreated: "Service point created successfully",
+    servicePointUpdated: "Service point updated successfully",
+    servicePointDeleted: "Service point deleted successfully",
+    servicePointNotFound: "Service point not found",
 }

--- a/raid-agency-app/src/constants/messages.ts
+++ b/raid-agency-app/src/constants/messages.ts
@@ -63,4 +63,5 @@ export const messages = {
     servicePointCreationFailed: "Service point creation failed",
     servicePointUpdateFailed: "Service point update failed",
     servicePointDeletionFailed: "Service point deletion failed",
+    servicePointUniqueRepositoryID: "Repository ID must be unique. The provided Repository ID is already in use.",
 }

--- a/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
+++ b/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
@@ -101,7 +101,6 @@ interface CustomizedInputBaseProps {
   name: string;
   defaultValue?: string;
   styles?: React.CSSProperties;
-  resetValue?: { id: string; name?: string } | null;
 }
 
 export default function CustomizedInputBase({
@@ -117,12 +116,6 @@ export default function CustomizedInputBase({
   const { watch, formState: { isDirty } } = useFormContext();
   const value = watch(`${name}`);
   const inputRef = React.useRef<HTMLInputElement>(null);
-
-  React.useEffect(() => {
-    if (resetValue === null) {
-      setInputText('');
-    }
-  }, [resetValue]);
 
   React.useEffect(() => {
     if (isDirty && value) {

--- a/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
+++ b/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
@@ -14,7 +14,7 @@ import { useFormContext } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
 import { ListItemButton, Popover, Typography } from '@mui/material';
 import { Search, CheckCircle, AlertCircle } from 'lucide-react';
-import { ClipLoader, PulseLoader, SyncLoader } from "react-spinners";
+import { ClipLoader, PulseLoader } from "react-spinners";
 
 // Type definitions for better type safety
 interface RORLocation {
@@ -100,12 +100,14 @@ interface CustomizedInputBaseProps {
   setSelectedValue: React.Dispatch<React.SetStateAction<{ id: string; name?: string } | null>>;
   name: string;
   defaultValue?: string;
+  styles?: React.CSSProperties;
 }
 
 export default function CustomizedInputBase({
   setSelectedValue,
   name,
-  defaultValue
+  defaultValue,
+  styles = { width: '400px' }
 }: CustomizedInputBaseProps) {
   const [searchText, clearSearchText] = React.useState(false);
   const [inputText, setInputText] = React.useState(defaultValue || '');
@@ -202,7 +204,7 @@ export default function CustomizedInputBase({
   return (
     <Stack spacing={2}>
       <Paper
-        sx={{ p: '2px 4px', display: 'flex', alignItems: 'center', width: 400, border: 1, borderColor: getStatusColor() }}
+        sx={{ p: '2px 4px', display: 'flex', alignItems: 'center', width: styles?.width || '400px', border: 1, borderColor: getStatusColor() }}
         className={getStatusColor()}
       >
         {<span style={{ height: "40px", margin:"-1px", marginRight:"8px" }} ref={inputRef}></span>}{getStatusIcon()}
@@ -230,23 +232,23 @@ export default function CustomizedInputBase({
         onClose={() => setDropBox(false)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-        sx={{ mt: 1, left:0}}
+        sx={{ mt: 1, left:0, width: styles?.width || '400px' }}
       >
         {searchMutation.data?.items?.length === 0 && (
-          <Box sx={{ padding: 2, maxWidth: '400px'}}>
+          <Box sx={{ padding: 2, maxWidth: styles?.width || '400px'}}>
             <Typography variant="body2" className="text-orange-500">
               No organizations found for "{inputText}"
             </Typography>
           </Box>
         )}
         {searchMutation.status === 'error' && (
-          <Box sx={{ padding: 2, maxWidth: '400px', color: getStatusColor() }}>
+          <Box sx={{ padding: 2, maxWidth: styles?.width || '400px', color: getStatusColor() }}>
             <Typography variant="body2" className="text-red-500">
               Failed to fetch results for "{inputText}". Please try again.
             </Typography>
           </Box>
         )}
-        <Box sx={{ maxHeight: "350px", overflow: "auto" }} display={dropBox ? 'block' : 'none'}>
+        <Box sx={{ maxHeight: "350px", overflow: "auto", width: styles?.width }} display={dropBox ? 'block' : 'none'}>
           {sortedCountries.length > 0 && (
             <List>
               {sortedCountries.map(([countryName, organizations]) => (
@@ -279,7 +281,7 @@ export default function CustomizedInputBase({
             </List>
           )}
           {searchMutation.status === 'pending' && (
-          <Box sx={{ padding: 2, minWidth: '350px' }}>
+          <Box sx={{ padding: 2, minWidth: '350px', width: styles?.width || '400px'}}>
             <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', color: getStatusColor() }}>
               {`Searching `} <PulseLoader color="#36a5dd" size={5} />
             </Typography>

--- a/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
+++ b/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
@@ -12,7 +12,7 @@ import Box from '@mui/material/Box';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import { useFormContext } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
-import { ListItemButton, Popover, Typography } from '@mui/material';
+import { FormHelperText, ListItemButton, Popover, Typography } from '@mui/material';
 import { Search, CheckCircle, AlertCircle } from 'lucide-react';
 import { ClipLoader, PulseLoader } from "react-spinners";
 
@@ -210,7 +210,7 @@ export default function CustomizedInputBase({
         {<span style={{ height: "40px", margin:"-1px", marginRight:"8px" }} ref={inputRef}></span>}{getStatusIcon()}
         <InputBase
           sx={{ ml: 1, flex: 1 }}
-          placeholder="Search Text or lookup ROR ID"
+          placeholder="Search Text or lookup ROR ID *"
           inputProps={{ 'aria-label': 'Search Text or lookup ROR ID' }}
           value={inputText}
           onChange={(e) => {setInputText(e.target.value),clearSearchText(true)}}
@@ -226,6 +226,7 @@ export default function CustomizedInputBase({
           {searchMutation.status === 'pending' ? <ClipLoader color="#36a5dd" size={25}/> : <TravelExploreIcon />}
         </IconButton>
       </Paper>
+      <FormHelperText>For e.g. "https://ror.org/123456" or "My Organization"</FormHelperText>
       <Popover
         open={dropBox}
         anchorEl={inputRef.current }

--- a/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
+++ b/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
@@ -101,6 +101,7 @@ interface CustomizedInputBaseProps {
   name: string;
   defaultValue?: string;
   styles?: React.CSSProperties;
+  resetValue?: { id: string; name?: string } | null;
 }
 
 export default function CustomizedInputBase({
@@ -116,6 +117,12 @@ export default function CustomizedInputBase({
   const { watch, formState: { isDirty } } = useFormContext();
   const value = watch(`${name}`);
   const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (resetValue === null) {
+      setInputText('');
+    }
+  }, [resetValue]);
 
   React.useEffect(() => {
     if (isDirty && value) {

--- a/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
+++ b/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
@@ -101,13 +101,15 @@ interface CustomizedInputBaseProps {
   name: string;
   defaultValue?: string;
   styles?: React.CSSProperties;
+  resetValue?: { id: string; name?: string } | null;
 }
 
 export default function CustomizedInputBase({
   setSelectedValue,
   name,
   defaultValue,
-  styles = { width: '400px' }
+  styles = { width: '400px' },
+  resetValue
 }: CustomizedInputBaseProps) {
   const [searchText, clearSearchText] = React.useState(false);
   const [inputText, setInputText] = React.useState(defaultValue || '');
@@ -115,6 +117,12 @@ export default function CustomizedInputBase({
   const { watch, formState: { isDirty } } = useFormContext();
   const value = watch(`${name}`);
   const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (resetValue === null) {
+      setInputText('');
+    }
+  }, [resetValue]);
 
   React.useEffect(() => {
     if (isDirty && value) {
@@ -210,7 +218,7 @@ export default function CustomizedInputBase({
         {<span style={{ height: "40px", margin:"-1px", marginRight:"8px" }} ref={inputRef}></span>}{getStatusIcon()}
         <InputBase
           sx={{ ml: 1, flex: 1 }}
-          placeholder="Search Text or lookup ROR ID *"
+          placeholder="Search Text or lookup ROR ID"
           inputProps={{ 'aria-label': 'Search Text or lookup ROR ID' }}
           value={inputText}
           onChange={(e) => {setInputText(e.target.value),clearSearchText(true)}}

--- a/raid-agency-app/src/generated/raid/ServicePointCreateRequest.ts
+++ b/raid-agency-app/src/generated/raid/ServicePointCreateRequest.ts
@@ -4,6 +4,7 @@
     techEmail?: string;
     identifierOwner: string;
     repositoryId?: string;
+    groupId?: string;
     prefix?: string;
     password?: string;
     appWritesEnabled?: boolean;

--- a/raid-agency-app/src/generated/raid/ServicePointCreateRequest.ts
+++ b/raid-agency-app/src/generated/raid/ServicePointCreateRequest.ts
@@ -4,7 +4,6 @@
     techEmail?: string;
     identifierOwner: string;
     repositoryId?: string;
-    groupId: string;
     prefix?: string;
     password?: string;
     appWritesEnabled?: boolean;

--- a/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
@@ -176,7 +176,7 @@ export const ServicePointCreateForm = () => {
                 )}
               />
             </Grid>
-            <Grid item xs={12} sm={6} md={4}>
+            {/* <Grid item xs={12} sm={6} md={4}>
               <Controller
                 name="servicePointCreateRequest.groupId"
                 control={form.control}
@@ -195,7 +195,7 @@ export const ServicePointCreateForm = () => {
                   />
                 )}
               />
-            </Grid>
+            </Grid> */}
             <Grid item xs={12} sm={6} md={4}>
               <Controller
                 name="servicePointCreateRequest.identifierOwner"

--- a/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
@@ -36,6 +36,18 @@ import { useErrorDialog } from "@/components/error-dialog";
 import { transformErrorMessage } from "@/components/raid-form-error-message/ErrorContentUtils";
 import { ErrorItem } from '@/components/raid-form-error-message/types';
 
+  const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  color: theme?.palette.text.secondary,
+  flexGrow: 1,
+  ...theme.applyStyles('dark', {
+    backgroundColor: '#1A2027',
+  }),
+  boxShadow: 'none',
+}));
+
 export const ServicePointCreateForm = () => {
   const queryClient = useQueryClient();
   const { token } = useKeycloak();
@@ -140,18 +152,7 @@ const createServicePointRequestValidationSchema = z.object({
     }
   }, [selectedValue, setValue, form]);
 
-  const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: '#fff',
-  ...theme.typography.body2,
-  padding: theme.spacing(1),
-  textAlign: 'center',
-  color: theme?.palette.text.secondary,
-  flexGrow: 1,
-  ...theme.applyStyles('dark', {
-    backgroundColor: '#1A2027',
-  }),
-  boxShadow: 'none',
-}));
+
   const { formState } = form;
   useEffect(() => {
     console.log("Form errors:", formState.errors);
@@ -209,6 +210,7 @@ const createServicePointRequestValidationSchema = z.object({
                   justifyContent: "flex-start",
                   alignItems: "flex-start",
                   mb: 3,
+                  width: '100%'
                 }}
                 divider={<Divider orientation="vertical" flexItem />}
               >
@@ -439,7 +441,7 @@ const createServicePointRequestValidationSchema = z.object({
                       name="servicePointCreateRequest.appWritesEnabled"
                       control={form.control}
                       render={({ field }) => (
-                        <FormGroup>
+                        <FormGroup sx={{ display: 'inline-flex' }}>
                           <FormControlLabel
                             control={
                               <Switch {...field} defaultChecked={!!field.value} />

--- a/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
@@ -137,13 +137,31 @@ const createServicePointRequestValidationSchema = z.object({
     onSuccess: handleCreateSuccess,
   });
 
-  const onSubmit = (item: CreateServicePointRequest) => {
-    if (selectedValue) {
-      item.servicePointCreateRequest.identifierOwner = selectedValue.id;
-    }
-    createServicePointMutation.mutate(item);
-    setAppState({...appState, loading: true });
-  };
+const onSubmit = (item: CreateServicePointRequest) => {
+  // Set identifier owner if selected
+  if (selectedValue) {
+    item.servicePointCreateRequest.identifierOwner = selectedValue.id;
+  }
+
+  // Check for duplicate repository ID
+  const apiData = queryClient.getQueryData<any[]>(["servicePoints"]);
+  const isDuplicateRepositoryID = apiData?.some(
+    (sp: { repositoryId: string }) => 
+      sp.repositoryId === item.servicePointCreateRequest.repositoryId
+  );
+
+  if (isDuplicateRepositoryID) {
+    form.setError("servicePointCreateRequest.repositoryId", {
+      type: "manual",
+      message: messages.servicePointUniqueRepositoryID
+    });
+    return;
+  }
+
+  // Proceed with mutation
+  createServicePointMutation.mutate(item);
+  setAppState({ ...appState, loading: true });
+};
 
   const { formState } = form;
   useEffect(() => {

--- a/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { useKeycloak } from "@/contexts/keycloak-context";
 import { createServicePoint } from "@/services/service-points";
-import { CreateServicePointRequest, ServicePointWithMembers } from "@/types";
+import { CreateServicePointRequest } from "@/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   Accordion,
@@ -17,8 +17,6 @@ import {
   Typography,
   Tab,
   Stack,
-  Paper,
-  styled,
   Divider,
   FormHelperText,
   CircularProgress
@@ -36,18 +34,8 @@ import { useErrorDialog } from "@/components/error-dialog";
 import { transformErrorMessage } from "@/components/raid-form-error-message/ErrorContentUtils";
 import { ErrorItem } from '@/components/raid-form-error-message/types';
 import { ServicePoint } from "@/generated/raid";
-
-  const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: '#fff',
-  ...theme.typography.body2,
-  padding: theme.spacing(1),
-  color: theme?.palette.text.secondary,
-  flexGrow: 1,
-  ...theme.applyStyles('dark', {
-    backgroundColor: '#1A2027',
-  }),
-  boxShadow: 'none',
-}));
+import { createServicePointRequestValidationSchema } from "@/pages/service-point/validation/Rules";
+import { StyledPaper as Item } from "./StyledComponent";
 
 export const ServicePointCreateForm = () => {
   const queryClient = useQueryClient();
@@ -75,28 +63,6 @@ export const ServicePointCreateForm = () => {
     },
   };
 
-const createServicePointRequestValidationSchema = z.object({
-  servicePointCreateRequest: z.object({
-    name: z.string().min(3, "Name must be at least 3 characters"),
-    identifierOwner: z.string(),
-    adminEmail: z.string()
-      .min(1, "Admin email is required")
-      .email("Invalid email format"), // Better than regex for emails
-    techEmail: z.string()
-      .min(1, "Tech email is required")
-      .email("Invalid email format"),
-    enabled: z.boolean(),
-    password: z.string().min(1, "Password is required").min(8, "Password must be at least 8 characters"),
-    prefix: z.string()
-      .min(1, "Prefix is required")
-      .regex(/^10\.\d+$/, "Prefix must follow format 10.xxx"),
-    repositoryId: z.string()
-      .min(1, "Repository ID is required")
-      .regex(/^[A-Z]+\.[A-Z]+$/, "Repository ID must be ABCD.EFGH format"),
-    appWritesEnabled: z.boolean(),
-  }),
-});
-
   const form = useForm<CreateServicePointRequest>({
     resolver: zodResolver(createServicePointRequestValidationSchema),
     mode: "onChange",
@@ -117,7 +83,6 @@ const createServicePointRequestValidationSchema = z.object({
   const handleCreateError = (error: Error) => {
     setAppState({...appState, loading: false, error: true });
     RaidFormErrorMessage(error, openErrorDialog);
-    snackbar.openSnackbar(messages.servicePointCreationFailed, 3000, "error");
   };
 
   const createServicePointHandler = async (

--- a/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
@@ -57,12 +57,12 @@ export const ServicePointCreateForm = () => {
     servicePointCreateRequest: z.object({
       name: z.string().min(3),
       identifierOwner: z.string(),
-      adminEmail: z.string(),
-      techEmail: z.string(),
+      adminEmail: z.string().regex(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/),
+      techEmail: z.string().regex(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/),
       enabled: z.boolean(),
       password: z.string().min(8),
-      prefix: z.string(),
-      repositoryId: z.string(),
+      prefix: z.string().regex(/^10\.\d+$/),
+      repositoryId: z.string().regex(/^[A-Z]+\.[A-Z]+$/),
       appWritesEnabled: z.boolean(),
       groupId: z.string(),
     }),
@@ -77,7 +77,6 @@ export const ServicePointCreateForm = () => {
 
   const handleCreateSuccess = () => {
     queryClient.invalidateQueries({ queryKey: ["servicePoints"] });
-    form.reset();
     // Show success snackbar
     snackbar.openSnackbar(messages.servicePointCreated, 3000, "success");
   };
@@ -104,7 +103,6 @@ export const ServicePointCreateForm = () => {
   });
 
   const onSubmit = (item: CreateServicePointRequest) => {
-    console.log("item", item);
     if (selectedValue) {
       setValue(`servicePointCreateRequest.identifierOwner`, selectedValue.id);
       item.servicePointCreateRequest.identifierOwner = selectedValue.id;
@@ -225,6 +223,7 @@ export const ServicePointCreateForm = () => {
                                 !!form.formState.errors?.servicePointCreateRequest
                                   ?.adminEmail
                               }
+                              required={true}
                             />
                           )}
                         />
@@ -245,6 +244,7 @@ export const ServicePointCreateForm = () => {
                                 !!form.formState.errors?.servicePointCreateRequest
                                   ?.techEmail
                               }
+                              required={true}
                             />
                           )}
                         />
@@ -290,6 +290,7 @@ export const ServicePointCreateForm = () => {
                               !!form.formState.errors?.servicePointCreateRequest
                                 ?.repositoryId
                             }
+                            required={true}
                           />
                         )}
                       />
@@ -309,6 +310,7 @@ export const ServicePointCreateForm = () => {
                             error={
                               !!form.formState.errors?.servicePointCreateRequest?.prefix
                             }
+                            required={true}
                           />
                         )}
                       />
@@ -334,6 +336,7 @@ export const ServicePointCreateForm = () => {
                               form.formState.errors?.servicePointCreateRequest?.password
                                 ?.message
                             }
+                            required={true}
                           />
                         )}
                       />

--- a/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
@@ -3,23 +3,38 @@ import { createServicePoint } from "@/services/service-points";
 import { CreateServicePointRequest } from "@/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
   Button,
   FormControlLabel,
   FormGroup,
   Grid,
-  Snackbar,
   Switch,
+  Tabs,
   TextField,
+  Typography,
+  Tab,
+  Stack,
+  Paper,
+  styled,
+  Divider
 } from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import React from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
+import { useSnackbar } from "@/components/snackbar";
+import { messages } from "@/constants/messages";
+import { Settings, User } from "lucide-react";
 
 export const ServicePointCreateForm = () => {
   const queryClient = useQueryClient();
   const { token } = useKeycloak();
+  const snackbar = useSnackbar();
 
   const initalServicePointValues: CreateServicePointRequest = {
     servicePointCreateRequest: {
@@ -60,9 +75,9 @@ export const ServicePointCreateForm = () => {
 
   const handleCreateSuccess = () => {
     queryClient.invalidateQueries({ queryKey: ["servicePoints"] });
-    console.log("✅ Item created");
     form.reset();
-    setSnackbarOpen(true);
+    // Show success snackbar
+    snackbar.openSnackbar(messages.servicePointCreated, 3000, "success");
   };
 
   const handleCreateError = (error: Error) => {
@@ -78,12 +93,6 @@ export const ServicePointCreateForm = () => {
       },
       token: token!,
     });
-    // return await api.createServicePoint(servicePoint, {
-    //   headers: {
-    //     "Content-Type": "application/json",
-    //     Authorization: `Bearer ${keycloak.token}`,
-    //   },
-    // });
   };
 
   const createServicePointMutation = useMutation({
@@ -96,241 +105,310 @@ export const ServicePointCreateForm = () => {
     createServicePointMutation.mutate(item);
   };
 
-  const [snackbarOpen, setSnackbarOpen] = React.useState<boolean>(false);
-
-  const handleSnackbarClose = (
-    event: React.SyntheticEvent | Event,
-    reason?: string
-  ) => {
-    if (reason === "clickaway") {
-      return;
-    }
-
-    setSnackbarOpen(false);
-  };
+  const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme?.palette.text.secondary,
+  flexGrow: 1,
+  ...theme.applyStyles('dark', {
+    backgroundColor: '#1A2027',
+  }),
+  boxShadow: 'none',
+}));
 
   return (
     <>
-      <FormProvider {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} autoComplete="off">
-          <Grid container spacing={2}>
-            <Grid item xs={12} sm={6} md={4}>
-              <Controller
-                name="servicePointCreateRequest.name"
-                control={form.control}
-                render={({ field }) => (
-                  <TextField
-                    error={
-                      !!form.formState.errors?.servicePointCreateRequest?.name
-                    }
-                    helperText={
-                      form.formState.errors?.servicePointCreateRequest?.name
-                        ?.message
-                    }
-                    label="Service point name"
-                    variant="outlined"
-                    size="small"
-                    fullWidth
-                    {...field}
-                    value={field.value}
-                  />
-                )}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6} md={4}>
-              <Controller
-                name="servicePointCreateRequest.repositoryId"
-                control={form.control}
-                render={({ field }) => (
-                  <TextField
-                    label="Repository ID"
-                    variant="outlined"
-                    size="small"
-                    fullWidth
-                    {...field}
-                    value={field.value}
-                    error={
-                      !!form.formState.errors?.servicePointCreateRequest
-                        ?.repositoryId
-                    }
-                  />
-                )}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6} md={4}>
-              <Controller
-                name="servicePointCreateRequest.prefix"
-                control={form.control}
-                render={({ field }) => (
-                  <TextField
-                    label="Prefix"
-                    variant="outlined"
-                    size="small"
-                    fullWidth
-                    {...field}
-                    value={field.value}
-                    error={
-                      !!form.formState.errors?.servicePointCreateRequest?.prefix
-                    }
-                  />
-                )}
-              />
-            </Grid>
-            {/* <Grid item xs={12} sm={6} md={4}>
-              <Controller
-                name="servicePointCreateRequest.groupId"
-                control={form.control}
-                render={({ field }) => (
-                  <TextField
-                    label="Group ID"
-                    variant="outlined"
-                    size="small"
-                    fullWidth
-                    {...field}
-                    value={field.value}
-                    error={
-                      !!form.formState.errors?.servicePointCreateRequest
-                        ?.groupId
-                    }
-                  />
-                )}
-              />
-            </Grid> */}
-            <Grid item xs={12} sm={6} md={4}>
-              <Controller
-                name="servicePointCreateRequest.identifierOwner"
-                control={form.control}
-                render={({ field }) => (
-                  <TextField
-                    label="Identifier Owner"
-                    variant="outlined"
-                    helperText="ROR Identifier. e.g. https://ror.org/038sjwq14"
-                    size="small"
-                    fullWidth
-                    {...field}
-                    value={field.value}
-                    error={
-                      !!form.formState.errors?.servicePointCreateRequest
-                        ?.identifierOwner
-                    }
-                  />
-                )}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6} md={4}>
-              <Controller
-                name="servicePointCreateRequest.adminEmail"
-                control={form.control}
-                render={({ field }) => (
-                  <TextField
-                    label="Admin email"
-                    variant="outlined"
-                    size="small"
-                    fullWidth
-                    {...field}
-                    value={field.value}
-                    error={
-                      !!form.formState.errors?.servicePointCreateRequest
-                        ?.adminEmail
-                    }
-                  />
-                )}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6} md={4}>
-              <Controller
-                name="servicePointCreateRequest.techEmail"
-                control={form.control}
-                render={({ field }) => (
-                  <TextField
-                    label="Tech email"
-                    variant="outlined"
-                    size="small"
-                    fullWidth
-                    {...field}
-                    value={field.value}
-                    error={
-                      !!form.formState.errors?.servicePointCreateRequest
-                        ?.techEmail
-                    }
-                  />
-                )}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6} md={4}>
-              <Controller
-                name="servicePointCreateRequest.password"
-                control={form.control}
-                render={({ field }) => (
-                  <TextField
-                    label="Password"
-                    type="password"
-                    variant="outlined"
-                    size="small"
-                    fullWidth
-                    {...field}
-                    value={field.value}
-                    error={
-                      !!form.formState.errors?.servicePointCreateRequest
-                        ?.password
-                    }
-                    helperText={
-                      form.formState.errors?.servicePointCreateRequest?.password
-                        ?.message
-                    }
-                  />
-                )}
-              />
-            </Grid>
-            <Grid item xs={12} sm={12} md={12}>
-              <Controller
-                name="servicePointCreateRequest.enabled"
-                control={form.control}
-                render={({ field }) => (
-                  <FormGroup>
-                    <FormControlLabel
-                      control={
-                        <Switch {...field} defaultChecked={!!field.value} />
+      <Accordion
+        disableGutters={true}
+      >
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel1-content"
+          id="panel1-header"
+        >
+          <Typography component="span">Create Service Point</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <FormProvider {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} autoComplete="off">
+              <Box sx={{ mb: 3, pb: 2, borderBottom: 1, borderColor: 'divider' }}>
+                <Controller
+                  name="servicePointCreateRequest.name"
+                  control={form.control}
+                  render={({ field }) => (
+                    <TextField
+                      error={
+                        !!form.formState.errors?.servicePointCreateRequest?.name
                       }
-                      label="Service point enabled?"
-                    />
-                  </FormGroup>
-                )}
-              />
-            </Grid>
-            <Grid item xs={12} sm={12} md={12}>
-              <Controller
-                name="servicePointCreateRequest.appWritesEnabled"
-                control={form.control}
-                render={({ field }) => (
-                  <FormGroup>
-                    <FormControlLabel
-                      control={
-                        <Switch {...field} defaultChecked={!!field.value} />
+                      helperText={
+                        form.formState.errors?.servicePointCreateRequest?.name
+                          ?.message
                       }
-                      label="Enable editing in app?"
+                      label="Service point name"
+                      variant="outlined"
+                      size="small"
+                      fullWidth
+                      {...field}
+                      value={field.value}
                     />
-                  </FormGroup>
-                )}
-              />
-            </Grid>
-          </Grid>
-          <Button
-            variant="outlined"
-            type="submit"
-            sx={{ mt: 3 }}
-            disabled={Object.keys(form.formState.errors).length > 0}
-          >
-            Create service point
-          </Button>
-        </form>
-      </FormProvider>
-      <Snackbar
-        open={snackbarOpen}
-        autoHideDuration={3000}
-        onClose={handleSnackbarClose}
-        message="✅ Service point created successfully"
-      />
+                  )}
+                />
+              </Box>
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                spacing={2}
+                sx={{
+                  justifyContent: "flex-start",
+                  alignItems: "flex-start",
+                  mb: 3,
+                }}
+                divider={<Divider orientation="vertical" flexItem />}
+              >
+                <Item>
+                  <Tabs
+                    value={"one"}
+                    textColor="secondary"
+                    indicatorColor="secondary"
+                    aria-label="secondary tabs example"
+                  >
+                    <Tab
+                      value="one"
+                      label={<Typography variant="body2">Service Point Owner</Typography>}
+                      iconPosition="start"
+                      icon={<User fontSize="small" />}
+                      sx={{ minHeight: "40px" }}
+                    />
+                  </Tabs>
+                    <Box>
+                    <Stack
+                      spacing={{ xs: 1, sm: 2 }}
+                      direction="column"
+                      useFlexGap
+                      sx={{ mt: 2 }}
+                    >
+                    
+                      <div>
+                        <Controller
+                          name="servicePointCreateRequest.identifierOwner"
+                          control={form.control}
+                          render={({ field }) => (
+                            <TextField
+                              label="Identifier Owner"
+                              variant="outlined"
+                              helperText="ROR Identifier. e.g. https://ror.org/038sjwq14"
+                              size="small"
+                              fullWidth
+                              {...field}
+                              value={field.value}
+                              error={
+                                !!form.formState.errors?.servicePointCreateRequest
+                                  ?.identifierOwner
+                              }
+                            />
+                          )}
+                        />
+                      </div>
+                      <div >
+                        <Controller
+                          name="servicePointCreateRequest.adminEmail"
+                          control={form.control}
+                          render={({ field }) => (
+                            <TextField
+                              label="Admin email"
+                              variant="outlined"
+                              size="small"
+                              fullWidth
+                              {...field}
+                              value={field.value}
+                              error={
+                                !!form.formState.errors?.servicePointCreateRequest
+                                  ?.adminEmail
+                              }
+                            />
+                          )}
+                        />
+                      </div>
+                      <div >
+                        <Controller
+                          name="servicePointCreateRequest.techEmail"
+                          control={form.control}
+                          render={({ field }) => (
+                            <TextField
+                              label="Tech email"
+                              variant="outlined"
+                              size="small"
+                              fullWidth
+                              {...field}
+                              value={field.value}
+                              error={
+                                !!form.formState.errors?.servicePointCreateRequest
+                                  ?.techEmail
+                              }
+                            />
+                          )}
+                        />
+                      </div>
+                    </Stack>
+                  </Box>
+                </Item>
+                <Item>
+                  <Tabs
+                    value={"two"}
+                    textColor="secondary"
+                    indicatorColor="secondary"
+                    aria-label="secondary tabs example"
+                  >
+                    <Tab
+                      value="two"
+                      label={<Typography variant="body2">DataCite repository</Typography>}
+                      iconPosition="start"
+                      icon={<User fontSize="small" />}
+                      sx={{ minHeight: "40px" }}
+                    />
+                  </Tabs>
+                  <Box>
+                  <Stack
+                    spacing={{ xs: 1, sm: 2 }}
+                    direction="column"
+                    useFlexGap
+                    sx={{ mt: 2 }}
+                  >
+                    <div>
+                      <Controller
+                        name="servicePointCreateRequest.repositoryId"
+                        control={form.control}
+                        render={({ field }) => (
+                          <TextField
+                            label="Repository ID"
+                            variant="outlined"
+                            size="small"
+                            fullWidth
+                            {...field}
+                            value={field.value}
+                            error={
+                              !!form.formState.errors?.servicePointCreateRequest
+                                ?.repositoryId
+                            }
+                          />
+                        )}
+                      />
+                    </div>
+                    <div >
+                      <Controller
+                        name="servicePointCreateRequest.prefix"
+                        control={form.control}
+                        render={({ field }) => (
+                          <TextField
+                            label="Prefix"
+                            variant="outlined"
+                            size="small"
+                            fullWidth
+                            {...field}
+                            value={field.value}
+                            error={
+                              !!form.formState.errors?.servicePointCreateRequest?.prefix
+                            }
+                          />
+                        )}
+                      />
+                    </div>
+                    <div >
+                      <Controller
+                        name="servicePointCreateRequest.password"
+                        control={form.control}
+                        render={({ field }) => (
+                          <TextField
+                            label="Password"
+                            type="password"
+                            variant="outlined"
+                            size="small"
+                            fullWidth
+                            {...field}
+                            value={field.value}
+                            error={
+                              !!form.formState.errors?.servicePointCreateRequest
+                                ?.password
+                            }
+                            helperText={
+                              form.formState.errors?.servicePointCreateRequest?.password
+                                ?.message
+                            }
+                          />
+                        )}
+                      />
+                    </div>
+                  </Stack>
+                  </Box>
+                </Item>
+              </Stack>
+              <Item>
+                <Tabs
+                  value={"three"}
+                  textColor="secondary"
+                  indicatorColor="secondary"
+                  aria-label="secondary tabs example"
+                >
+                  <Tab
+                    value="three"
+                    label={<Typography variant="body2">Settings</Typography>}
+                    iconPosition="start"
+                    icon={<Settings fontSize="small" />}
+                    sx={{ minHeight: "40px" }}
+                  />
+                </Tabs>
+                <Stack
+                  direction="row"
+                  spacing={3}
+                  sx={{ mb: 1 }}
+                >
+                  <Item>
+                    <Controller
+                      name="servicePointCreateRequest.enabled"
+                      control={form.control}
+                      render={({ field }) => (
+                        <FormGroup>
+                          <FormControlLabel
+                            control={
+                              <Switch {...field} defaultChecked={!!field.value} />
+                            }
+                            label="Enable service point?"
+                          />
+                        </FormGroup>
+                      )}
+                    />
+                  </Item>
+                  <Item>
+                    <Controller
+                      name="servicePointCreateRequest.appWritesEnabled"
+                      control={form.control}
+                      render={({ field }) => (
+                        <FormGroup>
+                          <FormControlLabel
+                            control={
+                              <Switch {...field} defaultChecked={!!field.value} />
+                            }
+                            label="Enable minting and editing RAiDs using web app?"
+                          />
+                        </FormGroup>
+                      )}
+                    />
+                  </Item>
+                </Stack>
+              </Item>
+              <Button
+                variant="outlined"
+                type="submit"
+                sx={{ mt: 3 }}
+                disabled={Object.keys(form.formState.errors).length > 0}
+              >
+                Create service point
+              </Button>
+            </form>
+          </FormProvider>
+        </AccordionDetails>
+      </Accordion>
     </>
   );
 };

--- a/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useKeycloak } from "@/contexts/keycloak-context";
 import { createServicePoint } from "@/services/service-points";
 import { CreateServicePointRequest } from "@/types";
@@ -28,11 +29,14 @@ import { z } from "zod";
 import { useSnackbar } from "@/components/snackbar";
 import { messages } from "@/constants/messages";
 import { Building2, Settings, User, SquarePen } from "lucide-react";
+import CustomizedInputBase from "@/containers/organisation-lookup/RORCustomComponent";
 
 export const ServicePointCreateForm = () => {
   const queryClient = useQueryClient();
   const { token } = useKeycloak();
   const snackbar = useSnackbar();
+  const [selectedValue, setSelectedValue] = React.useState<{ id: string; name?: string } | null>(null);
+  const { setValue, getValues } = useForm();
 
   const initalServicePointValues: CreateServicePointRequest = {
     servicePointCreateRequest: {
@@ -100,6 +104,11 @@ export const ServicePointCreateForm = () => {
   });
 
   const onSubmit = (item: CreateServicePointRequest) => {
+    console.log("item", item);
+    if (selectedValue) {
+      setValue(`servicePointCreateRequest.identifierOwner`, selectedValue.id);
+      item.servicePointCreateRequest.identifierOwner = selectedValue.id;
+    }
     createServicePointMutation.mutate(item);
   };
 
@@ -155,7 +164,7 @@ export const ServicePointCreateForm = () => {
                 />
               </Box>
               <Stack
-                direction={{ xs: 'column', sm: 'row' }}
+                direction={{ xs: 'column', sm: 'row', md: 'row' }}
                 spacing={2}
                 sx={{
                   justifyContent: "flex-start",
@@ -181,7 +190,7 @@ export const ServicePointCreateForm = () => {
                   </Tabs>
                     <Box>
                     <Stack
-                      spacing={{ xs: 1, sm: 2 }}
+                      spacing={{ xs: 1, sm: 1, md: 2 }}
                       direction="column"
                       useFlexGap
                       sx={{ mt: 2 }}
@@ -191,18 +200,11 @@ export const ServicePointCreateForm = () => {
                           name="servicePointCreateRequest.identifierOwner"
                           control={form.control}
                           render={({ field }) => (
-                            <TextField
-                              label="Identifier Owner"
-                              variant="outlined"
-                              helperText="ROR Identifier. e.g. https://ror.org/038sjwq14"
-                              size="small"
-                              fullWidth
-                              {...field}
-                              value={field.value}
-                              error={
-                                !!form.formState.errors?.servicePointCreateRequest
-                                  ?.identifierOwner
-                              }
+                            <CustomizedInputBase
+                              setSelectedValue={setSelectedValue}
+                              name={`servicePointCreateRequest.identifierOwner.id`}
+                              defaultValue={selectedValue?.id || getValues(`servicePointCreateRequest.identifierOwner.id`)}
+                              styles={{ width: '100%' }}
                             />
                           )}
                         />
@@ -267,7 +269,7 @@ export const ServicePointCreateForm = () => {
                   </Tabs>
                   <Box>
                   <Stack
-                    spacing={{ xs: 1, sm: 2 }}
+                    spacing={{ xs: 1, sm: 1, md: 2 }}
                     direction="column"
                     useFlexGap
                     sx={{ mt: 2 }}

--- a/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { useKeycloak } from "@/contexts/keycloak-context";
 import { createServicePoint } from "@/services/service-points";
-import { CreateServicePointRequest } from "@/types";
+import { CreateServicePointRequest, ServicePointWithMembers } from "@/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   Accordion,
@@ -35,6 +35,7 @@ import CustomizedInputBase from "@/containers/organisation-lookup/RORCustomCompo
 import { useErrorDialog } from "@/components/error-dialog";
 import { transformErrorMessage } from "@/components/raid-form-error-message/ErrorContentUtils";
 import { ErrorItem } from '@/components/raid-form-error-message/types';
+import { ServicePoint } from "@/generated/raid";
 
   const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: '#fff',
@@ -53,7 +54,6 @@ export const ServicePointCreateForm = () => {
   const { token } = useKeycloak();
   const snackbar = useSnackbar();
   const [selectedValue, setSelectedValue] = React.useState<{ id: string; name?: string } | null>(null);
-  const { setValue } = useForm();
   const { openErrorDialog } = useErrorDialog();
   const [appState, setAppState] = React.useState({
     loading: false,
@@ -144,10 +144,9 @@ const onSubmit = (item: CreateServicePointRequest) => {
   }
 
   // Check for duplicate repository ID
-  const apiData = queryClient.getQueryData<any[]>(["servicePoints"]);
+  const apiData = queryClient.getQueryData<ServicePoint[]>(["servicePoints"]);
   const isDuplicateRepositoryID = apiData?.some(
-    (sp: { repositoryId: string }) => 
-      sp.repositoryId === item.servicePointCreateRequest.repositoryId
+    (sp) => sp.repositoryId === item.servicePointCreateRequest.repositoryId
   );
 
   if (isDuplicateRepositoryID) {

--- a/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
@@ -10,7 +10,6 @@ import {
   Button,
   FormControlLabel,
   FormGroup,
-  Grid,
   Switch,
   Tabs,
   TextField,
@@ -24,12 +23,11 @@ import {
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import React from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 import { useSnackbar } from "@/components/snackbar";
 import { messages } from "@/constants/messages";
-import { Settings, User } from "lucide-react";
+import { Building2, Settings, User, SquarePen } from "lucide-react";
 
 export const ServicePointCreateForm = () => {
   const queryClient = useQueryClient();
@@ -128,12 +126,12 @@ export const ServicePointCreateForm = () => {
           aria-controls="panel1-content"
           id="panel1-header"
         >
-          <Typography component="span">Create Service Point</Typography>
+          <SquarePen /><Typography sx={{ml: 1}}component="span">Create Service Point</Typography>
         </AccordionSummary>
         <AccordionDetails>
           <FormProvider {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} autoComplete="off">
-              <Box sx={{ mb: 3, pb: 2, borderBottom: 1, borderColor: 'divider' }}>
+              <Box sx={{ mb: 2, pb: 2, borderBottom: 1, borderColor: 'divider' }}>
                 <Controller
                   name="servicePointCreateRequest.name"
                   control={form.control}
@@ -188,7 +186,6 @@ export const ServicePointCreateForm = () => {
                       useFlexGap
                       sx={{ mt: 2 }}
                     >
-                    
                       <div>
                         <Controller
                           name="servicePointCreateRequest.identifierOwner"
@@ -264,7 +261,7 @@ export const ServicePointCreateForm = () => {
                       value="two"
                       label={<Typography variant="body2">DataCite repository</Typography>}
                       iconPosition="start"
-                      icon={<User fontSize="small" />}
+                      icon={<Building2 fontSize="small" />}
                       sx={{ minHeight: "40px" }}
                     />
                   </Tabs>
@@ -403,7 +400,7 @@ export const ServicePointCreateForm = () => {
                 sx={{ mt: 3 }}
                 disabled={Object.keys(form.formState.errors).length > 0}
               >
-                Create service point
+                <SquarePen />{" "} Create
               </Button>
             </form>
           </FormProvider>

--- a/raid-agency-app/src/pages/service-point/components/StyledComponent.tsx
+++ b/raid-agency-app/src/pages/service-point/components/StyledComponent.tsx
@@ -1,0 +1,14 @@
+// Styled component for form sections
+import { Paper, styled } from "@mui/material";
+
+export const StyledPaper = styled(Paper)(({ theme }) => ({
+  backgroundColor: '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  color: theme?.palette.text.secondary,
+  flexGrow: 1,
+  ...theme.applyStyles('dark', {
+    backgroundColor: '#1A2027',
+  }),
+  boxShadow: 'none',
+}));

--- a/raid-agency-app/src/pages/service-point/validation/Rules.tsx
+++ b/raid-agency-app/src/pages/service-point/validation/Rules.tsx
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+// Validation schema for creating a service point
+
+export const createServicePointRequestValidationSchema = z.object({
+  servicePointCreateRequest: z.object({
+    name: z.string().min(3, "Name must be at least 3 characters"),
+    identifierOwner: z.string(),
+    adminEmail: z.string()
+      .min(1, "Admin email is required")
+      .email("Invalid email format"), // Better than regex for emails
+    techEmail: z.string()
+      .min(1, "Tech email is required")
+      .email("Invalid email format"),
+    enabled: z.boolean(),
+    password: z.string().min(1, "Password is required").min(8, "Password must be at least 8 characters"),
+    prefix: z.string()
+      .min(1, "Prefix is required")
+      .regex(/^10\.\d+$/, "Prefix must follow format 10.xxx"),
+    repositoryId: z.string()
+      .min(1, "Repository ID is required")
+      .regex(/^[A-Z]+\.[A-Z]+$/, "Repository ID must be ABCD.EFGH format"),
+    appWritesEnabled: z.boolean(),
+  }),
+});

--- a/raid-agency-app/src/pages/service-points/components/ServicePointsOperatorView.tsx
+++ b/raid-agency-app/src/pages/service-points/components/ServicePointsOperatorView.tsx
@@ -35,12 +35,6 @@ export const ServicePointsOperatorView = () => {
 
   return (
     <Stack direction="column" gap={2}>
-      {/* <Card>
-        <CardHeader title="Create new service point" />
-        <CardContent>
-          <ServicePointCreateForm />
-        </CardContent>
-      </Card> */}
       <ServicePointCreateForm />
       <Card>
         <CardHeader title="All service points" />

--- a/raid-agency-app/src/pages/service-points/components/ServicePointsOperatorView.tsx
+++ b/raid-agency-app/src/pages/service-points/components/ServicePointsOperatorView.tsx
@@ -35,12 +35,13 @@ export const ServicePointsOperatorView = () => {
 
   return (
     <Stack direction="column" gap={2}>
-      <Card>
+      {/* <Card>
         <CardHeader title="Create new service point" />
         <CardContent>
           <ServicePointCreateForm />
         </CardContent>
-      </Card>
+      </Card> */}
+      <ServicePointCreateForm />
       <Card>
         <CardHeader title="All service points" />
         <CardContent>

--- a/raid-agency-app/src/services/service-points/index.ts
+++ b/raid-agency-app/src/services/service-points/index.ts
@@ -90,6 +90,8 @@ export const fetchServicePointsWithMembers = async ({
         servicePoint.groupId,
         servicePointMembers.members as ServicePointMember[]
       );
+    } else {
+      members.set(servicePoint.groupId, []);
     }
   }
 
@@ -164,6 +166,8 @@ export const fetchServicePointWithMembers = async ({
       servicePoint.groupId,
       servicePointMembers.members as ServicePointMember[]
     );
+  } else {
+    members.set(servicePoint.groupId, []);
   }
 
   // Combine service point with its members
@@ -215,7 +219,30 @@ export const createServicePoint = async ({
   data: CreateServicePointRequest;
   token: string;
 }): Promise<ServicePoint> => {
+  let groupId;
   const url = new URL(API_CONSTANTS.SERVICE_POINT.ALL);
+  const groupUrl = `${kcUrl}/realms/${kcRealm}/group/create`;
+  const group = await authService.fetchWithAuth(groupUrl.toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      name: data.servicePointCreateRequest.name,
+      path: `/groups/${data.servicePointCreateRequest.name}`
+    })
+  });
+  if (group.ok) {
+    const result = await group.json();
+    groupId = result.id;
+
+  console.log('Created group ID:', groupId);
+} else {
+  console.error('Failed to create group:', group.statusText);
+}
+  console.log("Group ID:", groupId);
+  data.servicePointCreateRequest.groupId = groupId;
   const response = await authService.fetchWithAuth(url.toString(), {
     method: "POST",
     headers: {

--- a/raid-agency-app/src/services/service-points/index.ts
+++ b/raid-agency-app/src/services/service-points/index.ts
@@ -243,7 +243,6 @@ export const createServicePoint = async ({
 
     const groupResult = await group.json();
     groupId = groupResult.id;
-    console.log('Created group ID:', groupId);
 
     // Update data with groupId
     data.servicePointCreateRequest.groupId = groupId;


### PR DESCRIPTION
jira: https://ardc.atlassian.net/browse/RAID-329

Change Log:

- Add POST API request endpoint to backend to create groupID
- UI post request to pass token and service point path to POST request before creating SP request.
- Update the UI with the required grouping of the form fields(Service point owner, Data cite repository, Settings)
- Add the form under a accordion(expand and collapse) default collapse
- Integrate ROR search widget
- Add validation to the required form fields.
- Uplift the UX to show Status(loading, loaded and error) of the service point creation.
- Handle errors gracefully and show the human readable message on the UI
- Retain the form values in case of a failure.
- Show a snack bar with the required service point creation status(Success or failure).
- Fixed toggle Switch bug.