### PR TITLE
RAID-652: Decouple JOOQ schema for branch deployments

### DIFF
--- a/api-svc/db/build.gradle
+++ b/api-svc/db/build.gradle
@@ -57,6 +57,12 @@ if( file(configPath).exists() ){
 dependencies{
   runtimeOnly libs.postgresql
   jooqGenerator libs.postgresql
+  testImplementation libs.junit.jupiter
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+test {
+  useJUnitPlatform()
 }
 
 compileJava {
@@ -132,6 +138,7 @@ jooq{
           name = 'org.jooq.codegen.DefaultGenerator'
           database {
             name = 'org.jooq.meta.postgres.PostgresDatabase'
+            outputSchemaToDefault = true
             schemata {
               schema {
                 inputSchema = apiSvcPgSchema

--- a/api-svc/db/src/main/generated-jooq/au/org/raid/db/jooq/ApiSvc.java
+++ b/api-svc/db/src/main/generated-jooq/au/org/raid/db/jooq/ApiSvc.java
@@ -89,7 +89,7 @@ public class ApiSvc extends SchemaImpl {
      * No further instances allowed
      */
     private ApiSvc() {
-        super("api_svc", null);
+        super("", null);
     }
 
 

--- a/api-svc/db/src/test/java/au/org/raid/db/jooq/ApiSvcSchemaTest.java
+++ b/api-svc/db/src/test/java/au/org/raid/db/jooq/ApiSvcSchemaTest.java
@@ -1,0 +1,13 @@
+package au.org.raid.db.jooq;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ApiSvcSchemaTest {
+
+    @Test
+    void schemaNameIsDefaultSoJooqUsesConnectionSearchPath() {
+        assertEquals("", ApiSvc.API_SVC.getName());
+    }
+}

--- a/api-svc/raid-api/src/main/resources/application.yaml
+++ b/api-svc/raid-api/src/main/resources/application.yaml
@@ -78,7 +78,7 @@ spring:
       write-dates-as-timestamps: false
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${raid.db.host}:${raid.db.port}/${raid.db.name}
+    url: jdbc:postgresql://${raid.db.host}:${raid.db.port}/${raid.db.name}?currentSchema=${spring.flyway.default-schema}
     username: ${raid.db.user}
     password: ${raid.db.password}
   jooq:


### PR DESCRIPTION
## Summary
- Add `outputSchemaToDefault = true` to JOOQ codegen so generated SQL uses the connection search_path instead of hardcoding `api_svc`
- Append `?currentSchema=${spring.flyway.default-schema}` to the datasource URL, making the active schema configurable per deployment
- Add unit test verifying JOOQ schema name is empty (relies on connection search_path)

## Context
Prerequisite for RAID-647 (branch pipeline). Branch deployments need schema-per-branch isolation — each feature branch gets its own Postgres schema in the shared test RDS instance. This change is backward-compatible: existing deployments use `spring.flyway.default-schema: api_svc` (unchanged default).

## Test plan
- [x] `ApiSvcSchemaTest` verifies JOOQ schema name is empty string
- [x] `./gradlew test` — all unit tests pass (db module + raid-api)
- [ ] CI build passes
- [ ] Verify API starts normally with `./gradlew dockerComposeUp bootRun -Dspring.profiles.active=dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)