### PR TITLE
Feature/624 documentation

### DIFF
--- a/iam/doc/branding-customisation.md
+++ b/iam/doc/branding-customisation.md
@@ -1,0 +1,98 @@
+# Branding & Customisation Guide
+
+## 1. React App — Custom Branding via `app-config.json`
+
+The React app reads branding at runtime from `app-config.json`. No rebuild is required — update the config file and reload the page.
+
+Add a `branding` key to your `app-config.json` with only the fields you want to override. Anything omitted falls back to the defaults in `src/config/DefaultConfig.ts`.
+
+```json
+{
+  "keycloak": { "..." : "..." },
+  "apiBaseUrl": "https://api.example.org",
+  "branding": {
+    "header": {
+      "title": "My Organisation",
+      "logo": { "src": "/my-logo.svg", "alt": "My Logo" }
+    },
+    "footer": {
+      "copyright": "© 2025 My Organisation"
+    },
+    "theme": {
+      "palette": {
+        "primary": { "main": "#2a2f8f" },
+        "secondary": { "main": "#e65100" }
+      }
+    }
+  }
+}
+```
+
+### Configurable branding fields
+
+See `src/config/Appconfig.ts` for the full type definitions. The main overridable sections are:
+
+| Section | Key fields |
+|---------|-----------|
+| `header` | `title`, `subtitle`, `logo.src`, `logo.alt`, `logo.height`, `navLinks` |
+| `footer` | `copyright`, `links`, `main.logos`, `main.text`, `showSocialLinks`, `socialLinks` |
+| `content.landingPage` | `heroTitle`, `heroSubtitle`, `showHero` |
+| `theme.palette` | `primary`, `secondary`, `background`, `error`, `warning`, `info`, `success`, `text` |
+| `theme.typography` | `fontFamily`, `fontSize` |
+| `theme.shape` | `borderRadius` |
+
+### Deployment
+
+- **AWS S3**: upload the updated `app-config.json` to the S3 bucket and invalidate the CloudFront cache — see [DEPLOYMENT.md](../../raid-agency-app/DEPLOYMENT.md)
+- **Docker / Kubernetes**: replace the mounted config file or update the file at the external URL — see [DEPLOYMENT.md](../../raid-agency-app/DEPLOYMENT.md)
+
+---
+
+## 2. Keycloak — Creating a New Theme
+
+### Copy the existing theme as a starting point
+
+```sh
+cp -r themes/raid-custom themes/my-new-theme
+```
+
+### Update the theme name
+
+Edit `themes/my-new-theme/theme.properties` and update the parent if needed:
+
+```properties
+parent=keycloak
+```
+
+### Customise the theme
+
+| Asset | Location |
+|-------|----------|
+| Styles | `login/resources/css/login.css` |
+| HTML structure | `login/template.ftl` |
+| Login form | `login/login.ftl` |
+| Images / logo | `login/resources/img/` |
+| Text overrides | `login/messages/messages_en.properties` |
+
+### Register the theme in Keycloak
+
+1. Ensure the theme folder is mounted/deployed to Keycloak's `themes/` directory
+2. Log in to the Keycloak admin console
+3. Navigate to **Realm Settings → Themes**
+4. Select your new theme from the **Login Theme** dropdown
+5. Click **Save**
+
+### Docker Compose volume mount
+
+If running Keycloak in Docker, mount the theme directory:
+
+```yaml
+volumes:
+  - ./themes/my-new-theme:/opt/keycloak/themes/my-new-theme
+```
+
+Restart the Keycloak container to pick up the new theme.
+
+### Localization overrides
+
+Per-environment text (titles, badge label, policy links) can be set in the Keycloak admin console without touching the theme files — see [login-page-configuration.md](login-page-configuration.md).

--- a/iam/doc/login-page-configuration.md
+++ b/iam/doc/login-page-configuration.md
@@ -1,0 +1,62 @@
+# Keycloak Login Page Configuration
+
+This guide explains how to configure the RAiD login page via the Keycloak admin console.
+
+## Configuration Steps
+
+### 1. Login to Keycloak and Select Realm
+
+1. Log in to the Keycloak admin console
+2. Select the **raid** realm from the realm dropdown
+
+### 2. Configure Theme
+
+1. Navigate to **Realm Settings → Themes** tab
+2. Select theme: `raid-custom`
+3. Click **Save**
+
+### 3. Add Localization Overrides
+
+1. Click on the **Localization** tab
+2. Add the following key-value pairs under **Realm overrides**:
+
+| Key | Value |
+|-----|-------|
+| `welcomeTitle` | `ARDC Research Activity Identifier (RAiD) Service` |
+| `privacyPolicy` | `<a href="https://ardc.edu.au/privacy-policy/">ARDC privacy policy</a>` |
+| `servicePolicy` | `<a href="https://documentation.ardc.edu.au/raid/raid-service-policy">RAiD Service Policy</a>` |
+| `badge` | `dev` |
+| `welcomeText` | `To learn more, access the <a href="https://documentation.ardc.edu.au/raid/">RAiD documentation</a> <br/> Maintained by the <a href="https://ardc.edu.au/">ARDC</a>` |
+| `signinText` | `Please select your preferred sign-in method` |
+| `signinTitle` | `RAiD Sign-in` |
+| `federatedIdentityConfirmReauthenticateMessage` | `A user with the same details already exists. Authenticate using your original login button. This will link your account with your {0} login.` |
+| `groupSelectorAccessMessage` | `To use RAiD you must belong to a 'Service Point'; please request access to the appropriate Service Point in the list below.` |
+| `contact` | `services@ardc.edu.au` |
+| `termsOfUse` | `https://ardc.edu.au/terms-and-conditions/` |
+| `privacyPolicy` | `https://ardc.edu.au/privacy-policy/` |
+| `accessibility` | `https://ardc.edu.au/accessibility-statement-for-ardc/` |
+
+> The `badge` value should reflect the environment — e.g. `dev`, `test`, `stage`, `prod`.
+
+### 4. Configure Identity Providers
+
+1. Navigate to **Identity Providers**
+2. For each identity provider (Google, AAF, ORCID, etc.):
+   - Click on the provider name to edit
+   - Set **First Login Flow** to `first broker login`
+   - Click **Save**
+
+### 5. Configure Authentication Flow
+
+1. Navigate to the **Authentication** tab
+2. Select the **First Broker Login** flow
+3. Disable the following executions:
+   - Review Profile
+   - Confirm Link Existing Account
+4. Click **Save**
+
+## Notes
+
+- HTML anchor tags in localization values are rendered as clickable links on the login page
+- The `badge` localization key can be updated per environment without redeploying the theme
+- These configurations allow agencies to customize the login page without code changes

--- a/raid-agency-app/.dockerignore
+++ b/raid-agency-app/.dockerignore
@@ -5,3 +5,4 @@ dist
 *.test.*
 playwright-report
 test-results
+config/

--- a/raid-agency-app/DEPLOYMENT.md
+++ b/raid-agency-app/DEPLOYMENT.md
@@ -1,0 +1,322 @@
+# RAiD Agency App — Deployment Guide
+
+The app is configured at runtime via a single `app-config.json` file fetched on every page load. This means environment-specific values (API URLs, Keycloak config, branding) can be updated **without rebuilding or redeploying** the application.
+
+---
+
+## app-config.json Structure
+
+```json
+{
+  "keycloak": {
+    "url": "https://iam.{env}.raid.org.au",
+    "realm": "raid",
+    "clientId": "your-client-id"
+  },
+  "apiBaseUrl": "https://api.{env}.raid.org.au",
+  "environment": "{env}",
+  "supportEmail": "contact@example.org",
+  "googleAnalytics": {
+    "measurementId": "G-XXXXXXXXXX"
+  },
+  "services": {
+    "orcid": "https://orcid.{env}.example.org",
+    "staticProd": "https://static.prod.example.org",
+    "staticBase": "https://static.{env}.example.org"
+  },
+  "branding": {}
+}
+```
+
+**Required fields:** `keycloak`, `apiBaseUrl`, `environment`, `supportEmail`, `services.orcid`, `services.staticProd`, `services.staticBase`
+
+**Optional fields:**
+- `services.invite` — omit if the invite feature is disabled
+- `googleAnalytics` — omit or leave empty if not used
+- `branding` — omit entirely to use built-in defaults, or override individual fields
+
+---
+
+## AWS S3 + CloudFront
+
+This is the current ARDC deployment method. The app is served as a static site from S3 via CloudFront.
+
+### Prerequisites
+
+- AWS CLI installed and configured
+- Access to the target environment's S3 bucket and CloudFront distribution
+- The correct `app-config.{env}.json` file
+
+### Environment → Resource Mapping
+
+| Environment | S3 Bucket | URL |
+|-------------|-----------|-----|
+| test | `test-raid-ui-deployment` | `https://app.test.raid.org.au` |
+| demo | `demo-raid-ui-deployment` | `https://app.demo.raid.org.au` |
+| stage | `stage-raid-ui-deployment` | `https://app.stage.raid.org.au` |
+| prod | `prod-raid-ui-deployment` | `https://app.prod.raid.org.au` |
+
+### Initial Deployment
+
+**1. Build the app**
+```sh
+npm ci
+npm run build
+```
+
+**2. Upload build artifacts to S3**
+```sh
+aws s3 sync dist/ s3://{env}-raid-ui-deployment/ --delete --exclude "app-config.json"
+```
+
+> `app-config.json` is excluded from `dist/` by the build and excluded from the sync — the S3 config is never overwritten by a deployment.
+
+**3. Upload app-config.json (first time only)**
+```sh
+aws s3 cp config/app-config.{env}.json s3://{env}-raid-ui-deployment/app-config.json
+```
+
+**4. Invalidate CloudFront cache**
+```sh
+aws cloudfront create-invalidation \
+  --distribution-id {DISTRIBUTION_ID} \
+  --paths "/*"
+```
+
+**5. Verify**
+```sh
+curl https://app.{env}.raid.org.au/app-config.json
+```
+
+### Updating Config Only (no redeploy)
+
+**1. Edit the config file**
+
+Download, edit, and re-upload via AWS Console, or use CloudShell:
+```sh
+# In AWS CloudShell
+aws s3 cp s3://{env}-raid-ui-deployment/app-config.json app-config.json
+nano app-config.json
+aws s3 cp app-config.json s3://{env}-raid-ui-deployment/app-config.json
+```
+
+**2. Invalidate CloudFront cache**
+```sh
+aws cloudfront create-invalidation \
+  --distribution-id {DISTRIBUTION_ID} \
+  --paths "/app-config.json"
+```
+
+Changes take effect on the next page load.
+
+---
+
+## Docker
+
+For registration agencies deploying the app in a Docker container.
+
+### Prerequisites
+
+- Docker installed
+- `app-config.json` prepared with your environment's values (use `public/app-config.json` as a template)
+
+### Build the Image
+
+```sh
+docker build -t raid-agency-app:latest .
+```
+
+### Option A — Volume Mount (Recommended)
+
+Place your `app-config.json` on the host machine and mount it into the container:
+
+```sh
+docker run -d \
+  -p 80:80 \
+  -v /path/to/your/app-config.json:/usr/share/nginx/html/app-config.json:ro \
+  --name raid-agency-app \
+  raid-agency-app:latest
+```
+
+Or using Docker Compose — uncomment Option A in `docker-compose.yaml`:
+
+```yaml
+services:
+  raid-agency-app:
+    image: raid-agency-app:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./app-config.json:/usr/share/nginx/html/app-config.json:ro
+```
+
+```sh
+docker compose up -d
+```
+
+### Option B — External Config URL
+
+If your config is hosted at an external URL (your own S3, CDN, or any HTTPS endpoint), pass it as an environment variable. Nginx will proxy `/app-config.json` to that URL:
+
+```sh
+docker run -d \
+  -p 80:80 \
+  -e APP_CONFIG_URL=https://your-storage.example.com/app-config.json \
+  --name raid-agency-app \
+  raid-agency-app:latest
+```
+
+Or using Docker Compose — uncomment Option B in `docker-compose.yaml`:
+
+```yaml
+services:
+  raid-agency-app:
+    image: raid-agency-app:latest
+    ports:
+      - "80:80"
+    environment:
+      APP_CONFIG_URL: https://your-storage.example.com/app-config.json
+```
+
+```sh
+docker compose up -d
+```
+
+### Verify
+
+```sh
+curl http://localhost/app-config.json
+```
+
+### Updating Config Only (no redeploy)
+
+**Option A:** Replace the file at the mounted host path — takes effect on next page load, no restart needed.
+
+**Option B:** Update the file at the external URL — takes effect on next page load, no restart needed.
+
+---
+
+## Kubernetes
+
+For registration agencies deploying the app in a Kubernetes cluster.
+
+### Prerequisites
+
+- `kubectl` configured for the target cluster
+- `app-config.json` prepared with your environment's values
+- Docker image pushed to a registry accessible by the cluster
+
+### Option A — ConfigMap (Recommended)
+
+**1. Create the namespace**
+```sh
+kubectl create namespace raid
+```
+
+**2. Create a ConfigMap from your config file**
+```sh
+kubectl create configmap raid-app-config \
+  --from-file=app-config.json=/path/to/your/app-config.json \
+  --namespace raid
+```
+
+**3. Create a deployment manifest (`deployment.yaml`)**
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: raid-agency-app
+  namespace: raid
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: raid-agency-app
+  template:
+    metadata:
+      labels:
+        app: raid-agency-app
+    spec:
+      containers:
+        - name: raid-agency-app
+          image: your-registry/raid-agency-app:latest
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: app-config
+              mountPath: /usr/share/nginx/html/app-config.json
+              subPath: app-config.json
+      volumes:
+        - name: app-config
+          configMap:
+            name: raid-app-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: raid-agency-app
+  namespace: raid
+spec:
+  selector:
+    app: raid-agency-app
+  ports:
+    - port: 80
+      targetPort: 80
+  type: LoadBalancer
+```
+
+**4. Apply the manifest**
+```sh
+kubectl apply -f deployment.yaml
+```
+
+**5. Verify**
+```sh
+kubectl get pods -n raid
+curl http://{EXTERNAL_IP}/app-config.json
+```
+
+### Option B — External Config URL
+
+If your config is hosted at an external HTTPS URL, set `APP_CONFIG_URL` in the deployment:
+
+```yaml
+containers:
+  - name: raid-agency-app
+    image: your-registry/raid-agency-app:latest
+    env:
+      - name: APP_CONFIG_URL
+        value: https://your-storage.example.com/app-config.json
+```
+
+### Updating Config Only (no pod restart required for Option B)
+
+**Option A — Update the ConfigMap**
+```sh
+kubectl create configmap raid-app-config \
+  --from-file=app-config.json=/path/to/your/updated/app-config.json \
+  --namespace raid \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Kubernetes automatically propagates ConfigMap updates to mounted volumes within ~1 minute — no pod restart required. If you need the change to take effect immediately:
+```sh
+kubectl rollout restart deployment/raid-agency-app --namespace raid
+kubectl rollout status deployment/raid-agency-app --namespace raid
+```
+
+**Option B — Update file at external URL**
+
+Update the file at the external URL — takes effect on next page load, no pod restart needed.
+
+---
+
+## Quick Reference
+
+| Deployment | Config location | Update without redeploy? |
+|------------|-----------------|--------------------------|
+| AWS S3 + CloudFront | S3 bucket root | Yes — upload + CloudFront invalidation |
+| Docker volume mount | Host file path | Yes — replace file |
+| Docker external URL | Any HTTPS URL | Yes — update file at URL |
+| Kubernetes ConfigMap | ConfigMap + pod volume | Yes — update ConfigMap (auto-propagates ~1 min) |
+| Kubernetes external URL | Any HTTPS URL | Yes — update file at URL |

--- a/raid-agency-app/Dockerfile
+++ b/raid-agency-app/Dockerfile
@@ -2,14 +2,15 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
-COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+COPY package.json package-lock.json ./
+RUN npm ci
 
 COPY . .
-RUN yarn build
+RUN npm run build
 
 # Stage 2: serve
 FROM nginx:alpine
+RUN apk add --no-cache gettext
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
 COPY nginx/nginx.conf.template /etc/nginx/templates/nginx.conf.template

--- a/raid-agency-app/README.md
+++ b/raid-agency-app/README.md
@@ -79,6 +79,8 @@ npm run build
 
 This will create a production-ready build in the `dist` directory.
 
+For deploying to AWS S3 + CloudFront, Docker, or Kubernetes, see [DEPLOYMENT.md](DEPLOYMENT.md).
+
 ## Testing
 
 Run tests with:

--- a/raid-agency-app/nginx/nginx.conf.template
+++ b/raid-agency-app/nginx/nginx.conf.template
@@ -16,6 +16,7 @@ server {
         add_header Cache-Control "no-store, no-cache, must-revalidate";
         proxy_pass ${APP_CONFIG_URL};
         proxy_set_header Host $proxy_host;
+        proxy_ssl_server_name on;
     }
 
     # Hashed static assets can be cached aggressively

--- a/raid-agency-app/vite.config.ts
+++ b/raid-agency-app/vite.config.ts
@@ -1,5 +1,5 @@
 import react from "@vitejs/plugin-react";
-import fs from "fs";
+import { existsSync, unlinkSync } from "fs";
 import path from "path";
 import { defineConfig, type Plugin } from "vite";
 
@@ -40,7 +40,7 @@ function excludeAppConfig(): Plugin {
     name: "exclude-app-config",
     closeBundle() {
       const file = path.resolve(__dirname, "dist/app-config.json");
-      if (fs.existsSync(file)) fs.unlinkSync(file);
+      if (existsSync(file)) unlinkSync(file);
     },
   };
 }


### PR DESCRIPTION

- Fix Dockerfile: replace yarn with npm ci/run, add gettext for envsubst
- Add proxy_ssl_server_name to nginx.conf.template for HTTPS proxy_pass (SNI)
- Restore excludeAppConfig Vite plugin to prevent app-config.json being bundled into dist/
- Add config/ to .dockerignore to exclude env-specific config files from Docker build
- Add DEPLOYMENT.md covering AWS S3+CloudFront, Docker, and Kubernetes deployment