### PR TITLE
RAID-461: Throw UserNotFoundException when user is null in addAdminRaid

### DIFF
--- a/iam/src/main/java/au/org/raid/iam/provider/raid/RaidPermissionsController.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/raid/RaidPermissionsController.java
@@ -187,6 +187,10 @@ public class RaidPermissionsController {
         if (client.getRolesStream().anyMatch(role -> role.getName().equals("raid-permissions-admin"))) {
             final var user = session.users().getUserById(session.getContext().getRealm(), request.getUserId());
 
+            if (user == null) {
+                throw new UserNotFoundException(request.getUserId());
+            }
+
             final var adminRaids = user.getAttributeStream(ADMIN_RAIDS_ATTRIBUTE).collect(Collectors.toSet());
 
             adminRaids.add(request.getHandle());

--- a/iam/src/test/java/au/org/raid/iam/provider/raid/RaidPermissionsControllerTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/raid/RaidPermissionsControllerTest.java
@@ -308,4 +308,18 @@ class RaidPermissionsControllerTest {
         var response = controller.addAdminRaid(request);
         assertThat(response.getStatus(), is(401));
     }
+
+    @Test
+    void addAdminRaid_throwsUserNotFoundWhenUserDoesNotExist() {
+        var controller = createAuthenticatedController();
+        setupRaidPermissionsAdminRole();
+        when(session.users()).thenReturn(userProvider);
+        when(userProvider.getUserById(realm, "missing")).thenReturn(null);
+
+        var request = new AdminRaidsRequest();
+        request.setUserId("missing");
+        request.setHandle("test-handle");
+
+        assertThrows(UserNotFoundException.class, () -> controller.addAdminRaid(request));
+    }
 }


### PR DESCRIPTION
## Summary

The Keycloak SPI `addAdminRaid` endpoint (`POST /realms/raid/raid/admin-raids`) dereferences the result of `getUserById` without a null check. When the user no longer exists, this produces an opaque `NullPointerException` 500 (`{"error":"unknown_error"}`), which masked the real cause of a Branch-Build-Deploy integration test failure.

This was observed in the test environment when in-flight mint retries referenced an integration test user that had already been deleted by test teardown.

## Change

- Throw `UserNotFoundException` when `getUserById` returns null, matching the existing behaviour of `addUserToRaid`.
- Unit test mirroring the existing `addRaidUser_throwsUserNotFoundWhenUserDoesNotExist` pattern.

This needs to land on `main` so the shared test Keycloak picks it up; branch deployments (e.g. `feature/RAID-461`) use the shared `iam.test.raid.org.au`.

JIRA: [RAID-461](https://ardc.atlassian.net/browse/RAID-461)

🤖 Generated with [Claude Code](https://claude.com/claude-code)