### PR TITLE
Feature/raid-393 generic error messages

### DIFF
--- a/raid-agency-app/src/components/error-dialog/ErrorDialogProvider.tsx
+++ b/raid-agency-app/src/components/error-dialog/ErrorDialogProvider.tsx
@@ -1,5 +1,5 @@
 import { ErrorDialogContext } from "@/components/error-dialog";
-import { Alert, Button } from "@mui/material";
+import { Alert, Button, Card } from "@mui/material";
 import React, { PropsWithChildren, useState } from "react";
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -88,11 +88,15 @@ export const ErrorDialogProvider: React.FC<PropsWithChildren<unknown>> = ({
           <CloseIcon />
         </IconButton>
         <DialogContent >
-          <ul>
-            {errorDialogState.content.failures.map((message, index) => (
-              <li key={index}>{message}</li>
-            ))}
-          </ul>
+          {errorDialogState.content.failures.length <= 1 ? (
+            <Card sx={{boxShadow: "none", p: 2}}>{errorDialogState.content.failures[0]}</Card>
+          ) : (
+            <ul>
+              {errorDialogState.content.failures.map((message, index) => (
+                <li key={index}>{message}</li>
+              ))}
+            </ul>
+          )}
         </DialogContent>
         <DialogActions>
           <Button autoFocus onClick={closeErrorDialog}>

--- a/raid-agency-app/src/components/raid-form-error-message/ErrorContentUtils.ts
+++ b/raid-agency-app/src/components/raid-form-error-message/ErrorContentUtils.ts
@@ -1,3 +1,4 @@
+import { messages } from '@/constants/messages';
 import { ErrorItem, ErrorMessage } from './types';
 
 /**
@@ -20,14 +21,14 @@ export const transformErrorMessage = (errorData: Record<string, ErrorItem | Erro
       // This occurs when a single field has multiple validation errors
       value.forEach((error) => {
         // Extract error message with fallback chain: text.message -> message -> default
-        const message = error?.text?.message || error?.message || 'Unknown error';
+        const message = error?.text?.message || error?.message || messages.requestFailedContent;
         // Add formatted error message to failures array
         transformedError.failures.push(`${key} - ${message}`);
       });
     } else {
       // Handle single error object
       // This occurs when a field has only one validation error
-      const message = value?.message || 'Unknown error';
+      const message = value?.message || messages.requestFailedContent;
       // Add formatted error message to failures array
       transformedError.failures.push(`${key} - ${message}`);
     }

--- a/raid-agency-app/src/components/raid-form-error-message/RaidFormErrorMessage.ts
+++ b/raid-agency-app/src/components/raid-form-error-message/RaidFormErrorMessage.ts
@@ -1,3 +1,4 @@
+import { messages } from "@/constants/messages";
 import { Failure, ErrorMessage, ParsedErrorMessage } from "./";
 
 /**
@@ -37,7 +38,7 @@ export const RaidFormErrorMessage = (
   }
 
   if (messageParsed) {
-    message.title = messageParsed.title || "Error";
+    message.title = messageParsed.title || messages.requestFailedTitle;
     if (messageParsed.failures && Array.isArray(messageParsed.failures)) {
       // Ensure failures is an array before processing
       if (messageParsed.failures.length > 0) {
@@ -46,11 +47,14 @@ export const RaidFormErrorMessage = (
           if (failure.fieldId && failure.message) {
             message.failures.push(`${failure.fieldId}: ${failure.message}`);
           } else {
-            message.failures.push('Invalid failure format');
+            message.failures.push(messages.requestFailedContent);
           }
         });
       }
     }
+  } else {
+    message.title = messages.requestFailedTitle;
+    message.failures = [messages.requestFailedContent];
   }
   openErrorDialog(message);
   return message;

--- a/raid-agency-app/src/constants/messages.ts
+++ b/raid-agency-app/src/constants/messages.ts
@@ -64,4 +64,8 @@ export const messages = {
     servicePointUpdateFailed: "Service point update failed",
     servicePointDeletionFailed: "Service point deletion failed",
     servicePointUniqueRepositoryID: "Repository ID must be unique. The provided Repository ID is already in use.",
+
+    //Generic messages
+    requestFailedTitle: "Error while processing your request",
+    requestFailedContent: "Please try again or email: contact@raid.org.au"
 }

--- a/raid-agency-app/src/constants/messages.ts
+++ b/raid-agency-app/src/constants/messages.ts
@@ -67,5 +67,5 @@ export const messages = {
 
     //Generic messages
     requestFailedTitle: "Error while processing your request",
-    requestFailedContent: "Please try again or email: contact@raid.org.au"
+    requestFailedContent: "Please try again or email: contact@raid.org"
 }


### PR DESCRIPTION
Jira: https://ardc.atlassian.net/browse/RAID-393

Changelog:
1. Show a generic message if the api fails due to the network failure or provided incorrect payload to the api, resulting in 500 or 400 errors.
2. Show error messages in a list format only when the list is greater than 1, else show a single line error message.