### PR TITLE
RAID-609: re-throw HttpClientErrorException in DataciteService

### DIFF
--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/DataciteErrorIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/DataciteErrorIntegrationTest.java
@@ -1,0 +1,99 @@
+package au.org.raid.inttest;
+
+import feign.FeignException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class DataciteErrorIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String MOCKSERVER_EXPECTATION_URL = "http://localhost:1080/mockserver/expectation";
+    private static final String EXPECTATION_ID = "datacite-error-integration-test";
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @AfterEach
+    void cleanUpMockServerExpectation() {
+        final var cleanup = """
+                [{
+                    "id": "%s",
+                    "priority": 0,
+                    "httpRequest": {
+                        "method": "POST",
+                        "path": "/dois"
+                    },
+                    "httpResponse": {
+                        "statusCode": 201
+                    },
+                    "times": {
+                        "remainingTimes": 0,
+                        "unlimited": false
+                    }
+                }]
+                """.formatted(EXPECTATION_ID);
+
+        var headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        try {
+            restTemplate.put(MOCKSERVER_EXPECTATION_URL, new HttpEntity<>(cleanup, headers));
+        } catch (Exception ignored) {
+        }
+    }
+
+    @Test
+    @DisplayName("Mint fails when DataCite returns an error")
+    void mintFailsOnDataciteError() {
+        createDataciteErrorExpectation();
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("Expected mint to fail when DataCite returns 429");
+        } catch (FeignException e) {
+            assertThat(e.status()).isEqualTo(500);
+        }
+    }
+
+    private void createDataciteErrorExpectation() {
+        final var expectation = """
+                [{
+                    "id": "%s",
+                    "priority": 10,
+                    "httpRequest": {
+                        "method": "POST",
+                        "path": "/dois",
+                        "headers": {
+                            "Authorization": ["Basic ZGF0YWNpdGUtdXNlcm5hbWU6ZGF0YWNpdGUtcGFzc3dvcmQ="],
+                            "Content-Type": ["application/json"]
+                        }
+                    },
+                    "httpResponse": {
+                        "statusCode": 429,
+                        "headers": {
+                            "Content-Type": ["application/json"]
+                        },
+                        "body": {
+                            "errors": [{"status": "429", "title": "Too Many Requests"}]
+                        }
+                    },
+                    "times": {
+                        "remainingTimes": 1,
+                        "unlimited": false
+                    }
+                }]
+                """.formatted(EXPECTATION_ID);
+
+        var headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        restTemplate.put(MOCKSERVER_EXPECTATION_URL, new HttpEntity<>(expectation, headers));
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/datacite/DataciteService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/datacite/DataciteService.java
@@ -54,6 +54,7 @@ public class DataciteService {
             restTemplate.exchange(properties.getEndpoint(), HttpMethod.POST, entity, JsonNode.class);
         } catch (HttpClientErrorException e) {
             log.error("Unable to create Datacite record", e);
+            throw e;
         }
     }
 
@@ -99,6 +100,7 @@ public class DataciteService {
             restTemplate.exchange(endpoint, HttpMethod.PUT, entity, JsonNode.class);
         } catch (HttpClientErrorException e) {
             log.error("Unable to update Datacite record", e);
+            throw e;
         }
     }
 }

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/service/datacite/DataciteServiceTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/service/datacite/DataciteServiceTest.java
@@ -20,7 +20,10 @@ import org.springframework.web.client.RestTemplate;
 
 import au.org.raid.idl.raidv2.model.RaidDto;
 import au.org.raid.idl.raidv2.model.RaidUpdateRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -126,5 +129,71 @@ public class DataciteServiceTest {
         dataciteService.update(new RaidDto(), "10378.1/1700205", "repo", "pass");
 
         verifyNoInteractions(restTemplate);
+    }
+
+    @Test
+    @DisplayName("Throws HttpClientErrorException when Datacite mint fails")
+    void mintThrowsOnError() {
+        final var repositoryId = "repository-id";
+        final var password = "_password";
+        final var handle = "10.12345/abcde";
+        final var endpoint = "_endpoint";
+        final var raidRequest = new RaidCreateRequest();
+
+        final var dataciteRequest = new DataciteRequest();
+        final var entity = new HttpEntity<>(dataciteRequest, new HttpHeaders());
+
+        when(dataciteRequestFactory.create(raidRequest, handle)).thenReturn(dataciteRequest);
+        when(httpEntityFactory.create(dataciteRequest, repositoryId, password)).thenReturn(entity);
+        when(properties.getEndpoint()).thenReturn(endpoint);
+        when(restTemplate.exchange(endpoint, HttpMethod.POST, entity, JsonNode.class))
+                .thenThrow(new HttpClientErrorException(HttpStatus.TOO_MANY_REQUESTS));
+
+        assertThatThrownBy(() -> dataciteService.mint(raidRequest, handle, repositoryId, password))
+                .isInstanceOf(HttpClientErrorException.class);
+    }
+
+    @Test
+    @DisplayName("Throws HttpClientErrorException when Datacite update (RaidUpdateRequest) fails")
+    void updateRaidUpdateRequestThrowsOnError() {
+        final var repositoryId = "repository-id";
+        final var password = "_password";
+        final var handle = "10.12345/abcde";
+        final var endpoint = "_endpoint";
+        final var request = new RaidUpdateRequest();
+
+        final var dataciteRequest = new DataciteRequest();
+        final var entity = new HttpEntity<>(dataciteRequest, new HttpHeaders());
+
+        when(dataciteRequestFactory.create(request, handle)).thenReturn(dataciteRequest);
+        when(httpEntityFactory.create(dataciteRequest, repositoryId, password)).thenReturn(entity);
+        when(properties.getEndpoint()).thenReturn(endpoint);
+        when(restTemplate.exchange("%s/%s".formatted(endpoint, handle), HttpMethod.PUT, entity, JsonNode.class))
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> dataciteService.update(request, handle, repositoryId, password))
+                .isInstanceOf(HttpClientErrorException.class);
+    }
+
+    @Test
+    @DisplayName("Throws HttpClientErrorException when Datacite update (RaidDto) fails")
+    void updateRaidDtoThrowsOnError() {
+        final var repositoryId = "repository-id";
+        final var password = "_password";
+        final var handle = "10.12345/abcde";
+        final var endpoint = "_endpoint";
+        final var request = new RaidDto();
+
+        final var dataciteRequest = new DataciteRequest();
+        final var entity = new HttpEntity<>(dataciteRequest, new HttpHeaders());
+
+        when(dataciteRequestFactory.create(request, handle)).thenReturn(dataciteRequest);
+        when(httpEntityFactory.create(dataciteRequest, repositoryId, password)).thenReturn(entity);
+        when(properties.getEndpoint()).thenReturn(endpoint);
+        when(restTemplate.exchange("%s/%s".formatted(endpoint, handle), HttpMethod.PUT, entity, JsonNode.class))
+                .thenThrow(new HttpClientErrorException(HttpStatus.TOO_MANY_REQUESTS));
+
+        assertThatThrownBy(() -> dataciteService.update(request, handle, repositoryId, password))
+                .isInstanceOf(HttpClientErrorException.class);
     }
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: `DataciteService.mint()` was catching `HttpClientErrorException` but only logging it — never re-throwing. This caused DataCite 4xx errors (e.g. rate limiting during bulk creation) to be silently swallowed, allowing RAiDs to be saved locally without being registered with DataCite. This was identified as the root cause of ~180 missing UNDA DOIs in [RAID-554](https://ardc.atlassian.net/browse/RAID-554).
- **Consistency fix**: `update(RaidDto)` had the same swallowing bug. Both methods now log and re-throw, matching the existing `update(RaidUpdateRequest)` behaviour.
- **Side effect**: The retry logic in `RaidService.mintHandle()` (which catches `HttpClientErrorException` for 422 retries) was previously dead code — it now works as intended.

## Changes

- `DataciteService.mint()`: added `throw e;` after log statement
- `DataciteService.update(RaidDto)`: added `throw e;` after log statement
- Added 3 unit tests verifying error propagation for all three methods
- Added `DataciteErrorIntegrationTest` — uses MockServer REST API to inject a 429 error expectation and verifies mint fails with 500

## Test plan

- [x] All existing unit tests pass (`./gradlew :api-svc:raid-api:test`)
- [x] 3 new unit tests verify `HttpClientErrorException` propagates from `mint()`, `update(RaidUpdateRequest)`, and `update(RaidDto)`
- [x] Integration test verifies end-to-end: MockServer returns 429 → mint fails with 500 (no silent local save)
- [x] Full integration test suite passes (148 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)