### PR TITLE
RAID-545: replace hardcoded localhost URLs in E2E tests

### DIFF
--- a/raid-agency-app/e2e/tests/01-auth.spec.ts
+++ b/raid-agency-app/e2e/tests/01-auth.spec.ts
@@ -4,11 +4,21 @@
 
 import { test, expect } from "@playwright/test";
 
+const { VITE_KEYCLOAK_URL } = process.env;
+
+if (!VITE_KEYCLOAK_URL) {
+  throw new Error("VITE_KEYCLOAK_URL environment variable is not set.");
+}
+
+// Escape special regex characters in the URL so it can be used as a literal match
+const keycloakUrlPattern = new RegExp(
+  VITE_KEYCLOAK_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+);
+
 test.describe("Authentication", () => {
   test.describe("Unauthenticated access", () => {
     test(
       "redirects to Keycloak login when visiting root unauthenticated",
-      { tag: "@local" },
       async ({ browser }) => {
         // Create a fresh context with no stored session
         const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
@@ -17,8 +27,8 @@ test.describe("Authentication", () => {
         await page.goto("/");
 
         // Should redirect to Keycloak
-        await page.waitForURL(/localhost:8001/, { timeout: 15000 });
-        await expect(page).toHaveURL(/localhost:8001/);
+        await page.waitForURL(keycloakUrlPattern, { timeout: 15000 });
+        await expect(page).toHaveURL(keycloakUrlPattern);
 
         // Keycloak login page should be visible
         await expect(page.locator("#username")).toBeVisible();
@@ -30,15 +40,14 @@ test.describe("Authentication", () => {
 
     test(
       "redirects to Keycloak login when visiting /raids unauthenticated",
-      { tag: "@local" },
       async ({ browser }) => {
         const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
         const page = await context.newPage();
 
         await page.goto("/raids");
 
-        await page.waitForURL(/localhost:8001/, { timeout: 15000 });
-        await expect(page).toHaveURL(/localhost:8001/);
+        await page.waitForURL(keycloakUrlPattern, { timeout: 15000 });
+        await expect(page).toHaveURL(keycloakUrlPattern);
         await expect(page.locator("#username")).toBeVisible();
 
         await context.close();
@@ -51,19 +60,17 @@ test.describe("Authentication", () => {
 
     test(
       "authenticated session allows access to /raids",
-      { tag: "@local" },
       async ({ page }) => {
         await page.goto("/raids");
 
         // Should NOT be redirected to Keycloak
-        await expect(page).not.toHaveURL(/localhost:8001/);
+        await expect(page).not.toHaveURL(keycloakUrlPattern);
         await expect(page).toHaveURL(/\/raids/);
       }
     );
 
     test(
       "authenticated user can see the RAiD list page",
-      { tag: "@local" },
       async ({ page }) => {
         await page.goto("/raids");
 

--- a/raid-agency-app/e2e/utils/raid-api-client.ts
+++ b/raid-agency-app/e2e/utils/raid-api-client.ts
@@ -1,5 +1,5 @@
 // RAID-536: Thin HTTP client for API-based test data seeding
-// Uses the RAiD API at localhost:8080 to create and retrieve RAiDs directly,
+// Uses the RAiD API (API_BASE_URL) to create and retrieve RAiDs directly,
 // which is faster than driving the UI for test setup.
 
 const API_BASE = process.env.API_BASE_URL ?? "http://localhost:8080";


### PR DESCRIPTION
## Summary
- Replace hardcoded `localhost:8001` regex patterns in `01-auth.spec.ts` with a dynamic `keycloakUrlPattern` derived from `VITE_KEYCLOAK_URL` environment variable
- Remove `@local` tags from auth tests so they run in all environments (local and CI)
- Update stale comment in `raid-api-client.ts` to reference `API_BASE_URL` instead of hardcoded localhost

## Test plan
- [x] All 27 Playwright E2E tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)