### PR TITLE
RAID-573: fix service point fetch timeout on static site build

### DIFF
--- a/api-svc/raid-api/src/main/resources/application.yaml
+++ b/api-svc/raid-api/src/main/resources/application.yaml
@@ -69,6 +69,8 @@ raid:
       username: geonames
   history:
     baseline-interval: 50
+server:
+  forward-headers-strategy: native
 spring:
   jackson:
     default-property-inclusion: non_null

--- a/raid-agency-app-static/scripts/fetch-sp.js
+++ b/raid-agency-app-static/scripts/fetch-sp.js
@@ -16,7 +16,7 @@
  * @returns {Promise<Map<string, string>>} Map of servicePointId -> name
  */
 async function fetchAllServicePoints({ makeRequestWithRetry, config }) {
-  const url = `${config.apiEndpoint}/service-point`;
+  const url = `${config.apiEndpoint}/service-point/`;
 
   const response = await makeRequestWithRetry(url, {
     method: 'GET',


### PR DESCRIPTION
## Summary
- The static site build was showing all service points as "Unknown" on the prefixes page
- Root cause: `GET /service-point` (without trailing slash) triggers a Spring 302 redirect to `/service-point/`, but the redirect `Location` header uses `http://` instead of `https://` because `server.forward-headers-strategy` was not configured — the HTTP URL times out in PROD
- Added `server.forward-headers-strategy: native` to `application.yaml` so Spring respects `X-Forwarded-Proto` from the reverse proxy
- Added trailing slash to the fetch script URL to match the OpenAPI spec path and avoid the redirect entirely

## Test plan
- [ ] Verify `GET /service-point` no longer redirects to `http://` in PROD (after API deploy)
- [ ] Trigger a static site build and confirm service point names appear on the prefixes page
- [ ] Verify no regressions on other API redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)