### PR TITLE
Defect/raid 376 operators view all pending request

### DIFF
--- a/raid-agency-app/src/components/app-nav-bar/AppNavBar.tsx
+++ b/raid-agency-app/src/components/app-nav-bar/AppNavBar.tsx
@@ -14,13 +14,15 @@ import { NavigationDrawer } from "../../containers/header/NavigationDrawer";
 import { UserDropdown } from "../../containers/header/UserDropdown";
 import { NotificationBell } from '../alert-notifications/Notifications';
 import { useServicePointPendingRequest } from "@/shared/service-point/service-point-pending-request";
+import { useAuthHelper } from "@/auth/keycloak";
 
 const AuthenticatedNavbarContent = () => {
+  const { isOperator, isGroupAdmin } = useAuthHelper();
   useServicePointPendingRequest();
   return (
     <Stack direction="row" alignItems="center" gap={1}>
       <ServicePointSwitcher />
-      <NotificationBell />
+      {isOperator || isGroupAdmin ? <NotificationBell /> : null}
       <UserDropdown />
       <Chip
         label={import.meta.env.VITE_RAIDO_ENV.toUpperCase()}

--- a/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
+++ b/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
@@ -45,20 +45,27 @@ export const useServicePointPendingRequest = () => {
     });
 
     React.useEffect(() => {
-        const adminGroup = servicePointsQuery.data?.find((sp) => {
-            if (sp?.groupId && sp.groupId === groupId) {
+        //console.log('Service Points Data:', servicePointsQuery.data);
+/*         const adminGroup = servicePointsQuery.data?.find((sp) => {
+            console.log('Checking group:', sp);
+            if (!sp?.roles?.includes(['group-admin', 'operator']) && sp?.groupId === groupId) {
                 return sp;
             }
-        });
-        isOperator && servicePointsQuery.data?.filter((sp) => {
+        }); */
+        const accumulatedMembers = servicePointsQuery.data?.reduce((acc, sp) => {
+            //console.log('Checking service point:', sp);
             if (sp.members && sp.members.length > 0) {
-                isOperator && transformMemberToNotification(sp as unknown as ServicePointResponse, token as string);
+                const members = sp.members.map(member => ({
+                    ...member,
+                    groupId: sp.groupId
+                }));
+                return [...acc, ...members];
             }
-        });
-        console.log('Operator Groups:', adminGroup);
-        // Only transform if user is operator or group admin
-        //transformMemberToNotification(operatorGroup as unknown as ServicePointResponse, token as string);
-        isGroupAdmin && transformMemberToNotification(adminGroup as unknown as ServicePointResponse, token as string, groupId as string);
+            return acc;
+        }, [] as ServicePointMember[]);
+        console.log('Operator Groups:', accumulatedMembers);
+        isOperator && transformMemberToNotification(accumulatedMembers as unknown as ServicePointMember[], token as string);
+        //isGroupAdmin && transformMemberToNotification(adminGroup as unknown as ServicePointResponse, token as string, groupId as string);
     }, [servicePointsQuery.data, isOperator, isGroupAdmin]);
 
     const refetch = () => {

--- a/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
+++ b/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useKeycloak } from "@/contexts/keycloak-context";
 import { fetchServicePointsWithMembers } from "@/services/service-points";
 import { useServicePointNotification } from "./servicePointNotificationService";
+import { ServicePointWithMembers } from "@/types";
 
 interface ServicePointMember {
     id: string;
@@ -19,16 +20,6 @@ interface ServicePointMember {
     groupId?: string;
 }
 
-interface ServicePointResponse {
-    members: ServicePointMember[];
-    name: string;
-    attributes?: {
-        groupId: string;
-    };
-    id: string;
-    groupId?: string;
-}
-
 export const useServicePointPendingRequest = () => {
     const { isOperator, groupId, isGroupAdmin } = useAuthHelper();
     const { authenticated, isInitialized, token } = useKeycloak();
@@ -37,11 +28,11 @@ export const useServicePointPendingRequest = () => {
     const servicePointsQuery = useQuery({
     queryKey: ["service-point-request"],
     queryFn: async () => {
-        return await fetchServicePointsWithMembers({ 
+        return await fetchServicePointsWithMembers({
             token: token || "" 
         });
     },
-    enabled: isInitialized && authenticated && !!groupId && !!token,
+    enabled: isInitialized && authenticated && !!groupId && !!token && (isOperator || isGroupAdmin),
     refetchInterval: 30000, // Poll every 30 seconds
     });
 
@@ -54,13 +45,13 @@ export const useServicePointPendingRequest = () => {
                 });
                 return sp.members;
             }
-        });
+        }) as ServicePointWithMembers | undefined;
         const accumulatedMembers = servicePointsQuery.data?.reduce((acc, sp) => {
-            //console.log('Checking service point:', sp);
             if (sp.members && sp.members.length > 0) {
                 const members = sp.members.map(member => ({
                     ...member,
-                    groupId: sp.groupId
+                    groupId: sp.groupId,
+                    name: sp.name,
                 }));
                 return [...acc, ...members];
             }
@@ -68,6 +59,7 @@ export const useServicePointPendingRequest = () => {
         }, [] as ServicePointMember[]);
         isOperator && transformMemberToNotification(accumulatedMembers as unknown as ServicePointMember[], token as string);
         isGroupAdmin && transformMemberToNotification(adminGroup?.members  as unknown as ServicePointMember[] || [], token as string);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [servicePointsQuery.data, isOperator, isGroupAdmin]);
 
     const refetch = () => {

--- a/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
+++ b/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { useAuthHelper } from "@/auth/keycloak";
 import { useQuery } from "@tanstack/react-query";
 import { useKeycloak } from "@/contexts/keycloak-context";
-import { fetchServicePointMembersWithGroupId, fetchServicePointsWithMembers } from "@/services/service-points";
+import { fetchServicePointsWithMembers } from "@/services/service-points";
 import { useServicePointNotification } from "./servicePointNotificationService";
 
 interface ServicePointMember {
@@ -25,6 +25,7 @@ interface ServicePointResponse {
         groupId: string;
     };
     id: string;
+    groupId?: string;
 }
 
 export const useServicePointPendingRequest = () => {
@@ -41,39 +42,23 @@ export const useServicePointPendingRequest = () => {
     },
     enabled: isInitialized && authenticated && !!groupId && !!token,
     refetchInterval: 30000, // Poll every 30 seconds
-    //refetchOnWindowFocus: true, // Refetch when user returns to tab
     });
-    /* const servicePointsQueryAdmin = useQuery({
-    queryKey: ["service-point-request-admin", groupId],
-    queryFn: async () => {
-        return await fetchServicePointMembersWithGroupId({
-            token: token || "",
-            id: groupId || ""
-        });
-    },
-    enabled: isInitialized && authenticated && !!groupId && !!token,
-    refetchInterval: 30000, // Poll every 30 seconds
-    //refetchOnWindowFocus: true, // Refetch when user returns to tab
-    });*/
 
-    console.log('ServicePointQuery data:', servicePointsQuery.data);
     React.useEffect(() => {
         const adminGroup = servicePointsQuery.data?.find((sp) => {
-            //console.log('Checking SP:', sp);
             if (sp?.groupId && sp.groupId === groupId) {
                 return sp;
             }
         });
-        console.log('Admin Group:', adminGroup);
-        const operatorGroup = servicePointsQuery.data?.filter((sp)=>{
-            if(sp.members && sp.members.length > 0){
+        isOperator && servicePointsQuery.data?.filter((sp) => {
+            if (sp.members && sp.members.length > 0) {
                 isOperator && transformMemberToNotification(sp as unknown as ServicePointResponse, token as string);
             }
-        })
-        console.log('Operator Groups:', operatorGroup);
+        });
+        console.log('Operator Groups:', adminGroup);
         // Only transform if user is operator or group admin
         //transformMemberToNotification(operatorGroup as unknown as ServicePointResponse, token as string);
-        isGroupAdmin && transformMemberToNotification(adminGroup as unknown as ServicePointResponse, token as string);
+        isGroupAdmin && transformMemberToNotification(adminGroup as unknown as ServicePointResponse, token as string, groupId as string);
     }, [servicePointsQuery.data, isOperator, isGroupAdmin]);
 
     const refetch = () => {
@@ -84,4 +69,3 @@ export const useServicePointPendingRequest = () => {
         refetch
     );
 };
-

--- a/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
+++ b/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { useAuthHelper } from "@/auth/keycloak";
 import { useQuery } from "@tanstack/react-query";
 import { useKeycloak } from "@/contexts/keycloak-context";
-import { fetchServicePointMembersWithGroupId } from "@/services/service-points";
+import { fetchServicePointMembersWithGroupId, fetchServicePointsWithMembers } from "@/services/service-points";
 import { useServicePointNotification } from "./servicePointNotificationService";
 
 interface ServicePointMember {
@@ -31,35 +31,55 @@ export const useServicePointPendingRequest = () => {
     const { isOperator, groupId, isGroupAdmin } = useAuthHelper();
     const { authenticated, isInitialized, token } = useKeycloak();
     const { transformMemberToNotification } = useServicePointNotification();
+
     const servicePointsQuery = useQuery({
-    queryKey: ["service-point-request", groupId],
+    queryKey: ["service-point-request"],
     queryFn: async () => {
-        if (!groupId) {
-            return {
-                members: [],
-                name: "",
-                attributes: { groupId: "" },
-                id: "",
-                data: []
-            } as ServicePointResponse;
-        }
-        
-        return await fetchServicePointMembersWithGroupId({ 
-            id: String(groupId), // Convert to string to match the function signature
+        return await fetchServicePointsWithMembers({ 
             token: token || "" 
         });
     },
-        enabled: isInitialized && authenticated && !!groupId && !!token,
-        refetchInterval: 30000, // Poll every 30 seconds
-        //refetchOnWindowFocus: true, // Refetch when user returns to tab
+    enabled: isInitialized && authenticated && !!groupId && !!token,
+    refetchInterval: 30000, // Poll every 30 seconds
+    //refetchOnWindowFocus: true, // Refetch when user returns to tab
     });
+    /* const servicePointsQueryAdmin = useQuery({
+    queryKey: ["service-point-request-admin", groupId],
+    queryFn: async () => {
+        return await fetchServicePointMembersWithGroupId({
+            token: token || "",
+            id: groupId || ""
+        });
+    },
+    enabled: isInitialized && authenticated && !!groupId && !!token,
+    refetchInterval: 30000, // Poll every 30 seconds
+    //refetchOnWindowFocus: true, // Refetch when user returns to tab
+    });*/
 
+    console.log('ServicePointQuery data:', servicePointsQuery.data);
     React.useEffect(() => {
-        isOperator || isGroupAdmin ? transformMemberToNotification(servicePointsQuery.data as unknown as ServicePointResponse, token as string) : null;
-        }, [servicePointsQuery.data, isOperator, isGroupAdmin ]);
-      const refetch = () => {
-            servicePointsQuery.refetch();
-        };
+        const adminGroup = servicePointsQuery.data?.find((sp) => {
+            //console.log('Checking SP:', sp);
+            if (sp?.groupId && sp.groupId === groupId) {
+                return sp;
+            }
+        });
+        console.log('Admin Group:', adminGroup);
+        const operatorGroup = servicePointsQuery.data?.filter((sp)=>{
+            if(sp.members && sp.members.length > 0){
+                isOperator && transformMemberToNotification(sp as unknown as ServicePointResponse, token as string);
+            }
+        })
+        console.log('Operator Groups:', operatorGroup);
+        // Only transform if user is operator or group admin
+        //transformMemberToNotification(operatorGroup as unknown as ServicePointResponse, token as string);
+        isGroupAdmin && transformMemberToNotification(adminGroup as unknown as ServicePointResponse, token as string);
+    }, [servicePointsQuery.data, isOperator, isGroupAdmin]);
+
+    const refetch = () => {
+        servicePointsQuery.refetch();
+    };
+
     return (
         refetch
     );

--- a/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
+++ b/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
@@ -16,12 +16,13 @@ interface ServicePointMember {
         username: string;
         email: string;
     };
+    groupId?: string;
 }
 
 interface ServicePointResponse {
     members: ServicePointMember[];
     name: string;
-    attributes: {
+    attributes?: {
         groupId: string;
     };
     id: string;
@@ -45,13 +46,15 @@ export const useServicePointPendingRequest = () => {
     });
 
     React.useEffect(() => {
-        //console.log('Service Points Data:', servicePointsQuery.data);
-/*         const adminGroup = servicePointsQuery.data?.find((sp) => {
-            console.log('Checking group:', sp);
-            if (!sp?.roles?.includes(['group-admin', 'operator']) && sp?.groupId === groupId) {
-                return sp;
+        // Find the service point where the user is an admin or operator
+        const adminGroup = servicePointsQuery.data?.find((sp) => {
+            if (sp?.groupId === groupId) {
+                sp.members.forEach((member) => {
+                    member.groupId = groupId;
+                });
+                return sp.members;
             }
-        }); */
+        });
         const accumulatedMembers = servicePointsQuery.data?.reduce((acc, sp) => {
             //console.log('Checking service point:', sp);
             if (sp.members && sp.members.length > 0) {
@@ -63,9 +66,8 @@ export const useServicePointPendingRequest = () => {
             }
             return acc;
         }, [] as ServicePointMember[]);
-        console.log('Operator Groups:', accumulatedMembers);
         isOperator && transformMemberToNotification(accumulatedMembers as unknown as ServicePointMember[], token as string);
-        //isGroupAdmin && transformMemberToNotification(adminGroup as unknown as ServicePointResponse, token as string, groupId as string);
+        isGroupAdmin && transformMemberToNotification(adminGroup?.members  as unknown as ServicePointMember[] || [], token as string);
     }, [servicePointsQuery.data, isOperator, isGroupAdmin]);
 
     const refetch = () => {

--- a/raid-agency-app/src/shared/service-point/servicePointNotificationService.tsx
+++ b/raid-agency-app/src/shared/service-point/servicePointNotificationService.tsx
@@ -52,7 +52,7 @@ export const useServicePointNotification = () => {
       removeNotification('servicePointRequests');
       return;
     }
-
+    // Create notification object
     const notification = {
       title: 'Service Point Pending Requests',
       categories: pendingMembers?.map(member => ({

--- a/raid-agency-app/src/shared/service-point/servicePointNotificationService.tsx
+++ b/raid-agency-app/src/shared/service-point/servicePointNotificationService.tsx
@@ -18,7 +18,8 @@ export interface ServicePointMember {
     lastName: string;
     username: string;
     email: string;
-  };
+  },
+  groupId?: string;
 }
 
 interface ServicePointResponse {
@@ -37,22 +38,21 @@ export const useServicePointNotification = () => {
   const IsnackBar = snackbar as { openSnackbar: (message: string, duration?: number, severity?: string) => void };
   const modifyUserAccessMutation = useModifyUserAccess(IsnackBar);
   const removeUserFromServicePointMutation = useRemoveUserFromServicePoint(IsnackBar);
-  const pendingMembers = [] as ServicePointMember[];
+  let pendingMembers;
   // Transform service point members to notifications
-  const transformMemberToNotification = (data: ServicePointResponse, token: string, groupId?: string) => {
+  const transformMemberToNotification = (data: ServicePointMember[], token: string, groupId?: string) => {
     // Filter members without 'service-point-user' role
     const requiredRoles = ["service-point-user", "group-admin", "operator"];
-    pendingMembers.push(...data?.members.filter(
-      member => !member.roles.some(role => requiredRoles.includes(role))) || pendingMembers);
+    console.log('Transforming members for SP:', data);
+    pendingMembers = data?.filter(
+      member => !member.roles.some(role => requiredRoles.includes(role)));
     // If no pending members, remove notification and return
     if (pendingMembers?.length === 0) {
       // Remove notification if no pending members
       removeNotification('servicePointRequests');
       return;
     }
-    console.log('Pending Members:', pendingMembers);
-    console.log('Service Point ID:', data);
-    console.log('groupId:', groupId);
+
     const notification = {
       title: 'Service Point Pending Requests',
       categories: pendingMembers?.map(member => ({
@@ -124,7 +124,7 @@ export const useServicePointNotification = () => {
     groupId: string
   }) => modifyUserAccessMutation.mutate({
     userId: member.id,
-    userGroupId: groupId || data?.groupId as string,
+    userGroupId: member.groupId || data?.groupId as string,
     operation: "grant",
     token,
   });
@@ -136,7 +136,7 @@ export const useServicePointNotification = () => {
     groupId: string
   }) => removeUserFromServicePointMutation.mutate({
     userId: member.id,
-    groupId: groupId || data?.groupId as string,
+    groupId: member.groupId || data?.groupId as string,
     token: token as string,
   });
 

--- a/raid-agency-app/src/types.ts
+++ b/raid-agency-app/src/types.ts
@@ -41,6 +41,7 @@ type ServicePointMemberAttributes = {
  * Represents a member of a service point with roles and attributes
  */
 export type ServicePointMember = {
+  groupId: string | undefined;
   /** Roles assigned to this member within the service point */
   roles: string[];
   /** User attributes containing personal information and settings */


### PR DESCRIPTION
Jira: https://ardc.atlassian.net/browse/RAID-376

ChangeLog:
1. Fixed the issue with ACL(group-admin) role, to show only SP request related to respective group.
2. Show all the SP pending request if the role is a 'operator'
3. Hide the bell icon if the user is neither a 'group-admin' nor 'operator'
