### PR TITLE
RAID-607: Fix Jakarta validation errors returning wrong response format

### DIFF
--- a/api-svc/raid-api/src/main/java/au/org/raid/api/endpoint/raidv2/RaidExceptionHandler.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/endpoint/raidv2/RaidExceptionHandler.java
@@ -3,15 +3,21 @@ package au.org.raid.api.endpoint.raidv2;
 import au.org.raid.api.exception.*;
 import au.org.raid.idl.raidv2.model.ClosedRaid;
 import au.org.raid.idl.raidv2.model.FailureResponse;
+import au.org.raid.idl.raidv2.model.ValidationFailure;
 import au.org.raid.idl.raidv2.model.ValidationFailureResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.exception.DataAccessException;
 import org.springframework.http.*;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Set;
 
 @Slf4j
 @ControllerAdvice
@@ -186,6 +192,53 @@ public class RaidExceptionHandler extends ResponseEntityExceptionHandler {
                 .status(exception.getStatus())
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(body);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request
+    ) {
+        final var failures = ex.getBindingResult().getAllErrors().stream()
+                .map(error -> {
+                    if (error instanceof FieldError fieldError) {
+                        return toValidationFailure(fieldError);
+                    }
+                    return toValidationFailure(error);
+                })
+                .toList();
+
+        final var failureCount = failures.size();
+        final var body = new ValidationFailureResponse()
+                .type("https://raid.org.au/errors#ValidationException")
+                .title("There were validation failures.")
+                .status(400)
+                .detail("Request had %d validation failure(s). See failures for more details...".formatted(failureCount))
+                .instance("https://raid.org.au")
+                .failures(failures);
+
+        return ResponseEntity
+                .badRequest()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(body);
+    }
+
+    private static final Set<String> NOT_SET_CODES = Set.of("NotNull", "NotBlank", "NotEmpty");
+
+    private ValidationFailure toValidationFailure(FieldError fieldError) {
+        var rejectedValue = fieldError.getRejectedValue();
+        var isBlankValue = rejectedValue == null || (rejectedValue instanceof String s && s.isBlank());
+        var errorType = (NOT_SET_CODES.contains(fieldError.getCode()) || isBlankValue) ? "notSet" : "invalidValue";
+        var message = errorType.equals("notSet") ? "field must be set" : "field has an invalid value";
+        return new ValidationFailure(fieldError.getField(), errorType, message);
+    }
+
+    private ValidationFailure toValidationFailure(ObjectError error) {
+        var errorType = NOT_SET_CODES.contains(error.getCode()) ? "notSet" : "invalidValue";
+        var message = errorType.equals("notSet") ? "field must be set" : "field has an invalid value";
+        return new ValidationFailure(error.getObjectName(), errorType, message);
     }
 
     @Override

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/endpoint/raidv2/RaidExceptionHandlerTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/endpoint/raidv2/RaidExceptionHandlerTest.java
@@ -1,0 +1,215 @@
+package au.org.raid.api.endpoint.raidv2;
+
+import au.org.raid.idl.raidv2.model.ValidationFailureResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class RaidExceptionHandlerTest {
+
+    private final RaidExceptionHandler handler = new RaidExceptionHandler();
+
+    @Test
+    @DisplayName("NotNull field error maps to notSet errorType with field's default message")
+    void notNullFieldError_mapsToNotSet() {
+        final var bindingResult = new BeanPropertyBindingResult(new Object(), "raidCreateRequest");
+        bindingResult.addError(new FieldError("raidCreateRequest", "access", null, false,
+                new String[]{"NotNull"}, null, "must not be null"));
+
+        final var ex = new MethodArgumentNotValidException(null, bindingResult);
+        final var response = handler.handleMethodArgumentNotValid(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, new ServletWebRequest(new MockHttpServletRequest()));
+
+        assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
+        assertThat(response.getHeaders().getContentType(), is(MediaType.APPLICATION_JSON));
+
+        final var body = (ValidationFailureResponse) response.getBody();
+        assertThat(body, notNullValue());
+        assertThat(body.getType(), is("https://raid.org.au/errors#ValidationException"));
+        assertThat(body.getTitle(), is("There were validation failures."));
+        assertThat(body.getStatus(), is(400));
+        assertThat(body.getInstance(), is("https://raid.org.au"));
+        assertThat(body.getDetail(), is("Request had 1 validation failure(s). See failures for more details..."));
+
+        final var failures = body.getFailures();
+        assertThat(failures, hasSize(1));
+        assertThat(failures.get(0).getFieldId(), is("access"));
+        assertThat(failures.get(0).getErrorType(), is("notSet"));
+        assertThat(failures.get(0).getMessage(), is("field must be set"));
+    }
+
+    @Test
+    @DisplayName("NotBlank field error maps to notSet errorType")
+    void notBlankFieldError_mapsToNotSet() {
+        final var bindingResult = new BeanPropertyBindingResult(new Object(), "raidCreateRequest");
+        bindingResult.addError(new FieldError("raidCreateRequest", "title[0].text", null, false,
+                new String[]{"NotBlank"}, null, "must not be blank"));
+
+        final var ex = new MethodArgumentNotValidException(null, bindingResult);
+        final var response = handler.handleMethodArgumentNotValid(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, new ServletWebRequest(new MockHttpServletRequest()));
+
+        final var body = (ValidationFailureResponse) response.getBody();
+        assertThat(body, notNullValue());
+        final var failure = body.getFailures().get(0);
+        assertThat(failure.getFieldId(), is("title[0].text"));
+        assertThat(failure.getErrorType(), is("notSet"));
+        assertThat(failure.getMessage(), is("field must be set"));
+    }
+
+    @Test
+    @DisplayName("NotEmpty field error maps to notSet errorType")
+    void notEmptyFieldError_mapsToNotSet() {
+        final var bindingResult = new BeanPropertyBindingResult(new Object(), "raidCreateRequest");
+        bindingResult.addError(new FieldError("raidCreateRequest", "titles", null, false,
+                new String[]{"NotEmpty"}, null, "must not be empty"));
+
+        final var ex = new MethodArgumentNotValidException(null, bindingResult);
+        final var response = handler.handleMethodArgumentNotValid(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, new ServletWebRequest(new MockHttpServletRequest()));
+
+        final var body = (ValidationFailureResponse) response.getBody();
+        assertThat(body, notNullValue());
+        final var failure = body.getFailures().get(0);
+        assertThat(failure.getFieldId(), is("titles"));
+        assertThat(failure.getErrorType(), is("notSet"));
+    }
+
+    @Test
+    @DisplayName("Pattern field error maps to invalidValue errorType")
+    void patternFieldError_mapsToInvalidValue() {
+        final var bindingResult = new BeanPropertyBindingResult(new Object(), "raidCreateRequest");
+        bindingResult.addError(new FieldError("raidCreateRequest", "identifier.id", "bad-value", false,
+                new String[]{"Pattern"}, null, "must match \"^https://raid.org/.*\""));
+
+        final var ex = new MethodArgumentNotValidException(null, bindingResult);
+        final var response = handler.handleMethodArgumentNotValid(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, new ServletWebRequest(new MockHttpServletRequest()));
+
+        final var body = (ValidationFailureResponse) response.getBody();
+        assertThat(body, notNullValue());
+        final var failure = body.getFailures().get(0);
+        assertThat(failure.getFieldId(), is("identifier.id"));
+        assertThat(failure.getErrorType(), is("invalidValue"));
+        assertThat(failure.getMessage(), is("field has an invalid value"));
+    }
+
+    @Test
+    @DisplayName("Size field error maps to invalidValue errorType")
+    void sizeFieldError_mapsToInvalidValue() {
+        final var bindingResult = new BeanPropertyBindingResult(new Object(), "raidCreateRequest");
+        bindingResult.addError(new FieldError("raidCreateRequest", "description[0].text", "x", false,
+                new String[]{"Size"}, null, "size must be between 1 and 2000"));
+
+        final var ex = new MethodArgumentNotValidException(null, bindingResult);
+        final var response = handler.handleMethodArgumentNotValid(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, new ServletWebRequest(new MockHttpServletRequest()));
+
+        final var body = (ValidationFailureResponse) response.getBody();
+        assertThat(body, notNullValue());
+        final var failure = body.getFailures().get(0);
+        assertThat(failure.getErrorType(), is("invalidValue"));
+    }
+
+    @Test
+    @DisplayName("Pattern field error with blank rejected value maps to notSet errorType")
+    void patternFieldErrorWithBlankValue_mapsToNotSet() {
+        final var bindingResult = new BeanPropertyBindingResult(new Object(), "raidCreateRequest");
+        bindingResult.addError(new FieldError("raidCreateRequest", "access.statement.language.id", "", false,
+                new String[]{"Pattern"}, null, "must match \"^\\s*\\S.*$\""));
+
+        final var ex = new MethodArgumentNotValidException(null, bindingResult);
+        final var response = handler.handleMethodArgumentNotValid(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, new ServletWebRequest(new MockHttpServletRequest()));
+
+        final var body = (ValidationFailureResponse) response.getBody();
+        assertThat(body, notNullValue());
+        final var failure = body.getFailures().get(0);
+        assertThat(failure.getFieldId(), is("access.statement.language.id"));
+        assertThat(failure.getErrorType(), is("notSet"));
+        assertThat(failure.getMessage(), is("field must be set"));
+    }
+
+    @Test
+    @DisplayName("Multiple field errors are all included in failures list")
+    void multipleErrors_allIncluded() {
+        final var bindingResult = new BeanPropertyBindingResult(new Object(), "raidCreateRequest");
+        bindingResult.addError(new FieldError("raidCreateRequest", "access", null, false,
+                new String[]{"NotNull"}, null, "must not be null"));
+        bindingResult.addError(new FieldError("raidCreateRequest", "identifier.id", "bad", false,
+                new String[]{"Pattern"}, null, "must match pattern"));
+
+        final var ex = new MethodArgumentNotValidException(null, bindingResult);
+        final var response = handler.handleMethodArgumentNotValid(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, new ServletWebRequest(new MockHttpServletRequest()));
+
+        final var body = (ValidationFailureResponse) response.getBody();
+        assertThat(body, notNullValue());
+        assertThat(body.getDetail(), is("Request had 2 validation failure(s). See failures for more details..."));
+        assertThat(body.getFailures(), hasSize(2));
+    }
+
+    @Test
+    @DisplayName("Null defaultMessage falls back to sensible default for notSet")
+    void nullDefaultMessage_fallsBackForNotSet() {
+        final var bindingResult = new BeanPropertyBindingResult(new Object(), "raidCreateRequest");
+        bindingResult.addError(new FieldError("raidCreateRequest", "access", null, false,
+                new String[]{"NotNull"}, null, null));
+
+        final var ex = new MethodArgumentNotValidException(null, bindingResult);
+        final var response = handler.handleMethodArgumentNotValid(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, new ServletWebRequest(new MockHttpServletRequest()));
+
+        final var body = (ValidationFailureResponse) response.getBody();
+        assertThat(body, notNullValue());
+        assertThat(body.getFailures().get(0).getMessage(), is("field must be set"));
+    }
+
+    @Test
+    @DisplayName("Null defaultMessage falls back to sensible default for invalidValue")
+    void nullDefaultMessage_fallsBackForInvalidValue() {
+        final var bindingResult = new BeanPropertyBindingResult(new Object(), "raidCreateRequest");
+        bindingResult.addError(new FieldError("raidCreateRequest", "identifier.id", "bad", false,
+                new String[]{"Pattern"}, null, null));
+
+        final var ex = new MethodArgumentNotValidException(null, bindingResult);
+        final var response = handler.handleMethodArgumentNotValid(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, new ServletWebRequest(new MockHttpServletRequest()));
+
+        final var body = (ValidationFailureResponse) response.getBody();
+        assertThat(body, notNullValue());
+        assertThat(body.getFailures().get(0).getMessage(), is("field has an invalid value"));
+    }
+
+    @Test
+    @DisplayName("Non-field ObjectError uses objectName as fieldId and maps unknown code to invalidValue")
+    void objectError_usesObjectNameAsFieldId() {
+        final var bindingResult = new BeanPropertyBindingResult(new Object(), "raidCreateRequest");
+        bindingResult.addError(new ObjectError("raidCreateRequest",
+                new String[]{"CustomObjectConstraint"}, null, "object-level constraint violated"));
+
+        final var ex = new MethodArgumentNotValidException(null, bindingResult);
+        final var response = handler.handleMethodArgumentNotValid(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, new ServletWebRequest(new MockHttpServletRequest()));
+
+        final var body = (ValidationFailureResponse) response.getBody();
+        assertThat(body, notNullValue());
+        final var failure = body.getFailures().get(0);
+        assertThat(failure.getFieldId(), is("raidCreateRequest"));
+        assertThat(failure.getErrorType(), is("invalidValue"));
+        assertThat(failure.getMessage(), is("field has an invalid value"));
+    }
+}


### PR DESCRIPTION
## Summary

- Override `handleMethodArgumentNotValid` in `RaidExceptionHandler` to convert Jakarta Bean Validation errors into `ValidationFailureResponse` format with a `failures` list, instead of Spring's default `ProblemDetail` (which has no `failures` field)
- Map `NotNull`/`NotBlank`/`NotEmpty` constraints to `notSet` errorType, and `Pattern`/`Size`/other constraints to `invalidValue` errorType
- Treat blank/null rejected values as `notSet` regardless of constraint type (e.g., an empty string failing a `@Pattern` check is semantically "not set")

## Context

OpenAPI-generated model classes have Jakarta Bean Validation annotations (`@NotNull`, `@Pattern`, `@Valid`). When these fire before the custom `ValidationService`, Spring was returning its default `ProblemDetail` format instead of `ValidationFailureResponse`. This broke clients that deserialize the `failures` list from error responses (e.g., `RaidApiValidationException.getFailures()` returned null).

## Test plan

- [x] All 14 `AccessIntegrationTest` tests pass (previously 10 were failing)
- [x] 10 unit tests covering: NotNull, NotBlank, NotEmpty, Pattern, Size constraint mappings; blank value edge case; multiple errors; null messages; object-level errors
- [x] No regressions — the 5 other failing integration tests are pre-existing and unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)