### PR TITLE
RAID-550: Conditional CI with paths-filter and gate jobs

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -2,12 +2,25 @@ name: PR E2E Tests
 
 on:
   pull_request:
-    paths:
-      - '.github/**'
-      - 'raid-agency-app/**'
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      frontend-changed: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - '.github/**'
+              - 'raid-agency-app/**'
+
   e2e-tests:
+    needs: check-paths
+    if: needs.check-paths.outputs.frontend-changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -128,3 +141,16 @@ jobs:
         if: always()
         working-directory: api-svc/raid-api
         run: docker compose down
+
+  e2e-tests-result:
+    if: always()
+    needs: [check-paths, e2e-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check result
+        run: |
+          if [ "${{ needs.e2e-tests.result }}" = "failure" ]; then
+            echo "E2E tests failed"
+            exit 1
+          fi
+          echo "E2E tests passed or were skipped"

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -2,20 +2,32 @@ name: PR Integration Tests
 
 on:
   pull_request:
-    paths:
-      - '.github/**'
-      - 'api-svc/**'
-      - 'iam/**'
-      - 'gradle/**'
-      - 'build.gradle'
-      - 'settings.gradle'
-      - 'gradle.properties'
-      - 'libs.versions.toml'
-      - 'gradlew'
-      - 'gradlew.bat'
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      backend-changed: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - '.github/**'
+              - 'api-svc/**'
+              - 'iam/**'
+              - 'gradle/**'
+              - 'build.gradle'
+              - 'settings.gradle'
+              - 'gradle.properties'
+              - 'gradlew'
+              - 'gradlew.bat'
+
   integration-tests:
+    needs: check-paths
+    if: needs.check-paths.outputs.backend-changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -81,3 +93,16 @@ jobs:
         if: always()
         working-directory: api-svc/raid-api
         run: docker compose down
+
+  integration-tests-result:
+    if: always()
+    needs: [check-paths, integration-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check result
+        run: |
+          if [ "${{ needs.integration-tests.result }}" = "failure" ]; then
+            echo "Integration tests failed"
+            exit 1
+          fi
+          echo "Integration tests passed or were skipped"


### PR DESCRIPTION
## Summary
- Both `pr-integration-tests` and `pr-e2e-tests` workflows now trigger on **all PRs** (no path filters on the trigger)
- Uses `dorny/paths-filter` to conditionally run tests only when relevant files change
- Adds gate jobs (`integration-tests-result`, `e2e-tests-result`) that always report a status, so they can be used as required checks without blocking unrelated PRs

## Branch protection setup
Set these as required status checks on `main`:
- `integration-tests-result`
- `e2e-tests-result`

## Test plan
- [ ] Verify gate jobs report success when paths don't match (e.g. a docs-only PR)
- [ ] Verify integration tests run when backend files change
- [ ] Verify e2e tests run when frontend files change
- [ ] Verify gate jobs report failure when tests fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)