### PR TITLE
Add integration tests for web archive related objects

### DIFF
--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RelatedObjectIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RelatedObjectIntegrationTest.java
@@ -1,0 +1,123 @@
+package au.org.raid.inttest;
+
+import au.org.raid.idl.raidv2.model.RelatedObject;
+import au.org.raid.idl.raidv2.model.RelatedObjectCategory;
+import au.org.raid.idl.raidv2.model.RelatedObjectType;
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import au.org.raid.inttest.service.RaidApiValidationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static au.org.raid.fixtures.TestConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class RelatedObjectIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String RELATED_OBJECT_CATEGORY_SCHEMA_URI =
+            "https://vocabulary.raid.org/relatedObject.category.schemaUri/386";
+    private static final String INPUT_RELATED_OBJECT_CATEGORY_ID =
+            "https://vocabulary.raid.org/relatedObject.category.id/191";
+
+    private RelatedObject webArchiveRelatedObject(String id) {
+        return new RelatedObject()
+                .id(id)
+                .schemaUri(WEB_ARCHIVE_SCHEMA_URI)
+                .type(new RelatedObjectType()
+                        .id(BOOK_CHAPTER_RELATED_OBJECT_TYPE)
+                        .schemaUri(RELATED_OBJECT_TYPE_SCHEMA_URI))
+                .category(List.of(new RelatedObjectCategory()
+                        .id(INPUT_RELATED_OBJECT_CATEGORY_ID)
+                        .schemaUri(RELATED_OBJECT_CATEGORY_SCHEMA_URI)));
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with a valid web archive related object succeeds")
+    void validWebArchiveRelatedObject() {
+        createRequest.setRelatedObject(List.of(webArchiveRelatedObject(VALID_WEB_ARCHIVE_URL)));
+
+        try {
+            final var result = raidApi.mintRaid(createRequest);
+            final var raid = result.getBody();
+            assertThat(raid).isNotNull();
+            assertThat(raid.getRelatedObject()).hasSize(1);
+            assertThat(raid.getRelatedObject().get(0).getId()).isEqualTo(VALID_WEB_ARCHIVE_URL);
+            assertThat(raid.getRelatedObject().get(0).getSchemaUri()).isEqualTo(WEB_ARCHIVE_SCHEMA_URI);
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with an invalid web archive URL fails validation")
+    void invalidWebArchiveUrl() {
+        createRequest.setRelatedObject(List.of(webArchiveRelatedObject(INVALID_WEB_ARCHIVE_URL)));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown with invalid web archive URL");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures).contains(new ValidationFailure()
+                    .fieldId("relatedObject[0].id")
+                    .errorType("invalid")
+                    .message("Must be a valid Web Archive URL (e.g. https://web.archive.org/web/20220101000000/https://example.com)"));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with an unsupported related object schemaUri fails validation")
+    void unsupportedSchemaUri() {
+        final var relatedObject = new RelatedObject()
+                .id("https://example.com/some-object")
+                .schemaUri("https://example.com/")
+                .type(new RelatedObjectType()
+                        .id(BOOK_CHAPTER_RELATED_OBJECT_TYPE)
+                        .schemaUri(RELATED_OBJECT_TYPE_SCHEMA_URI))
+                .category(List.of(new RelatedObjectCategory()
+                        .id(INPUT_RELATED_OBJECT_CATEGORY_ID)
+                        .schemaUri(RELATED_OBJECT_CATEGORY_SCHEMA_URI)));
+
+        createRequest.setRelatedObject(List.of(relatedObject));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown with unsupported schemaUri");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures).contains(new ValidationFailure()
+                    .fieldId("relatedObject[0].schemaUri")
+                    .errorType("invalid")
+                    .message("Only [https://doi.org/, https://web.archive.org/] is supported."));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with a web archive URL missing the inner URL fails validation")
+    void webArchiveUrlMissingInnerUrl() {
+        createRequest.setRelatedObject(List.of(
+                webArchiveRelatedObject("https://web.archive.org/web/20220101000000/https://")));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown with web archive URL missing inner URL");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures).contains(new ValidationFailure()
+                    .fieldId("relatedObject[0].id")
+                    .errorType("invalid")
+                    .message("Must be a valid Web Archive URL (e.g. https://web.archive.org/web/20220101000000/https://example.com)"));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+}

--- a/api-svc/testFixtures/src/testFixtures/java/au/org/raid/fixtures/TestConstants.java
+++ b/api-svc/testFixtures/src/testFixtures/java/au/org/raid/fixtures/TestConstants.java
@@ -95,4 +95,14 @@ public class TestConstants {
     public static final String GEONAMES_SCHEMA_URI = "https://www.geonames.org/";
 
     public static final String CONTRIBUTOR_EMAIL = "authenticated@test.raid.org.au";
+
+    public static final String RELATED_OBJECT_TYPE_SCHEMA_URI =
+            "https://vocabulary.raid.org/relatedObject.type.schema/329";
+    public static final String BOOK_CHAPTER_RELATED_OBJECT_TYPE =
+            "https://vocabulary.raid.org/relatedObject.type.schema/248";
+
+    public static final String WEB_ARCHIVE_SCHEMA_URI = "https://web.archive.org/";
+    public static final String VALID_WEB_ARCHIVE_URL =
+            "https://web.archive.org/web/20220101000000/https://example.com";
+    public static final String INVALID_WEB_ARCHIVE_URL = "https://web.archive.org/foo/bar";
 }

--- a/documentation/20260414-web-archive-related-object-integration-tests.md
+++ b/documentation/20260414-web-archive-related-object-integration-tests.md
@@ -1,0 +1,30 @@
+# Web Archive Related Object Integration Tests
+
+**Date:** 2026-04-14
+
+## What Changed
+
+Added integration tests for the web archive related object validation feature introduced in Flyway migration V39. The `RelatedObjectValidator` supports `https://web.archive.org/` as a related object `schemaUri` and validates URLs against the pattern `https://web.archive.org/web/<14-digit-timestamp>/<url>`.
+
+### Files Changed
+
+- `api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RelatedObjectIntegrationTest.java` — new integration test class with 4 scenarios
+- `api-svc/testFixtures/src/testFixtures/java/au/org/raid/fixtures/TestConstants.java` — added constants for web archive and related object type/category vocabulary URIs
+
+### Test Scenarios
+
+| # | Test | Input | Expected |
+|---|------|-------|----------|
+| 1 | Valid web archive URL | `https://web.archive.org/web/20220101000000/https://example.com` | 201 - RAiD minted |
+| 2 | Invalid web archive URL | `https://web.archive.org/foo/bar` | 400 - validation failure on `relatedObject[0].id` |
+| 3 | Unsupported schemaUri | `https://example.com/` | 400 - validation failure on `relatedObject[0].schemaUri` |
+| 4 | Missing inner URL | `https://web.archive.org/web/20220101000000/https://` | 400 - validation failure on `relatedObject[0].id` |
+
+## Why
+
+The web archive schema support was added without integration test coverage. These tests verify the full request lifecycle (API request -> validation -> response) and were manually confirmed against all three environments (local, test, demo).
+
+## Links
+
+- **PR:** https://github.com/au-research/raid-au/pull/429
+- **Branch:** `defect/related-object-schemaURI-weborigin`


### PR DESCRIPTION
## Summary
- Adds `RelatedObjectIntegrationTest` with 4 integration test scenarios for web archive related object validation
- Adds test constants for related object type/category vocabulary URIs to `TestConstants.java`
- Manually verified all 4 scenarios pass against local, test (`api.test.raid.org.au`), and demo (`api.demo.raid.org.au`) environments

## Test Scenarios
1. **Valid web archive URL** — minting succeeds with a properly formatted URL
2. **Invalid web archive URL** (`/foo/bar`) — returns 400 with validation failure
3. **Unsupported schemaUri** (`example.com`) — returns 400 with validation failure
4. **Missing inner URL** (`https://`) — returns 400 with validation failure

## Test plan
- [x] Unit tests pass (`RelatedObjectValidatorTest`)
- [x] Integration tests pass locally
- [x] Manual curl verification on test environment
- [x] Manual curl verification on demo environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)