### PR TITLE
RAID-644: add name and headline to static page JSON-LD

### DIFF
--- a/raid-agency-app-static/src/utils/json-ld.test.ts
+++ b/raid-agency-app-static/src/utils/json-ld.test.ts
@@ -36,6 +36,28 @@ describe("buildResearchProjectJsonLd", () => {
     expect(result["@type"]).toBe("ResearchProject");
   });
 
+  it("sets name and headline from primary title", () => {
+    const raid = minimalRaid();
+    raid.title = [
+      {
+        text: "Researching the lived experience of First Nations Peoples",
+        type: { id: "https://vocabulary.raid.org/title.type.schema/5", schemaUri: "" },
+        startDate: "2025-01-01",
+        language: { id: "eng", schemaUri: "https://www.iso.org/standard/74575.html" },
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.name).toBe("Researching the lived experience of First Nations Peoples");
+    expect(result.headline).toBe("Researching the lived experience of First Nations Peoples");
+  });
+
+  it("defaults name and headline to empty string when no title", () => {
+    const result = buildResearchProjectJsonLd(minimalRaid());
+    expect(result.name).toBe("");
+    expect(result.headline).toBe("");
+  });
+
   it("sets @id and identifier from raid identifier", () => {
     const result = buildResearchProjectJsonLd(minimalRaid());
     expect(result["@id"]).toBe("https://raid.org/10.26259/0d7f1865");
@@ -264,6 +286,8 @@ describe("buildResearchProjectJsonLd", () => {
   it("handles empty/missing optional fields", () => {
     const result = buildResearchProjectJsonLd({});
     expect(result["@id"]).toBe("");
+    expect(result.name).toBe("");
+    expect(result.headline).toBe("");
     expect(result.identifier.value).toBe("");
     expect(result.parentOrganization["@id"]).toBe("");
     expect(result).not.toHaveProperty("description");

--- a/raid-agency-app-static/src/utils/json-ld.ts
+++ b/raid-agency-app-static/src/utils/json-ld.ts
@@ -33,6 +33,8 @@ interface ResearchProjectJsonLd {
   "@context": "https://schema.org";
   "@type": "ResearchProject";
   "@id": string;
+  name: string;
+  headline: string;
   identifier: PropertyValue;
   parentOrganization: {
     "@type": "Organization";
@@ -136,10 +138,14 @@ export function buildResearchProjectJsonLd(raid: Partial<RaidDto>): ResearchProj
     inDefinedTermSet: subject.schemaUri,
   }));
 
+  const name = raid.title?.at(0)?.text ?? "";
+
   return {
     "@context": "https://schema.org",
     "@type": "ResearchProject",
     "@id": raid.identifier?.id ?? "",
+    name,
+    headline: name,
     identifier: {
       "@type": "PropertyValue",
       propertyID: "https://registry.identifiers.org/registry/raid",


### PR DESCRIPTION
## Summary
- Adds `name` and `headline` fields to the JSON-LD structured data on all static RAiD pages
- Maps `raid.title[0].text` (the primary title) into `schema:name` and `schema:headline`
- The RAID-619 refactor into `buildResearchProjectJsonLd()` omitted the `name` field that existed in the original inline template, leaving all 564 production records without a human-readable label in their structured data

## Test plan
- [x] 2 new unit tests: title present maps to `name`/`headline`, title absent defaults to empty string
- [x] Updated empty-fields test to assert `name` and `headline`
- [x] All 15 tests pass
- [x] TypeScript compiles clean
- [ ] After deploy, verify JSON-LD on https://static.prod.raid.org.au/raids/10.26259/0e59e9a5/ contains `name` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)