### PR TITLE
Implemented SEO, added noIndexing to embargoed Raids, improved access…

### DIFF
--- a/raid-agency-app-static/astro.config.mjs
+++ b/raid-agency-app-static/astro.config.mjs
@@ -1,9 +1,17 @@
 // @ts-check
 import { defineConfig } from "astro/config";
+import { readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 
 import tailwindcss from "@tailwindcss/vite";
-
 import sitemap from "@astrojs/sitemap";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const embargoedRaids = JSON.parse(
+  readFileSync(resolve(__dirname, "src/raw-data/embargoed-raids.json"), "utf-8")
+);
+const embargoedHandles = new Set(embargoedRaids.map((r) => r.handle));
 
 // https://astro.build/config
 // todo: replace `prod` with actual value per environment
@@ -11,8 +19,20 @@ export default defineConfig({
   site: `https://static.prod.raid.org.au`,
   integrations: [
     sitemap({
-      filter: (page) =>
-        !page.endsWith(".json/") && !page.endsWith(".download/"),
+      filter: (page) => {
+        if (page.endsWith(".json/") || page.endsWith(".download/")) return false;
+
+        const { pathname } = new URL(page);
+
+        // Exclude the embargoed listing page
+        if (pathname.startsWith("/embargoed")) return false;
+
+        // Exclude individual embargoed RAiD pages
+        const match = pathname.match(/^\/raids\/(.+?)\/?$/);
+        if (match && embargoedHandles.has(match[1])) return false;
+
+        return true;
+      },
     }),
   ],
   vite: {

--- a/raid-agency-app-static/public/site-config.json
+++ b/raid-agency-app-static/public/site-config.json
@@ -19,7 +19,7 @@
         },
         {
           "src": "https://object-store.rc.nectar.org.au/v1/AUTH_9dbba2bab9754d389ec1829fc61b06ae/web-images/ardc-logo.svg",
-          "alt": "",
+          "alt": "Australian Research Data Commons (ARDC)",
           "height": 80,
           "link": "https://www.ardc.edu.au"
         },

--- a/raid-agency-app-static/src/components/navbar.astro
+++ b/raid-agency-app-static/src/components/navbar.astro
@@ -10,7 +10,7 @@ const { topBar } = getSiteConfig().header;
   <div
     class="mx-auto flex w-full max-w-7xl items-center px-4 sm:px-6 lg:px-8 gap-6"
   >
-    <a href="/">
+    <a href="/" aria-label="RAiD home">
       <div class="flex flex-1 items-center gap-x-6">
         <img src=`${topBar.show ? "/RAiD-Strapline.svg" : "/raid-logo-light.svg"}` class="h-8 w-auto" alt="" style={`height: ${topBar.height}`}/>
       </div>

--- a/raid-agency-app-static/src/components/raid-components/embargoed-stub.astro
+++ b/raid-agency-app-static/src/components/raid-components/embargoed-stub.astro
@@ -22,7 +22,7 @@ const { raid } = Astro.props as Props;
           />
           <InfoField
             label="Access Statement"
-            value={raid.accessStatement ?? "No access statement provided."}
+            value={raid.accessStatement ?? "No access statement provided"}
           />
         </div>
       </div>
@@ -40,12 +40,12 @@ const { raid } = Astro.props as Props;
           <div>
             <span class="block font-medium text-gray-900">Identifier</span>
             {raid.registrationAgencyRor ? (
-              <a href={raid.registrationAgencyRor} target="_blank">
-                <img style="display: inline; margin-right: 2px" src="/ror-icon.png" alt="ror-icon" height="24" />
+              <a href={raid.registrationAgencyRor} target="_blank" rel="noopener noreferrer">
+                <img style="display: inline; margin-right: 2px" src="/ror-icon.png" alt="" height="24" />
                 <span style="text-decoration: underline">{raid.registrationAgencyRor}</span>
               </a>
             ) : (
-              <span class="text-gray-500">—</span>
+              <span class="text-gray-600">—</span>
             )}
           </div>
         </div>
@@ -77,12 +77,12 @@ const { raid } = Astro.props as Props;
           <div>
             <span class="block font-medium text-gray-900">Identifier</span>
             {raid.ownerRor ? (
-              <a href={raid.ownerRor} target="_blank">
-                <img style="display: inline; margin-right: 2px" src="/ror-icon.png" alt="ror-icon" height="24" />
+              <a href={raid.ownerRor} target="_blank" rel="noopener noreferrer">
+                <img style="display: inline; margin-right: 2px" src="/ror-icon.png" alt="" height="24" />
                 <span style="text-decoration: underline">{raid.ownerRor}</span>
               </a>
             ) : (
-              <span class="text-gray-500">—</span>
+              <span class="text-gray-600">—</span>
             )}
           </div>
         </div>

--- a/raid-agency-app-static/src/layouts/main.astro
+++ b/raid-agency-app-static/src/layouts/main.astro
@@ -14,9 +14,10 @@ const { topBar } = getSiteConfig().header;
 
 interface Props {
   title: string;
+  noindex?: boolean;
 }
 
-const { title } = Astro.props;
+const { title, noindex = false } = Astro.props;
 // Only show banner in non-production environments
 const raidEnv = import.meta.env.RAID_ENV;
 const isProduction = raidEnv === 'prod';
@@ -32,6 +33,7 @@ const shouldRender = !isProduction;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="sitemap" href="/sitemap-index.xml" />
     <meta name="generator" content={Astro.generator} />
+    {noindex && <meta name="robots" content="noindex, nofollow" />}
     <title>{title}</title>
     <style>
       body {

--- a/raid-agency-app-static/src/pages/embargoed/index.astro
+++ b/raid-agency-app-static/src/pages/embargoed/index.astro
@@ -5,7 +5,7 @@ import Layout from "@/layouts/main.astro";
 import { embargoedRaids } from "@/store/embargoed-raids";
 ---
 
-<Layout title="Embargoed RAiDs">
+<Layout title="Embargoed RAiDs" noindex={true}>
   <div class="overflow-hidden rounded-md bg-white border border-gray-300">
     <Breadcrumbs elements={[{ to: "/embargoed", label: "Embargoed RAiDs" }]} />
     <div class="p-4 sm:p-6 lg:p-8">

--- a/raid-agency-app-static/src/pages/index.astro
+++ b/raid-agency-app-static/src/pages/index.astro
@@ -19,34 +19,32 @@ const totalRaids = raids.length + embargoedRaids.length;
 ---
 
 <Layout title="main">
-  <dl
+  <div
     class="mx-auto grid max-w-7xl grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 lg:px-2 xl:px-0 gap-3"
   >
-    <a href="/prefixes">
-      <div
-        class="bg-white hover:bg-gray-50 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 px-4 py-10 sm:px-6 xl:px-8 rounded-md border border-gray-300"
+    <a
+      href="/prefixes"
+      class="bg-white hover:bg-gray-50 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 px-4 py-10 sm:px-6 xl:px-8 rounded-md border border-gray-300"
+    >
+      <span class="text-sm font-medium leading-6 text-gray-600 block">
+        Total Prefixes
+      </span>
+      <span
+        class="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900"
       >
-        <dt class="text-sm font-medium leading-6 text-gray-500">
-          Total Prefixes
-        </dt>
-        <dd
-          class="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900"
-        >
-          {[...prefixRaidCount.entries()].length}
-        </dd>
-      </div>
+        {[...prefixRaidCount.entries()].length}
+      </span>
     </a>
-    <a href="/raids">
-      <div
-        class="bg-white hover:bg-gray-50 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 px-4 py-10 sm:px-6 xl:px-8 rounded-md border border-gray-300"
+    <a
+      href="/raids"
+      class="bg-white hover:bg-gray-50 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 px-4 py-10 sm:px-6 xl:px-8 rounded-md border border-gray-300"
+    >
+      <span class="text-sm font-medium leading-6 text-gray-600 block">Total RAiDs</span>
+      <span
+        class="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900"
       >
-        <dt class="text-sm font-medium leading-6 text-gray-500">Total RAiDs</dt>
-        <dd
-          class="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900"
-        >
-          {totalRaids}
-        </dd>
-      </div>
+        {totalRaids}
+      </span>
     </a>
-  </dl>
+  </div>
 </Layout>

--- a/raid-agency-app-static/src/pages/raids/[prefix]/[suffix].astro
+++ b/raid-agency-app-static/src/pages/raids/[prefix]/[suffix].astro
@@ -54,7 +54,7 @@ const { raid, isEmbargoed, embargoedRaid } = Astro.props as {
 };
 ---
 
-<Layout title={`RAiD ${prefix}/${suffix}`}>
+<Layout title={isEmbargoed ? `Embargoed RAiD – ${prefix}/${suffix}` : `RAiD ${prefix}/${suffix}`} noindex={isEmbargoed}>
   {!isEmbargoed && raid && (
     <script
       is:inline


### PR DESCRIPTION
Jira: https://ardc.atlassian.net/browse/RAID-614

change log:
Added noindex prop to the shared layout — embargoed RAiD detail pages and the /embargoed listing page now emit <meta name="robots" content="noindex, nofollow"> to prevent search engine indexing
Updated embargoed RAiD page title to Embargoed RAiD – {prefix}/{suffix} (en dash) to satisfy the acceptance criteria title pattern
Excluded embargoed RAiD URLs and /embargoed/* from the generated sitemap by reading the embargoed handles at build time in astro.config.mjs
Fixed WCAG 2.1 AA contrast failure: text-gray-500 (#6B7280, ratio ~4.48:1) bumped to text-gray-600 (#4B5563, ratio ~7.0:1) on the embargoed stub and home page stat cards
Added rel="noopener noreferrer" to external ROR links in the embargoed stub; changed decorative ROR icon alt to alt="" (URL text is the visible label)
Fixed invalid <dl> structure on home page: replaced <dl> + <a> children with a <div> grid of <a> card elements, eliminating the Axe "dl element has direct children that are not allowed" violation
Added aria-label="RAiD home" to the navbar logo link (image-only link had no accessible name)
Fixed empty alt on the ARDC footer logo in site-config.json, resolving the "links must have discernible text" Axe violation