### PR TITLE
Feature/r ai d 373 orcid lookup widget

### DIFF
--- a/raid-agency-app/src/components/raid-form-error-message/ErrorContentUtils.ts
+++ b/raid-agency-app/src/components/raid-form-error-message/ErrorContentUtils.ts
@@ -13,15 +13,16 @@ export const transformErrorMessage = (errorData: Record<string, ErrorItem | Erro
     // Default title for the error message
     failures: [],
   };
-
   // Iterate through each field and its associated error(s)
   Object.entries(errorData).forEach(([key, value]) => {
     if (Array.isArray(value)) {
       // Handle array of errors (like title field)
       // This occurs when a single field has multiple validation errors
-      value.forEach((error) => {
-        // Extract error message with fallback chain: text.message -> message -> default
-        const message = error?.text?.message || error?.message || messages.requestFailedContent;
+      value.forEach((error, index) => {
+        // Extract error message with fallback chain: text.message -> {key}.message -> error.message -> default
+        const extractKey = Object.keys(error)[index] as keyof ErrorItem;
+        const nested = (error as Record<string, ErrorItem | undefined>)[extractKey as string];
+        const message = error?.text?.message || nested?.message || (error as ErrorItem)?.message || messages.requestFailedContent;
         // Add formatted error message to failures array
         transformedError.failures.push(`${key} - ${message}`);
       });
@@ -33,6 +34,6 @@ export const transformErrorMessage = (errorData: Record<string, ErrorItem | Erro
       transformedError.failures.push(`${key} - ${message}`);
     }
   });
-
+  
   return transformedError;
 };

--- a/raid-agency-app/src/components/raid-form-error-message/RaidFormErrorMessage.ts
+++ b/raid-agency-app/src/components/raid-form-error-message/RaidFormErrorMessage.ts
@@ -36,7 +36,6 @@ export const RaidFormErrorMessage = (
     // If parsing fails, handle the error message as a plain string
     message.failures.push(error.message);
   }
-
   if (messageParsed) {
     message.title = messageParsed.title || messages.requestFailedTitle;
     if (messageParsed.failures && Array.isArray(messageParsed.failures)) {

--- a/raid-agency-app/src/components/raid-form/RaidForm.tsx
+++ b/raid-agency-app/src/components/raid-form/RaidForm.tsx
@@ -82,7 +82,6 @@ export const RaidForm = memo(
     });
 
     const { control, trigger, formState } = formMethods;
-    const isFormValid = Object.keys(formState.errors).length === 0;
 
     const handleSubmit = useCallback(
       (data: RaidDto) => {
@@ -98,7 +97,7 @@ export const RaidForm = memo(
         setIsInitialLoad(false);
       }
     }, [isInitialLoad]);
-    console.log("formState.errors:", formState.errors);
+
     useEffect(() => {
       // This effect runs when the form is submitted
       // and there are validation errors

--- a/raid-agency-app/src/components/raid-form/RaidForm.tsx
+++ b/raid-agency-app/src/components/raid-form/RaidForm.tsx
@@ -98,7 +98,7 @@ export const RaidForm = memo(
         setIsInitialLoad(false);
       }
     }, [isInitialLoad]);
-
+    console.log("formState.errors:", formState.errors);
     useEffect(() => {
       // This effect runs when the form is submitted
       // and there are validation errors

--- a/raid-agency-app/src/components/tooltips/StyledTooltip.tsx
+++ b/raid-agency-app/src/components/tooltips/StyledTooltip.tsx
@@ -55,7 +55,7 @@ export const CustomStyledTooltip: React.FC<CustomTooltipProps> = ({
       const target = event.target as Node;
       if (tooltipRef.current && !tooltipRef.current.contains(target) &&
           buttonRef.current && !buttonRef.current.contains(target)) {
-        setIsOpen(false);
+          setIsOpen(false);
       }
     };
 
@@ -72,14 +72,14 @@ export const CustomStyledTooltip: React.FC<CustomTooltipProps> = ({
     }, [isOpen]);
 
   const customContent = (
-    <React.Fragment>
+    <div ref={tooltipRef}>
       <Typography color="primary" variant="subtitle1" sx={{ fontWeight: 600 }}>
         {title}
       </Typography>
       <Typography variant="body2" sx={{ mt: 1 }}>
         {content}
       </Typography>
-    </React.Fragment>
+    </div>
   );
 
   return (
@@ -93,8 +93,6 @@ export const CustomStyledTooltip: React.FC<CustomTooltipProps> = ({
         id="tooltip-button"
         color="primary"
         onClick={() => setIsOpen(!isOpen)}
-        onMouseEnter={() => setIsOpen(true)}
-        onMouseLeave={() => setIsOpen(false)}
         ref={buttonRef}
       >
         <div style={{ all: 'inherit', padding: 0 }} ref={tooltipRef}>

--- a/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
+++ b/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
@@ -10,28 +10,93 @@ import {
   InputBase,
   Divider,
   FormHelperText,
-  Popover
+  Popover,
+  Card,
+  CardContent,
+  Avatar,
+  Chip,
+  Link
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import PersonIcon from '@mui/icons-material/Person';
 import FingerprintIcon from '@mui/icons-material/Fingerprint';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { AlertCircle, CheckCircle, CircleCheck, Search } from 'lucide-react';
+import { AlertCircle, CheckCircle, CircleCheck, Search, ScanSearch } from 'lucide-react';
 import { ClipLoader } from 'react-spinners';
 import { useMutation } from '@tanstack/react-query';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import TravelExploreIcon from '@mui/icons-material/TravelExplore';
 import PulseLoader from "react-spinners/PulseLoader";
 
+  // JSONP helper function
+  const fetchJSONP = (url) => {
+    return new Promise((resolve, reject) => {
+      // Create a unique callback name
+      const uniqueCallback = `jsonp_callback_${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+      
+      // Create the script element
+      const script = document.createElement('script');
+      script.async = true;
+      
+      // Set up the callback function
+      window[uniqueCallback] = (data) => {
+        // Clean up
+        try {
+          delete window[uniqueCallback];
+          document.body.removeChild(script);
+        } catch (e) {
+          // Ignore cleanup errors
+        }
+        resolve(data);
+      };
+      
+      // Handle errors
+      script.onerror = (error) => {
+        try {
+          delete window[uniqueCallback];
+          document.body.removeChild(script);
+        } catch (e) {
+          // Ignore cleanup errors
+        }
+        reject(new Error('JSONP request failed: ' + url));
+      };
+      
+      // Add timeout
+      const timeout = setTimeout(() => {
+        try {
+          delete window[uniqueCallback];
+          document.body.removeChild(script);
+        } catch (e) {
+          // Ignore cleanup errors
+        }
+        reject(new Error('JSONP request timeout'));
+      }, 10000);
+      
+      // Override cleanup to clear timeout
+      const originalCallback = window[uniqueCallback];
+      window[uniqueCallback] = (data) => {
+        clearTimeout(timeout);
+        originalCallback(data);
+      };
+      
+      // Replace callback=? with our callback name (jQuery style)
+      const finalUrl = url.replace('callback=?', `callback=${uniqueCallback}`);
+      script.src = finalUrl;
+      
+      // Append script to body to trigger the request
+      document.body.appendChild(script);
+    });
+  };
 
-const searchAPI = async ({ query, mode }: { query: string; mode: string }): Promise<any> => {
-  const response = await fetch(
-    `https://researchdata.edu.au/api/v2.0/orcid.jsonp/${mode}&q=${encodeURIComponent(query)}`
+const searchAPI = async (url: string): Promise<any> => {
+    console.log('Fetching URL:', url);
+  const response = await fetchJSONP(
+    url
   );
-  if (!response.ok) {
+/*   if (!response.ok) {
     throw new Error('Search failed');
-  }
-  return response.json();
+  } */
+  return response;
 };
 
 export default function ORCIDLookup() {
@@ -47,14 +112,14 @@ export default function ORCIDLookup() {
   const searchConfig = {
     lookup: {
       placeholder: 'Enter ORCID ID (e.g., 0000-0002-1825-0097)',
-      endpoint: 'https://pub.orcid.org/v3.0/',
+      endpoint: `https://researchdata.edu.au/api/v2.0/orcid.jsonp/lookup/${encodeURIComponent(searchValue)}/?api_key=public&callback=?`,
       label: 'ORCID ID',
       description: 'Search by unique ORCID identifier',
       icon: <FingerprintIcon />
     },
     search: {
       placeholder: 'Enter contributor name (e.g., John Smith)',
-      endpoint: 'https://pub.orcid.org/v3.0/search/',
+      endpoint: `https://researchdata.edu.au/api/v2.0/orcid.jsonp/search?api_key=public&q=${encodeURIComponent(searchValue)}&start=0&rows=10&wt=json&callback=?`,
       label: 'Custom Search',
       description: 'Search by name or keywords',
       icon: <PersonIcon />
@@ -70,26 +135,28 @@ export default function ORCIDLookup() {
       setError('');
     }
   };
-
-  const handleSearch = async () => {
+  console.log("currentConfig", currentConfig);
+  const handleSearch = async (e?: React.SyntheticEvent) => {
+    e?.preventDefault();
     if (!searchValue.trim()) {
       setError('Please enter a search term');
       return;
     }
     // Pass a single object matching the mutationFn signature
-    searchMutation.mutate({ query: searchValue.trim(), mode: searchMode });
+    searchMutation.mutate(currentConfig.endpoint);
     setDropBox(true);
     setLoading(true);
     setError('');
     setResults(null);
   };
-
+/* 
   const handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
-      handleSearch();
+      handleSearch(event);
     }
   };
-
+*/
+ console.log("results", results);
   const searchMutation = useMutation({
     mutationFn: searchAPI,
     onError: (error) => {
@@ -97,8 +164,58 @@ export default function ORCIDLookup() {
     },
   });
 
-    const groupedData = React.useMemo(() => {
-        //return transformToGroupedData(searchMutation.data?.items);
+  React.useMemo(() => {
+    if (searchMutation.data) {
+    try {
+      if (searchMode === 'lookup') {
+        // ORCID Lookup - match jQuery format exactly
+        const data = searchMutation.data;
+        setResults({
+          type: 'orcid',
+          data: {
+            orcid: data.orcid,
+            name: data.person?.name?.['credit-name']?.value || 
+                  `${data.person?.name?.['given-names']?.value || ''} ${data.person?.name?.['family-name']?.value || ''}`.trim(),
+            affiliation: data.person?.['activities-summary']?.employments?.['employment-summary']?.[0]?.organization?.name || 'N/A',
+            keywords: data.person?.keywords?.keyword?.map(k => k.content).join(', ') || 'N/A',
+          }
+        });
+      } else {
+        // Name Search - match jQuery format exactly
+        const url = `${searchConfig.search.endpoint}?api_key=public&q=${encodeURIComponent(searchValue)}&start=0&rows=10&wt=json&callback=?`;
+        console.log('Name Search URL:', url);
+        const data = searchMutation.data;
+        
+        if (data['orcid-search-results'] && data['orcid-search-results'].length > 0) {
+          const mappedResults = data['orcid-search-results'].map((item, index) => {
+            const given = item.person?.name?.['given-names']?.value || '';
+            const family = item.person?.name?.['family-name']?.value || '';
+            const credit = item.person?.name?.['credit-name']?.value || '';
+            
+            return {
+              orcid: item.orcid,
+              name: credit || `${given} ${family}`.trim() || 'N/A',
+              affiliation: item.person?.['activities-summary']?.employments?.['employment-summary']?.[0]?.organization?.name || 'N/A',
+              relevance: 95 - (index * 5) // Mock relevance based on position
+            };
+          });
+          
+          setResults({
+            type: 'search',
+            data: mappedResults
+          });
+        } else {
+          setError('No results found. Please try a different search term.');
+        }
+      }
+    } catch (err) {
+      console.error('Search error:', err);
+      setError(`Failed to fetch results: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+    }
+        console.log('Search results:', searchMutation.data);
     }, [searchMutation.data]);
 
     const getStatusColor = () => {
@@ -115,20 +232,6 @@ export default function ORCIDLookup() {
             return '#e0e0e0';
         }
     };
-    const getStatusIcon = () => {
-        switch (searchMutation.status) {
-          case 'pending':
-            return <ClipLoader color="#36a5dd" size={25}/>;
-          case 'success':
-            return <CheckCircle color="green" />;
-          case 'error':
-            return <AlertCircle color="red" />;
-          case 'idle':
-            return <Search color="gray" />;
-          default:
-            return <Search color="gray" />;
-        }
-    };
 
   return (
     <Box sx={{ p: 1 }}>
@@ -140,22 +243,34 @@ export default function ORCIDLookup() {
             onChange={(event, newMode) => handleSearchModeChange(event, newMode)}
             aria-label="search mode"
             sx={{
+             backgroundColor: 'grey.100',
+             padding: '4px',
+             borderRadius: '8px',
               '& .MuiToggleButton-root': {
                 px: 3,
                 py: 1.5,
                 textTransform: 'none',
                 fontWeight: 500,
-                border: '1px solid',
-                borderColor: 'divider',
+                border: 'none',
+                borderRadius: '6px',
+                color: 'text.secondary',
+                transition: 'all 0.3s ease',
+                boxShadow: 'none',
                 '&.Mui-selected': {
                   bgcolor: 'white',
                   color: 'primary.main',
-                  borderColor: 'primary.main',
+                  fontWeight: 600,
+                  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.12), 0 1px 3px rgba(0, 0, 0, 0.08)',
+                  transform: 'translateY(-1px)',
+                  '&:hover': {
+                    bgcolor: 'white',
+                    boxShadow: '0 3px 10px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.1)',
+                  }
                 },
                 '&:hover': {
                     color: 'primary.main',
                 },
-                width: '250px',
+                width: '190px',
               }
             }}
           >
@@ -178,30 +293,24 @@ export default function ORCIDLookup() {
             sx={{ p: '2px 4px', display: 'flex', alignItems: 'center', width: '400px', border: 1, borderColor: getStatusColor() }}
             className={getStatusColor()}
         >
-        {<span style={{ height: "40px", margin:"-1px", marginRight:"8px" }} ref={inputRef}></span>}{getStatusIcon()}
+        {<span style={{ height: "40px", margin:"-1px", marginRight:"8px" }} ref={inputRef}></span>}{currentConfig.icon}
          <InputBase
             sx={{ ml: 1, flex: 1 }}
             placeholder={currentConfig?.placeholder}
-            inputProps={{
-              startAdornment: (
-                <Box sx={{ mr: 1, display: 'flex', color: 'action.active' }}>
-                  {currentConfig?.icon}
-                </Box>
-              )
-            }}
+            inputProps={{ 'aria-label': 'search orcid' }}
             value={searchValue}
             onChange={(e) => {setSearchValue(e.target.value),clearSearchText(true)}}
             onKeyDown={(e) => {
             if (e.key === 'Enter') {
-                handleSearch(e);
-            }
+                    handleSearch(e);
+                }
             }}
         /> 
        
         {searchText && <CloseRoundedIcon onClick={() => {clearSearchText(false), setSearchValue('')}} />}
         <Divider sx={{ height: 28, m: 0.5 }} orientation="vertical" />
         <IconButton  onClick={(e) => handleSearch(e)}  color="primary" sx={{ p: '10px' }} aria-label="directions">
-            {searchMutation.status === 'pending' ? <ClipLoader color="#36a5dd" size={25}/> : <TravelExploreIcon />}
+            {searchMutation.status === 'pending' ? <ClipLoader color="#36a5dd" size={25}/> : <ScanSearch />}
         </IconButton>
         </Paper>
         {/* <FormHelperText>For e.g. "https://ror.org/123456" or "My Organization"</FormHelperText> */}
@@ -228,37 +337,162 @@ export default function ORCIDLookup() {
                 </Box>
             )}
             <Box sx={{ maxHeight: "350px", overflow: "auto", width: '400px' }} display={dropBox ? 'block' : 'none'}>
-                {/* {sortedCountries.length > 0 && (
-                <List>
-                    {sortedCountries.map(([countryName, organizations]) => (
-                    <React.Fragment key={countryName}>
-                        <ListSubheader
-                        sx={{
-                            backgroundColor: "primary.light",
-                            color: "primary.contrastText",
-                            position: "sticky",
-                            top: 0,
-                            zIndex: 1,
-                            opacity: 1,
+                        {/* Results Display */}
+        {results && (
+          <Box>
+            <Typography variant="h6" sx={{ m: 2, fontWeight: 600 }}>
+              Search Results
+            </Typography>
+
+            {results.type === 'orcid' ? (
+              // Single ORCID Result
+              <Card 
+                variant="outlined" 
+                sx={{ 
+                  mb: 2,
+                  background: 'linear-gradient(to right, #eff6ff, #ffffff)',
+                  '&:hover': { boxShadow: 2 }
+                }}
+                onClick={() => {
+                    setSearchValue(`https://orcid.org/${results?.data.orcid}`);
+                    setDropBox(false);
+                }}
+              >
+                <CardContent>
+                  <Box sx={{ display: 'flex', alignItems: 'start', gap: 2 }}>
+                    <Avatar 
+                      sx={{ 
+                        bgcolor: 'primary.main', 
+                        width: 56, 
+                        height: 56 
+                      }}
+                    >
+                      <PersonIcon sx={{ fontSize: 32 }} />
+                    </Avatar>
+                    <Box sx={{ flex: 1 }}>
+                      <Typography variant="h6" fontWeight={600}>
+                        {results?.data.name}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                        {results?.data.affiliation}
+                      </Typography>
+                      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
+                        <Chip
+                          label={`ORCID: ${results?.data.orcid}`}
+                          size="small"
+                          color="primary"
+                          variant="outlined"
+                          sx={{ fontWeight: 500 }}
+                        />
+                        {results?.data.keywords && (
+                          <Chip
+                            label={results?.data.keywords}
+                            size="small"
+                            variant="outlined"
+                          />
+                        )}
+                      </Box>
+                      <Link
+                        href={`https://orcid.org/${results?.data?.orcid}`}
+                        target="_blank"
+                        rel="noopener"
+                        sx={{ 
+                          fontSize: '0.875rem',
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: 0.5
                         }}
-                        >
-                        {countryName} ({organizations.length})
-                        </ListSubheader>
-                        {organizations.map((org, index) => (
-                        <ListItemButton
-                            key={`${org.id}-${index}`}
-                            onClick={() => handleListItemClick(org)}
-                        >
-                            <ListItemText
-                            primary={org.displayName}
-                            secondary={formatSecondaryText(org.links)}
+                      >
+                        View ORCID Profile
+                        <OpenInNewIcon sx={{ fontSize: 16 }} />
+                      </Link>
+                    </Box>
+                  </Box>
+                </CardContent>
+              </Card>
+            ) : (
+              // Multiple Search Results
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {results?.data.map((person, index) => (
+                  <Card 
+                    key={index} 
+                    variant="outlined" 
+                    sx={{ 
+                      cursor: 'pointer',
+                      transition: 'all 0.2s',
+                      '&:hover': { 
+                        bgcolor: 'action.hover',
+                        boxShadow: 2
+                      }
+                    }}
+                    onClick={() => {
+                      setSearchValue(person.orcid);
+                      setDropBox(false);
+                    }}
+                  >
+                    <CardContent>
+                      <Box sx={{ display: 'flex', alignItems: 'start', gap: 2 }}>
+                        <Avatar sx={{ bgcolor: 'secondary.main' }}>
+                          <PersonIcon />
+                        </Avatar>
+                        <Box sx={{ flex: 1 }}>
+                          <Box sx={{ 
+                            display: 'flex', 
+                            justifyContent: 'space-between', 
+                            alignItems: 'start',
+                            flexWrap: 'wrap',
+                            gap: 1,
+                            mb: 0.5 
+                          }}>
+                            <Typography variant="h6" fontWeight={600}>
+                              {person.name}
+                            </Typography>
+                            <Chip
+                              label={`${person.relevance}% match`}
+                              size="small"
+                              color="success"
+                              sx={{ fontWeight: 600 }}
                             />
-                        </ListItemButton>
-                        ))}
-                    </React.Fragment>
-                    ))}
-                </List>
-                )} */}
+                          </Box>
+                          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                            {person.affiliation}
+                          </Typography>
+                          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+                            <Chip
+                              label={person.orcid}
+                              size="small"
+                              variant="outlined"
+                              icon={
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                                  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v2h-2zm0 4h2v6h-2z"/>
+                                </svg>
+                              }
+                            />
+                            <Link
+                              href={`https://orcid.org/${person.orcid}`}
+                              target="_blank"
+                              rel="noopener"
+                              sx={{ 
+                                fontSize: '0.875rem',
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: 0.5
+                              }}
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              View Profile
+                              <OpenInNewIcon sx={{ fontSize: 16 }} />
+                            </Link>
+                          </Box>
+                        </Box>
+                      </Box>
+                    </CardContent>
+                  </Card>
+                ))}
+              </Box>
+            )}
+          </Box>
+        )}
                 {searchMutation.status === 'pending' && (
                 <Box sx={{ padding: 2, minWidth: '350px', width: '400px'}}>
                 <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', color: getStatusColor() }}>

--- a/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
+++ b/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
@@ -109,7 +109,7 @@ export default function ORCIDLookup(path: { name: string }) {
     givenName?: string;
     lastName?: string;
   } | null>(null);
-  const { register, setValue, watch, getValues } = useFormContext();
+  const { register, setValue, watch } = useFormContext();
   const fieldName = path.name;
   const registration = register(fieldName);
   const searchValue = watch(fieldName) || '';

--- a/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
+++ b/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
@@ -1,0 +1,274 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  TextField,
+  Paper,
+  Typography,
+  IconButton,
+  ToggleButtonGroup,
+  ToggleButton,
+  InputBase,
+  Divider,
+  FormHelperText,
+  Popover
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import PersonIcon from '@mui/icons-material/Person';
+import FingerprintIcon from '@mui/icons-material/Fingerprint';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { AlertCircle, CheckCircle, CircleCheck, Search } from 'lucide-react';
+import { ClipLoader } from 'react-spinners';
+import { useMutation } from '@tanstack/react-query';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import TravelExploreIcon from '@mui/icons-material/TravelExplore';
+import PulseLoader from "react-spinners/PulseLoader";
+
+
+const searchAPI = async ({ query, mode }: { query: string; mode: string }): Promise<any> => {
+  const response = await fetch(
+    `https://researchdata.edu.au/api/v2.0/orcid.jsonp/${mode}&q=${encodeURIComponent(query)}`
+  );
+  if (!response.ok) {
+    throw new Error('Search failed');
+  }
+  return response.json();
+};
+
+export default function ORCIDLookup() {
+  const [searchMode, setSearchMode] = useState('lookup');
+  const [searchValue, setSearchValue] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState(null);
+  const [error, setError] = useState('');
+  const [searchText, clearSearchText] = useState(false);
+  const [dropBox, setDropBox] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const searchConfig = {
+    lookup: {
+      placeholder: 'Enter ORCID ID (e.g., 0000-0002-1825-0097)',
+      endpoint: 'https://pub.orcid.org/v3.0/',
+      label: 'ORCID ID',
+      description: 'Search by unique ORCID identifier',
+      icon: <FingerprintIcon />
+    },
+    search: {
+      placeholder: 'Enter contributor name (e.g., John Smith)',
+      endpoint: 'https://pub.orcid.org/v3.0/search/',
+      label: 'Custom Search',
+      description: 'Search by name or keywords',
+      icon: <PersonIcon />
+    }
+  };
+  const currentConfig = searchConfig[searchMode];
+
+  const handleSearchModeChange = (event, newMode) => {
+    if (newMode !== null) {
+      setSearchMode(newMode);
+      setSearchValue('');
+      setResults(null);
+      setError('');
+    }
+  };
+
+  const handleSearch = async () => {
+    if (!searchValue.trim()) {
+      setError('Please enter a search term');
+      return;
+    }
+    // Pass a single object matching the mutationFn signature
+    searchMutation.mutate({ query: searchValue.trim(), mode: searchMode });
+    setDropBox(true);
+    setLoading(true);
+    setError('');
+    setResults(null);
+  };
+
+  const handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
+  const searchMutation = useMutation({
+    mutationFn: searchAPI,
+    onError: (error) => {
+        console.error('Search error:', error);
+    },
+  });
+
+    const groupedData = React.useMemo(() => {
+        //return transformToGroupedData(searchMutation.data?.items);
+    }, [searchMutation.data]);
+
+    const getStatusColor = () => {
+        switch (searchMutation.status) {
+        case 'pending':
+            return '#36a5dd';
+        case 'success':
+            return '#4caf50';
+        case 'error':
+            return '#f44336';
+        case 'idle':
+            return '#e0e0e0';
+        default:
+            return '#e0e0e0';
+        }
+    };
+    const getStatusIcon = () => {
+        switch (searchMutation.status) {
+          case 'pending':
+            return <ClipLoader color="#36a5dd" size={25}/>;
+          case 'success':
+            return <CheckCircle color="green" />;
+          case 'error':
+            return <AlertCircle color="red" />;
+          case 'idle':
+            return <Search color="gray" />;
+          default:
+            return <Search color="gray" />;
+        }
+    };
+
+  return (
+    <Box sx={{ p: 1 }}>
+      <Paper elevation={0} sx={{ p: 4, borderRadius: 2 }}>
+        <Box sx={{ mb: 3 }}>
+          <ToggleButtonGroup
+            value={searchMode}
+            exclusive
+            onChange={(event, newMode) => handleSearchModeChange(event, newMode)}
+            aria-label="search mode"
+            sx={{
+              '& .MuiToggleButton-root': {
+                px: 3,
+                py: 1.5,
+                textTransform: 'none',
+                fontWeight: 500,
+                border: '1px solid',
+                borderColor: 'divider',
+                '&.Mui-selected': {
+                  bgcolor: 'white',
+                  color: 'primary.main',
+                  borderColor: 'primary.main',
+                },
+                '&:hover': {
+                    color: 'primary.main',
+                },
+                width: '250px',
+              }
+            }}
+          >
+            <ToggleButton value="lookup" aria-label="orcid search">
+              <FingerprintIcon sx={{ mr: 1, fontSize: 20 }} />
+              {searchConfig.lookup.label}
+            </ToggleButton>
+            <Divider sx={{ height: 28, m: 1 }} orientation="vertical" />
+            <ToggleButton value="search" aria-label="name search">
+              <PersonIcon sx={{ mr: 1, fontSize: 20 }} />
+              {searchConfig.search.label}
+            </ToggleButton>
+          </ToggleButtonGroup>
+          
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+            {currentConfig?.description}
+          </Typography>
+        </Box>
+        <Paper
+            sx={{ p: '2px 4px', display: 'flex', alignItems: 'center', width: '400px', border: 1, borderColor: getStatusColor() }}
+            className={getStatusColor()}
+        >
+        {<span style={{ height: "40px", margin:"-1px", marginRight:"8px" }} ref={inputRef}></span>}{getStatusIcon()}
+         <InputBase
+            sx={{ ml: 1, flex: 1 }}
+            placeholder={currentConfig?.placeholder}
+            inputProps={{
+              startAdornment: (
+                <Box sx={{ mr: 1, display: 'flex', color: 'action.active' }}>
+                  {currentConfig?.icon}
+                </Box>
+              )
+            }}
+            value={searchValue}
+            onChange={(e) => {setSearchValue(e.target.value),clearSearchText(true)}}
+            onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+                handleSearch(e);
+            }
+            }}
+        /> 
+       
+        {searchText && <CloseRoundedIcon onClick={() => {clearSearchText(false), setSearchValue('')}} />}
+        <Divider sx={{ height: 28, m: 0.5 }} orientation="vertical" />
+        <IconButton  onClick={(e) => handleSearch(e)}  color="primary" sx={{ p: '10px' }} aria-label="directions">
+            {searchMutation.status === 'pending' ? <ClipLoader color="#36a5dd" size={25}/> : <TravelExploreIcon />}
+        </IconButton>
+        </Paper>
+        {/* <FormHelperText>For e.g. "https://ror.org/123456" or "My Organization"</FormHelperText> */}
+        <Popover
+            open={dropBox}
+            anchorEl={inputRef.current }
+            onClose={() => setDropBox(false)}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+            sx={{ mt: 1, left:0, width: '400px' }}
+            >
+            {searchMutation.data?.items?.length === 0 && (
+                <Box sx={{ padding: 2, maxWidth:'400px'}}>
+                <Typography variant="body2" className="text-orange-500">
+                    No organizations found for "{searchValue}"
+                </Typography>
+                </Box>
+            )}
+            {searchMutation.status === 'error' && (
+                <Box sx={{ padding: 2, maxWidth: '400px', color: getStatusColor() }}>
+                <Typography variant="body2" className="text-red-500">
+                    Failed to fetch results for "{searchValue}". Please try again.
+                </Typography>
+                </Box>
+            )}
+            <Box sx={{ maxHeight: "350px", overflow: "auto", width: '400px' }} display={dropBox ? 'block' : 'none'}>
+                {/* {sortedCountries.length > 0 && (
+                <List>
+                    {sortedCountries.map(([countryName, organizations]) => (
+                    <React.Fragment key={countryName}>
+                        <ListSubheader
+                        sx={{
+                            backgroundColor: "primary.light",
+                            color: "primary.contrastText",
+                            position: "sticky",
+                            top: 0,
+                            zIndex: 1,
+                            opacity: 1,
+                        }}
+                        >
+                        {countryName} ({organizations.length})
+                        </ListSubheader>
+                        {organizations.map((org, index) => (
+                        <ListItemButton
+                            key={`${org.id}-${index}`}
+                            onClick={() => handleListItemClick(org)}
+                        >
+                            <ListItemText
+                            primary={org.displayName}
+                            secondary={formatSecondaryText(org.links)}
+                            />
+                        </ListItemButton>
+                        ))}
+                    </React.Fragment>
+                    ))}
+                </List>
+                )} */}
+                {searchMutation.status === 'pending' && (
+                <Box sx={{ padding: 2, minWidth: '350px', width: '400px'}}>
+                <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', color: getStatusColor() }}>
+                    {`Searching `} <PulseLoader color="#36a5dd" size={5} />
+                </Typography>
+                </Box>
+            )}
+            </Box>
+        </Popover>
+    </Paper>
+    </Box>
+  );
+}

--- a/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
+++ b/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
@@ -198,7 +198,7 @@ export default function ORCIDLookup(path: { name: string }) {
     genericPlaceholder: `You can search by full ORCID iD or by contributor name (e.g., John Smith).`
   };
   const currentConfig = searchConfig[searchMode];
-  console.log("getValues", getValues(path.name));
+
   const handleSearch = async (e?: React.SyntheticEvent) => {
     e?.preventDefault();
     setResults(null);
@@ -310,7 +310,7 @@ export default function ORCIDLookup(path: { name: string }) {
             return '#e0e0e0';
         }
     };
-    //console.log("ORCID Lookup render with searchValue:",searchValue.trim(),"and path.name:", path.name);
+
   return (
     <Box sx={{ p: 1 }}>
       <Paper elevation={0} sx={{ p: 1, borderRadius: 2 }}>

--- a/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
+++ b/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
@@ -190,11 +190,11 @@ export default function ORCIDLookup(path: { name: string }) {
       description: 'Search by name or keywords',
       icon: <PersonIcon />
     },
-    tooltipContent: `After selecting an ORCID record, the Credit Name will be displayed if available. 
+    tooltipContent: ( <>After selecting an ORCID record, the Credit Name will be displayed if available. 
     If no Credit Name is provided, the Given Name and Family Name will be shown instead. 
     Some details may not appear due to the researcher’s visibility settings. 
-    For more information, see [ORCID Visibility Settings]  
-    {https://support.orcid.org/hc/en-us/articles/360006897614-Visibility-settings}`,
+    For more information, see <a href="https://support.orcid.org/hc/en-us/articles/360006897614-Visibility-settings" target="_blank" rel="noopener noreferrer">[ORCID Visibility Settings]</a></>
+    ),
     genericPlaceholder: `You can search by full ORCID iD or by contributor name (e.g., John Smith).`
   };
   const currentConfig = searchConfig[searchMode];

--- a/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
@@ -1,6 +1,7 @@
 import { DisplayItem } from "@/components/display-item";
 import { CheckboxField } from "@/components/fields/CheckboxField";
 import { TextInputField } from "@/components/fields/TextInputField";
+import ORCIDLookup from "@/containers/orcid-lookup/ORCID";
 import { Contributor } from "@/generated/raid";
 import { IndeterminateCheckBox } from "@mui/icons-material";
 import { Grid, IconButton, Stack, Tooltip, Typography } from "@mui/material";
@@ -11,12 +12,15 @@ function FieldGrid({ index, data }: { index: number; data: Contributor[] }) {
   return (
     <Grid container spacing={2}>
       {(!data || !data[index] || !Object.hasOwn(data[index], "status")) && (
-        <TextInputField
+        <>
+        {/* <TextInputField
           name={`contributor.${index}.id`}
           label="ORCID ID"
           placeholder="Full ORCID ID, e.g. https://orcid.org/0000-0000-0000-0000"
           width={12}
-        />
+        /> */}
+        <ORCIDLookup />
+        </>
       )}
       {data[index] && Object.hasOwn(data[index], "status") && (
         <DisplayItem

--- a/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
@@ -4,7 +4,7 @@ import { TextInputField } from "@/components/fields/TextInputField";
 import ORCIDLookup from "@/containers/orcid-lookup/ORCID";
 import { Contributor } from "@/generated/raid";
 import { IndeterminateCheckBox } from "@mui/icons-material";
-import { Grid, IconButton, Stack, Tooltip, Typography } from "@mui/material";
+import { Grid, IconButton, Stack, Tooltip, Typography, Box } from "@mui/material";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 
@@ -12,7 +12,7 @@ function FieldGrid({ index, data }: { index: number; data: Contributor[] }) {
   return (
     <Grid container spacing={2}>
       {(!data || !data[index] || !Object.hasOwn(data[index], "status")) && (
-        <>
+        <Box width="100%" mb={2}>
         {/* <TextInputField
           name={`contributor.${index}.id`}
           label="ORCID ID"
@@ -20,7 +20,7 @@ function FieldGrid({ index, data }: { index: number; data: Contributor[] }) {
           width={12}
         /> */}
         <ORCIDLookup />
-        </>
+        </Box>
       )}
       {data[index] && Object.hasOwn(data[index], "status") && (
         <DisplayItem

--- a/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
@@ -19,7 +19,7 @@ function FieldGrid({ index, data }: { index: number; data: Contributor[] }) {
           placeholder="Full ORCID ID, e.g. https://orcid.org/0000-0000-0000-0000"
           width={12}
         /> */}
-        <ORCIDLookup index={index} />
+        <ORCIDLookup name={`contributor.${index}.id`} />
         </Box>
       )}
       {data[index] && Object.hasOwn(data[index], "status") && (

--- a/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
@@ -12,14 +12,14 @@ function FieldGrid({ index, data }: { index: number; data: Contributor[] }) {
   return (
     <Grid container spacing={2}>
       {(!data || !data[index] || !Object.hasOwn(data[index], "status")) && (
-        <Box width="100%" mb={2}>
+        <Box width="100%">
         {/* <TextInputField
           name={`contributor.${index}.id`}
           label="ORCID ID"
           placeholder="Full ORCID ID, e.g. https://orcid.org/0000-0000-0000-0000"
           width={12}
         /> */}
-        <ORCIDLookup />
+        <ORCIDLookup index={index} />
         </Box>
       )}
       {data[index] && Object.hasOwn(data[index], "status") && (

--- a/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
@@ -1,6 +1,5 @@
 import { DisplayItem } from "@/components/display-item";
 import { CheckboxField } from "@/components/fields/CheckboxField";
-import { TextInputField } from "@/components/fields/TextInputField";
 import ORCIDLookup from "@/containers/orcid-lookup/ORCID";
 import { Contributor } from "@/generated/raid";
 import { IndeterminateCheckBox } from "@mui/icons-material";
@@ -13,19 +12,13 @@ function FieldGrid({ index, data }: { index: number; data: Contributor[] }) {
     <Grid container spacing={2}>
       {(!data || !data[index] || !Object.hasOwn(data[index], "status")) && (
         <Box width="100%">
-        {/* <TextInputField
-          name={`contributor.${index}.id`}
-          label="ORCID ID"
-          placeholder="Full ORCID ID, e.g. https://orcid.org/0000-0000-0000-0000"
-          width={12}
-        /> */}
         <ORCIDLookup name={`contributor.${index}.id`} />
         </Box>
       )}
       {data[index] && Object.hasOwn(data[index], "status") && (
         <DisplayItem
           label="Contributor Status"
-          value={"status" in data[index] ? String((data[index] as any).status) : ""}
+          value={"status" in data[index] ? String((data[index] as Contributor).status) : ""}
           width={12}
         />
       )}

--- a/raid-agency-app/src/entities/contributor/forms/contributors-form/ContributorsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributors-form/ContributorsForm.tsx
@@ -25,6 +25,7 @@ import { ContributorDetailsForm } from "@/entities/contributor/forms/contributor
 import { MetadataContext } from "@/components/raid-form/RaidForm";
 import { CustomStyledTooltip } from "@/components/tooltips/StyledTooltip";
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import ORCIDLookup from "@/containers/orcid-lookup/ORCID";
 
 export function ContributorsForm({
   control,

--- a/raid-agency-app/src/entities/contributor/forms/contributors-form/ContributorsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributors-form/ContributorsForm.tsx
@@ -25,7 +25,6 @@ import { ContributorDetailsForm } from "@/entities/contributor/forms/contributor
 import { MetadataContext } from "@/components/raid-form/RaidForm";
 import { CustomStyledTooltip } from "@/components/tooltips/StyledTooltip";
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import ORCIDLookup from "@/containers/orcid-lookup/ORCID";
 
 export function ContributorsForm({
   control,

--- a/raid-agency-app/src/entities/contributor/validation-schema/contributor-validation-schema.ts
+++ b/raid-agency-app/src/entities/contributor/validation-schema/contributor-validation-schema.ts
@@ -49,7 +49,7 @@ export const singleContributorValidationSchema = z.union([
       .optional(),
   }),
   baseContributorSchema.extend({
-    uuid: z.string().optional(),
+    uuid: z.string(),
   }),
   baseContributorSchema.extend({
     email: z.string().optional(),

--- a/raid-agency-app/src/entities/contributor/validation-schema/contributor-validation-schema.ts
+++ b/raid-agency-app/src/entities/contributor/validation-schema/contributor-validation-schema.ts
@@ -18,7 +18,7 @@ import { z } from "zod";
 
 // The ORCID regex pattern used in multiple places
 const orcidPattern =
-  "^https://(sandbox\\.)?orcid\\.org/\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$";
+  "^https://(sandbox\\.)?orcid\\.org/\\d{4}-?\\d{4}-?\\d{4}-?\\d{3}[0-9X]$";
 const orcidErrorMsg =
   "Invalid ORCID ID, must be full url, e.g. https://orcid.org/0000-0000-0000-0000";
 
@@ -45,13 +45,11 @@ export const singleContributorValidationSchema = z.union([
     id: z
       .string()
       .trim()
-      .regex(
-        new RegExp("^https://orcid.org/\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"),
-        { message: orcidErrorMsg }
-      ),
+      .regex(/^https:\/\/orcid\.org\/\d{4}-?\d{4}-?\d{4}-?\d{3}[0-9X]$/, { message: orcidErrorMsg })
+      .optional(),
   }),
   baseContributorSchema.extend({
-    uuid: z.string(),
+    uuid: z.string().optional(),
   }),
   baseContributorSchema.extend({
     email: z.string().optional(),

--- a/raid-agency-app/src/pages/cache-manager/CacheManager.tsx
+++ b/raid-agency-app/src/pages/cache-manager/CacheManager.tsx
@@ -174,6 +174,10 @@ export function CacheManager() {
     key: "organisationNames",
   });
 
+  const { data: contributorNames } = useCache({
+    key: "contributorNames",
+  });
+
   const handleDelete = ({
     key,
     storageKey,
@@ -224,6 +228,19 @@ export function CacheManager() {
                 storageKey="organisationNames"
               />
             )) || <Typography>No organisation names in cache</Typography>}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader title="ORCID names" />
+          <CardContent>
+            {(contributorNames?.size && (
+              <CachedItemsList
+                cachedMap={contributorNames}
+                handleDelete={handleDelete}
+                storageKey="contributorNames"
+              />
+            )) || <Typography>No ORCID names in cache</Typography>}
           </CardContent>
         </Card>
       </Stack>


### PR DESCRIPTION
Jira: https://ardc.atlassian.net/browse/RAID-373

ChangeLog:
Implemented below ACs:
1. Keep only one search bar to cater for both type of user inputs: free text search and ORCID look up. To achieve this, a pattern detection mechanism will be added to determine whether the input is a valid ORCID or anything else.
2. For the ORCID lookup, support more formats of inputs, including:
16 digit ORCID identifiers (with or without dashes)
Full ORCID URL
3. For each displayed search result, display “Country“ as additional info together with their credit name, given name, family name, and a “view Profile“ link.
4. After the user makes a selection, display the selected ORCID party’s credit name on top of their ORCID ID. If the credit name is empty, display their given name + family name instead.
5. Add a tooltip at the bottom to briefly explain to user how this widget works, what to expect, and in which case there would be no name being displayed on top (aka the profile is private)