### PR TITLE
Defect/r ai d 642 cateogories free text

### DIFF
--- a/iam/themes/ardc-branding/login/login.ftl
+++ b/iam/themes/ardc-branding/login/login.ftl
@@ -127,10 +127,10 @@
 
             <!-- Footer Links -->
             <div class="raid-footer-links">
-                <a href="mailto:contact@raid.org" class="footer-link">contact@raid.org</a>
-                <a href="#" class="footer-link">Terms of use</a>
-                <a href="#" class="footer-link">Accessibility</a>
-                <a href="#" class="footer-link">Privacy policy</a>
+                <a href="mailto:${msg("contact")}" class="footer-link">${msg("contact")}</a>
+                <a href="${msg("termsOfUse")}" class="footer-link">Terms of use</a>
+                <a href="${msg("accessibility")}" class="footer-link">Accessibility</a>
+                <a href="${msg("privacyPolicy")}" class="footer-link">Privacy policy</a>
             </div>
 
             <!-- Acknowledgement of Country -->

--- a/raid-agency-app/src/entities/related-object/bulk-upload/components/Bulkuploadpreviewtable.tsx
+++ b/raid-agency-app/src/entities/related-object/bulk-upload/components/Bulkuploadpreviewtable.tsx
@@ -58,7 +58,7 @@ export function BulkUploadPreviewTable({
     [vocabulary.relatedObjectTypes]
   );
   const categoryOptions = useMemo(
-    () => vocabulary.relatedObjectCategories.map((c) => c.value),
+    () => generateCategorySubsets(vocabulary.relatedObjectCategories.map((c) => c.value)),
     [vocabulary.relatedObjectCategories]
   );
 
@@ -285,35 +285,36 @@ function DebouncedTextCell({
 }
 
 // ------------------------------------------------------------------
-// MultiValueCell — Autocomplete with chips for multi-select with freeSolo
+// MultiValueCell — single-select Autocomplete for category combinations
 // ------------------------------------------------------------------
 
 interface MultiValueCellProps {
-  value: string; // comma-separated string from the underlying state
+  value: string; // the selected combination (e.g. "Input, Output")
   onCommit: (value: string) => void;
   error?: string;
-  options: string[];
+  options: string[]; // all pre-built category combinations
   disabled?: boolean;
   placeholder?: string;
 }
 
 /**
- * Splits a comma-separated string into an array of trimmed values.
- * Handles "Input, Output" and "Input,Output" the same way.
+ * Generates all non-empty subsets of `options` as comma-separated strings,
+ * ordered by size then by original position. Matches the Excel dropdown order.
+ *
+ * For 3 categories [A, B, C] this produces:
+ *   A, B, A+B, C, A+C, B+C, A+B+C
  */
-function stringToArray(value: string): string[] {
-  if (!value) return [];
-  return value
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-}
-
-/**
- * Joins an array back into a comma-separated string for storage.
- */
-function arrayToString(values: string[]): string {
-  return values.join(", ");
+export function generateCategorySubsets(options: string[]): string[] {
+  const subsets: string[] = [];
+  const n = options.length;
+  for (let mask = 1; mask < (1 << n); mask++) {
+    const subset: string[] = [];
+    for (let i = 0; i < n; i++) {
+      if (mask & (1 << i)) subset.push(options[i]);
+    }
+    subsets.push(subset.join(", "));
+  }
+  return subsets;
 }
 
 function MultiValueCell({
@@ -324,8 +325,6 @@ function MultiValueCell({
   disabled,
   placeholder,
 }: MultiValueCellProps) {
-  const arrayValue = stringToArray(value);
-
   return (
     <Tooltip
       title={error ?? ""}
@@ -334,38 +333,18 @@ function MultiValueCell({
       disableHoverListener={!error}
     >
       <Autocomplete
-        multiple
-        freeSolo
         size="small"
         options={options}
-        value={arrayValue}
+        value={value || null}
         disabled={disabled}
         onChange={(_, newValue) => {
-          // newValue is string[] — convert each item to string in case
-          // freeSolo passes a custom typed entry as an object
-          const cleaned = newValue
-            .map((v) => (typeof v === "string" ? v.trim() : String(v).trim()))
-            .filter((v) => v.length > 0);
-          onCommit(arrayToString(cleaned));
+          onCommit(typeof newValue === "string" ? newValue : "");
         }}
-        renderTags={(tagValue, getTagProps) =>
-          tagValue.map((option, index) => {
-            const { key, ...chipProps } = getTagProps({ index });
-            return (
-              <Chip
-                key={key}
-                size="small"
-                label={option}
-                {...chipProps}
-              />
-            );
-          })
-        }
         renderInput={(params) => (
           <TextField
             {...params}
             error={!!error}
-            placeholder={arrayValue.length === 0 ? placeholder : ""}
+            placeholder={placeholder}
             variant="outlined"
             size="small"
           />

--- a/raid-agency-app/src/entities/related-object/bulk-upload/hooks/useBulkUpload.ts
+++ b/raid-agency-app/src/entities/related-object/bulk-upload/hooks/useBulkUpload.ts
@@ -159,6 +159,30 @@ const IMPORT_START_MARKER = "Import table starts here";
 const IMPORT_END_MARKER = "Import table ends here";
 
 /**
+ * Returns a user-facing error message describing which sentinel marker(s)
+ * are absent. Covers three cases: both missing, start only, end only.
+ */
+function missingMarkerError(startFound: boolean, endFound: boolean): string {
+  if (!startFound && !endFound) {
+    return (
+      `This file is missing both required template markers ("${IMPORT_START_MARKER}" and "${IMPORT_END_MARKER}"). ` +
+      `The template structure may have been accidentally modified or the wrong file was uploaded. ` +
+      `Please download a fresh template and enter your data between the two marker rows.`
+    );
+  }
+  if (!startFound) {
+    return (
+      `This file is missing the "${IMPORT_START_MARKER}" marker. ` +
+      `Please download a fresh template and enter your data between the two marker rows.`
+    );
+  }
+  return (
+    `This file is missing the "${IMPORT_END_MARKER}" marker. ` +
+    `Please download a fresh template and enter your data between the two marker rows.`
+  );
+}
+
+/**
  * Marker that Excel produces when it tries to evaluate a cell that
  * starts with '-', '=', '+', or '@' as a formula but can't.
  * If we see this in column A, the user almost certainly opened an
@@ -241,16 +265,14 @@ function parseCsvToRows(csvText: string): Record<string, string>[] {
     }
   }
 
-  // Fallback: no sentinels found, treat the whole file as a flat table
-  let dataLines: string[];
   if (startIdx === -1 || endIdx === -1) {
-    dataLines = allLines.filter((line) => line.trim().length > 0);
-  } else {
-    // Lines strictly between the sentinels, blank lines stripped
-    dataLines = allLines
-      .slice(startIdx + 1, endIdx)
-      .filter((line) => line.trim().length > 0);
+    throw new Error(missingMarkerError(startIdx !== -1, endIdx !== -1));
   }
+
+  // Lines strictly between the sentinels, blank lines stripped
+  const dataLines = allLines
+    .slice(startIdx + 1, endIdx)
+    .filter((line) => line.trim().length > 0);
 
   if (dataLines.length < 2) return [];
 
@@ -632,11 +654,12 @@ export function useBulkUpload(
           }
         });
 
-        // Determine the data region. If sentinels are missing, fall back
-        // to assuming row 1 = headers (legacy behaviour).
-        const headerRowIdx = startRowIdx !== -1 ? startRowIdx + 1 : 1;
-        const lastDataRowIdx =
-          endRowIdx !== -1 ? endRowIdx - 1 : sheet.actualRowCount;
+        if (startRowIdx === -1 || endRowIdx === -1) {
+          throw new Error(missingMarkerError(startRowIdx !== -1, endRowIdx !== -1));
+        }
+
+        const headerRowIdx = startRowIdx + 1;
+        const lastDataRowIdx = endRowIdx - 1;
 
         if (headerRowIdx > lastDataRowIdx) return [];
 

--- a/raid-agency-app/src/entities/related-object/forms/related-objects-form/RelatedObjectsForm.tsx
+++ b/raid-agency-app/src/entities/related-object/forms/related-objects-form/RelatedObjectsForm.tsx
@@ -20,7 +20,7 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { useState, useContext, useLayoutEffect, useRef, useCallback } from "react";
+import { useState, useContext, useLayoutEffect, useRef, useCallback, useMemo } from "react";
 import {
   Control,
   FieldErrors,
@@ -131,9 +131,16 @@ export function RelatedObjectsForm({
   }, [fields]);
 
   const { watch } = useFormContext();
-  const existingIdentifiers: string[] = (watch("relatedObject") ?? [])
+  // Build a primitive key so useMemo only produces a new array when IDs actually
+  // change. Using "\n" as separator — it cannot appear in valid DOI/URL values.
+  const existingIdsKey = (watch("relatedObject") ?? [])
     .map((obj: { id?: string }) => obj.id ?? "")
-    .filter((id: string) => id.length > 0);
+    .filter((id: string) => id.length > 0)
+    .join("\n");
+  const existingIdentifiers: string[] = useMemo(
+    () => (existingIdsKey.length === 0 ? [] : existingIdsKey.split("\n")),
+    [existingIdsKey]
+  );
 
   const handleDuplicateIdentifiers = useCallback((dois: string[]) => {
     const doiSet = new Set(dois.map((d) => d.trim().toLowerCase()));

--- a/raid-agency-app/vite.config.ts
+++ b/raid-agency-app/vite.config.ts
@@ -1,4 +1,5 @@
 import react from "@vitejs/plugin-react";
+import fs from "fs";
 import path from "path";
 import { defineConfig, type Plugin } from "vite";
 
@@ -34,8 +35,18 @@ function muiEsmPlugin(): Plugin {
   };
 }
 
+function excludeAppConfig(): Plugin {
+  return {
+    name: "exclude-app-config",
+    closeBundle() {
+      const file = path.resolve(__dirname, "dist/app-config.json");
+      if (fs.existsSync(file)) fs.unlinkSync(file);
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [muiEsmPlugin(), react()],
+  plugins: [muiEsmPlugin(), react(), excludeAppConfig()],
   base: "/.",
   resolve: {
     alias: {


### PR DESCRIPTION
### Change log

- **Fix: Categories field allowed free-text input** — The bulk upload preview table's Categories `Autocomplete` had `freeSolo` enabled, letting users type and submit arbitrary text that bypassed vocabulary validation. Removed `freeSolo`; users can now only select from the predefined category list.

- **Feat: Category combinations in preview table dropdown** — The Categories dropdown now shows all valid single-value and multi-value combinations (e.g. "Input", "Output", "Input, Output", etc.), matching the Excel template's dropdown list. Combinations are generated dynamically from the vocabulary via `generateCategorySubsets`.

- **Fix: Bulk-uploaded rows were expanding on add** — After a bulk upload, all newly added accordion items were incorrectly auto-expanding. The fix snapshots pre-existing field IDs before each bulk `append` and restricts `handleDuplicateIdentifiers` to only expand items that existed before the upload. Items with real validation errors still expand correctly via `handleBulkComplete`.

- **Fix: Missing template markers now error clearly** — Uploading a file where the sentinel rows (`Import table starts here` / `Import table ends here`) had been deleted previously fell back silently to flat-table parsing. Both the CSV and Excel parsers now throw with a specific message identifying which marker(s) are missing and directing the user to download a fresh template.

- **Fix: Maximum update depth / infinite re-render loop** — `existingIdentifiers` was recomputed as a new array reference on every render (via `.map().filter()`), causing `handleDuplicateIdentifiers` (`useCallback`) to recreate each render, which caused the `useEffect` in `BulkUploadComponent` to fire every render, which called `setState`, which re-rendered — infinitely. Fixed by memoising `existingIdentifiers` against a primitive string key so only actual ID changes produce a new array reference.
