### PR TITLE
RAID-575: add operator-only GET /raid/all endpoint

### DIFF
--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RaidAllEndpointIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RaidAllEndpointIntegrationTest.java
@@ -1,0 +1,85 @@
+package au.org.raid.inttest;
+
+import au.org.raid.idl.raidv2.model.RaidDto;
+import au.org.raid.inttest.service.Handle;
+import feign.FeignException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Slf4j
+public class RaidAllEndpointIntegrationTest extends AbstractIntegrationTest {
+
+    @Value("${raid.test.api.url}")
+    private String apiUrl;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Test
+    @DisplayName("GET /raid/all returns raids for operator user")
+    void findAllRaidsAsOperator() {
+        final var operatorContext = userService.createUser("raid-au", "service-point-user", "operator");
+
+        try {
+            // Mint a raid so there's at least one to find
+            final var mintedRaid = raidApi.mintRaid(createRequest).getBody();
+            assert mintedRaid != null;
+
+            final var headers = new HttpHeaders();
+            headers.setBearerAuth(operatorContext.getToken());
+
+            final var response = restTemplate.exchange(
+                    apiUrl + "/raid/all",
+                    HttpMethod.GET,
+                    new HttpEntity<>(headers),
+                    new ParameterizedTypeReference<List<RaidDto>>() {}
+            );
+
+            assertThat(response.getStatusCode(), is(HttpStatus.OK));
+            assertThat(response.getBody(), is(notNullValue()));
+            assertThat(response.getBody().size(), is(greaterThanOrEqualTo(1)));
+
+            // Verify the minted raid appears in the results
+            final var raidIds = response.getBody().stream()
+                    .map(r -> r.getIdentifier().getId())
+                    .toList();
+            assertThat(raidIds, hasItem(mintedRaid.getIdentifier().getId()));
+        } finally {
+            userService.deleteUser(operatorContext.getId());
+        }
+    }
+
+    @Test
+    @DisplayName("GET /raid/all returns 403 for non-operator user")
+    void findAllRaidsAsNonOperator() {
+        // The default userContext from AbstractIntegrationTest has service-point-user role, not operator
+        final var headers = new HttpHeaders();
+        headers.setBearerAuth(userContext.getToken());
+
+        try {
+            restTemplate.exchange(
+                    apiUrl + "/raid/all",
+                    HttpMethod.GET,
+                    new HttpEntity<>(headers),
+                    new ParameterizedTypeReference<List<RaidDto>>() {}
+            );
+            fail("Expected 403 Forbidden but got 200");
+        } catch (HttpClientErrorException e) {
+            assertThat(e.getStatusCode(), is(HttpStatus.FORBIDDEN));
+        }
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/controller/RaidController.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/controller/RaidController.java
@@ -180,6 +180,14 @@ public class RaidController implements RaidApi {
         return ResponseEntity.ok(raidService.findAllNonLegacy());
     }
 
+    @GetMapping(value="/raid/all")
+    public ResponseEntity<List<RaidDto>> findAllRaidsIncludingWithoutHistory() {
+        if (!TokenUtil.hasRole(TokenUtil.OPERATOR_ROLE)) {
+            return ResponseEntity.status(403).build();
+        }
+        return ResponseEntity.ok(raidIngestService.findAllIncludingWithoutHistory());
+    }
+
     @Override
     public ResponseEntity<RaidCountResponse> countRaids(
             final Long servicePointId,

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/repository/RaidRepository.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/repository/RaidRepository.java
@@ -142,6 +142,13 @@ public class RaidRepository {
                 .fetchInto(RaidRecord.class);
     }
 
+    public List<RaidRecord> findAllIncludingWithoutHistory() {
+        return dslContext.selectFrom(RAID)
+                .where(RAID.METADATA_SCHEMA.ne(Metaschema.legacy_metadata_schema_v1))
+                .orderBy(RAID.DATE_CREATED.desc())
+                .fetch();
+    }
+
     public List<RaidRecord> findAllByContributorOrcid(final String orcid) {
         return dslContext.select()
                 .from(RAID)

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/RaidIngestService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/RaidIngestService.java
@@ -206,4 +206,17 @@ public class RaidIngestService {
                 })
                 .collect(Collectors.toList());
     }
+
+    public List<RaidDto> findAllIncludingWithoutHistory() {
+        return raidRepository.findAllIncludingWithoutHistory().stream()
+                .map(RaidRecord::getMetadata)
+                .map(metadata -> {
+                    try {
+                        return objectMapper.readValue(metadata.data(), RaidDto.class);
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/controller/RaidControllerTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/controller/RaidControllerTest.java
@@ -1049,4 +1049,35 @@ class RaidControllerTest {
             return null;
         };
     }
+
+    @Test
+    @DisplayName("GET /raid/all returns 200 with all raids when user has operator role")
+    void findAllRaidsIncludingWithoutHistory_returnsOk() throws Exception {
+        final var raidDto = new RaidDto();
+
+        try (MockedStatic<TokenUtil> tokenUtil = Mockito.mockStatic(TokenUtil.class)) {
+            tokenUtil.when(() -> TokenUtil.hasRole(TokenUtil.OPERATOR_ROLE)).thenReturn(true);
+            when(raidIngestService.findAllIncludingWithoutHistory()).thenReturn(List.of(raidDto));
+
+            mockMvc.perform(get("/raid/all"))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+
+            verify(raidIngestService).findAllIncludingWithoutHistory();
+        }
+    }
+
+    @Test
+    @DisplayName("GET /raid/all returns 403 when user does not have operator role")
+    void findAllRaidsIncludingWithoutHistory_returnsForbidden() throws Exception {
+        try (MockedStatic<TokenUtil> tokenUtil = Mockito.mockStatic(TokenUtil.class)) {
+            tokenUtil.when(() -> TokenUtil.hasRole(TokenUtil.OPERATOR_ROLE)).thenReturn(false);
+
+            mockMvc.perform(get("/raid/all"))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+
+            verifyNoInteractions(raidIngestService);
+        }
+    }
 }

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/repository/RaidRepositoryTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/repository/RaidRepositoryTest.java
@@ -56,4 +56,12 @@ class RaidRepositoryTest {
 
         verify(dslContext).selectFrom(RAID);
     }
+
+    @Test
+    @DisplayName("findAllIncludingWithoutHistory() queries RAID table directly without RAID_HISTORY join")
+    void findAllIncludingWithoutHistory() {
+        raidRepository.findAllIncludingWithoutHistory();
+
+        verify(dslContext).selectFrom(RAID);
+    }
 }

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/service/RaidIngestServiceTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/service/RaidIngestServiceTest.java
@@ -4,6 +4,10 @@ import au.org.raid.api.factory.HandleFactory;
 import au.org.raid.api.factory.RaidRecordFactory;
 import au.org.raid.api.repository.RaidRepository;
 import au.org.raid.db.jooq.tables.records.RaidRecord;
+import au.org.raid.idl.raidv2.model.RaidDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jooq.JSONB;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,6 +64,8 @@ class RaidIngestServiceTest {
     RaidHistoryService raidHistoryService;
     @Mock
     RaidDtoReadService raidDtoReadService;
+    @Mock
+    ObjectMapper objectMapper;
     @InjectMocks
     RaidIngestService raidIngestService;
 
@@ -183,5 +189,20 @@ class RaidIngestServiceTest {
         verify(relatedRaidService).update(RELATED_RAIDS, HANDLE);
         verify(subjectService).update(SUBJECTS, HANDLE);
         verify(spatialCoverageService).update(SPATIAL_COVERAGES, HANDLE);
+    }
+
+    @Test
+    @DisplayName("findAllIncludingWithoutHistory() maps records via objectMapper")
+    void findAllIncludingWithoutHistory() throws JsonProcessingException {
+        final var metadata = JSONB.valueOf("{\"test\":true}");
+        final var raidRecord = new RaidRecord().setMetadata(metadata);
+        final var raidDto = new RaidDto();
+
+        when(raidRepository.findAllIncludingWithoutHistory()).thenReturn(List.of(raidRecord));
+        when(objectMapper.readValue(metadata.data(), RaidDto.class)).thenReturn(raidDto);
+
+        final var result = raidIngestService.findAllIncludingWithoutHistory();
+
+        assertThat(result, is(List.of(raidDto)));
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ See the [Changelog audience](#changelog-audience) section for info about
 ## API
 * Skip DataCite API calls for non-DOI handles — legacy handles (102.100.100/*, 10378.1/*) were
   never registered with DataCite and caused 500 errors on update (RAID-575).
+* Add operator-only GET /raid/all endpoint to return all raids without RAID_HISTORY join limitation (RAID-575).
 * Add web.archive.org as a valid related object schema URI (RAID-572).
 
 ## App-client UI


### PR DESCRIPTION
## Summary
- Add `GET /raid/all` operator-only endpoint that returns all raids without the `RAID_HISTORY` join limitation
- The existing `findAll()` joins on `RAID_HISTORY`, filtering out raids without history entries (704 of 19,147 on demo)
- This endpoint is needed by the vocabulary URI uplift script to process all raids
- Returns 403 for non-operator users

## Test plan
- [x] Unit tests for RaidController (200 for operator, 403 for non-operator)
- [x] Unit tests for RaidIngestService and RaidRepository
- [x] Integration test (RaidAllEndpointIntegrationTest) — operator and non-operator scenarios
- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)