### PR TITLE
Feature/r ai d 615 adding localised date

### DIFF
--- a/raid-agency-app-static/src/components/raid-components/embargoed-stub.astro
+++ b/raid-agency-app-static/src/components/raid-components/embargoed-stub.astro
@@ -7,6 +7,19 @@ interface Props {
 }
 
 const { raid } = Astro.props as Props;
+
+function formatEmbargoExpiry(isoDate: string | null): string {
+  if (!isoDate) return "Not specified";
+  const [year, month, day] = isoDate.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  const human = new Intl.DateTimeFormat("en-AU", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+  return `${human} (ISO 8601: ${isoDate})`;
+}
 ---
 
 <section class="bg-gray-50 py-5">
@@ -18,7 +31,7 @@ const { raid } = Astro.props as Props;
           <InfoField label="Status" value={raid.embargoedStatusLabel} />
           <InfoField
             label="Embargo Expiry"
-            value={raid.embargoExpiry ?? "Not specified"}
+            value={formatEmbargoExpiry(raid.embargoExpiry)}
           />
           <InfoField
             label="Access Statement"

--- a/raid-agency-app-static/src/layouts/main.astro
+++ b/raid-agency-app-static/src/layouts/main.astro
@@ -15,9 +15,10 @@ const { topBar } = getSiteConfig().header;
 interface Props {
   title: string;
   noindex?: boolean;
+  lastModified?: string;
 }
 
-const { title, noindex = false } = Astro.props;
+const { title, noindex = false, lastModified } = Astro.props;
 // Only show banner in non-production environments
 const raidEnv = import.meta.env.RAID_ENV;
 const isProduction = raidEnv === 'prod';
@@ -34,6 +35,7 @@ const shouldRender = !isProduction;
     <link rel="sitemap" href="/sitemap-index.xml" />
     <meta name="generator" content={Astro.generator} />
     {noindex && <meta name="robots" content="noindex, nofollow" />}
+    {lastModified && <meta name="last-modified" content={lastModified} />}
     <title>{title}</title>
     <style>
       body {

--- a/raid-agency-app-static/src/pages/raids/index.astro
+++ b/raid-agency-app-static/src/pages/raids/index.astro
@@ -7,6 +7,7 @@ import { raids } from "@/store/raids";
 import { embargoedRaids } from "@/store/embargoed-raids";
 
 const raidAppUrl = getRaidAppUrl();
+const buildTime = new Date().toISOString();
 
 const raidParts = raids.map((el) => {
   const [_, prefix, suffix] = new URL(el.identifier.id).pathname.split("/");
@@ -41,7 +42,7 @@ const tableRaids = [
   })}
 />
 
-<Layout title="main">
+<Layout title="main" lastModified={buildTime}>
   <div class="overflow-hidden rounded-md bg-white border border-gray-300">
     <Breadcrumbs elements={[{ to: "/raids", label: "RAiDs" }]} />
     <div class="p-4 sm:p-6 lg:p-8">
@@ -61,5 +62,8 @@ const tableRaids = [
       </div>
       <RaidsTable raids={tableRaids} />
     </div>
+    <p class="px-4 pb-4 text-xs text-gray-500 text-right">
+      Page generated: <time datetime={buildTime}>{buildTime}</time>
+    </p>
   </div>
 </Layout>


### PR DESCRIPTION
Jira: 
https://ardc.atlassian.net/browse/RAID-645
https://ardc.atlassian.net/browse/RAID-615

Change log:

- Embargo expiry date on embargoed RAiD stub pages now displays in Australian English alongside the ISO 8601 string — e.g. 12 July 2024 (ISO 8601: 2024-07-12)
- Date is parsed via Date.UTC to prevent timezone-shift bugs, then formatted using Intl.DateTimeFormat with en-AU locale
- Falls back to Not specified when no expiry date is present
- RAiDs list page (/raids) now shows the page generation timestamp at the bottom in ISO 8601 UTC format — e.g. 2026-06-02T04:45:37.917Z
- Generation timestamp is also embedded as <meta name="last-modified" content="..."> in <head> for tooling and crawlers
- Layout updated with an optional lastModified prop to support the meta tag — no impact on pages that don't pass it