### PR TITLE
RAID-593: add RAiD Search API section to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,9 @@
 4. [Running E2E Tests](#running-e2e-tests)
 5. [Project Structure](#project-structure)
 6. [API Documentation](#api-documentation)
-7. [Contributing](#contributing)
-8. [License](#license)
+7. [RAiD Search API](#raid-search-api)
+8. [Contributing](#contributing)
+9. [License](#license)
 ## Getting Started
 To get started you'll need the following tools installed in your machine:
 - Node.js >= 18
@@ -69,6 +70,67 @@ npx playwright test
 ## API Documentation
 * [Swagger](https://api.demo.raid.org.au/swagger-ui/index.html#/raid/findRaidByName)
 * [RAiD Metadata Schema](https://metadata.raid.org/en/latest/index.html)
+
+## RAiD Search API
+
+The RAiD Search API provides a publicly accessible endpoint for searching RAiDs via the Datacite GraphQL API. It is deployed as an AWS Lambda function behind API Gateway at `api.raid.org`.
+
+### Endpoint
+
+```
+GET https://api.raid.org
+```
+
+### Query Parameters
+
+Only one filter parameter may be used per request.
+
+| Parameter       | Description                                        | Example                       |
+| --------------- | -------------------------------------------------- | ----------------------------- |
+| `contributor`   | Filter by contributor ORCID iD                     | `0000-0002-1825-0097`        |
+| `organisation`  | Filter by organisation ROR ID                      | `038sjwq09`                  |
+| `relatedObject` | Filter by related object DOI                       | `10.1234/example`            |
+| `relatedRaid`   | Filter by related RAiD ID                          | `10.26312/db3c5429`          |
+| `limit`         | Page size (default: 25, max: 100)                  | `25`                         |
+| `cursor`        | Pagination cursor from a previous response          | `MTIzNDU2Nzg5MA==`           |
+
+### Examples
+
+List all RAiDs:
+```bash
+curl "https://api.raid.org"
+```
+
+Search by contributor ORCID:
+```bash
+curl "https://api.raid.org?contributor=0000-0002-1825-0097"
+```
+
+Search by organisation:
+```bash
+curl "https://api.raid.org?organisation=038sjwq09&limit=10"
+```
+
+Paginate through results:
+```bash
+curl "https://api.raid.org?organisation=038sjwq09&cursor=MTIzNDU2Nzg5MA=="
+```
+
+### Response
+
+```json
+{
+  "data": [
+    { "identifier": { "id": "https://raid.org/10.26312/db3c5429" } },
+    { "identifier": { "id": "https://raid.org/10.26312/a1b2c3d4" } }
+  ],
+  "totalCount": 42,
+  "nextCursor": "MTIzNDU2Nzg5MA==",
+  "hasMore": true
+}
+```
+
+When there are no more results, `nextCursor` is absent and `hasMore` is `false`.
 
 # Contributing
 We welcome contributions from the community! Whether you're fixing bugs, adding new features, improving documentation, or suggesting ideas, we'd love to have your input. Feel free to raise a pull request (include tests).


### PR DESCRIPTION
## Summary
- Add "RAiD Search API" section to readme documenting the public search endpoint at `api.raid.org`
- Includes query parameter reference, curl examples, and response format

Relates to RAID-548