### PR TITLE
RAID-618: Fix SERVICE_POINT_ID / JSONB metadata divergence

### DIFF
--- a/api-svc/db/src/main/resources/db/migration/V40__sync_service_point_id_from_metadata.sql
+++ b/api-svc/db/src/main/resources/db/migration/V40__sync_service_point_id_from_metadata.sql
@@ -1,0 +1,5 @@
+UPDATE api_svc.raid
+SET service_point_id = (metadata -> 'identifier' -> 'owner' ->> 'servicePoint')::bigint
+WHERE metadata IS NOT NULL
+  AND metadata -> 'identifier' -> 'owner' ->> 'servicePoint' IS NOT NULL
+  AND service_point_id != (metadata -> 'identifier' -> 'owner' ->> 'servicePoint')::bigint;

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/Api.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/Api.java
@@ -1,9 +1,7 @@
 package au.org.raid.api;
 
-import au.org.raid.api.service.RaidMetadataBackfillService;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.servers.Server;
-import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
@@ -42,12 +40,6 @@ public class Api {
 
         restTemplate.setMessageConverters(converters);
         return restTemplate;
-    }
-
-    // TODO: Remove after 2.8.0 release — one-time backfill of metadata column
-    @Bean
-    public ApplicationRunner backfillMetadata(RaidMetadataBackfillService backfillService) {
-        return args -> backfillService.backfill();
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
## Summary
- Removed the `ApplicationRunner` bean from `Api.java` that auto-ran `RaidMetadataBackfillService.backfill()` on startup — it backfilled the JSONB `metadata` column but never synced the `SERVICE_POINT_ID` column, causing the two to diverge
- Added Flyway migration `V40` to reconcile existing divergent records by setting `SERVICE_POINT_ID` from the JSONB `metadata.identifier.owner.servicePoint` source of truth
- The backfill service remains available for manual use via `AdminController`

## Test plan
- [ ] `./gradlew build` passes (verified locally)
- [ ] `./gradlew intTest` — `closedRaidsExcludedFromList` test no longer fails
- [ ] Verify V40 migration runs cleanly against test/staging database

🤖 Generated with [Claude Code](https://claude.com/claude-code)