### PR TITLE
RAID-461: LinkML enum refactoring, conditional validation, and content negotiation

### DIFF
--- a/api-svc/raid-api/src/main/java/au/org/raid/api/controller/RaidController.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/controller/RaidController.java
@@ -174,7 +174,7 @@ public class RaidController implements RaidApi {
         return ResponseEntity.ok(raidService.findAllPublic());
     }
 
-    @GetMapping(value = "/raid/embargoed")
+    @GetMapping(value = "/raid/all-embargoed")
     public ResponseEntity<List<RaidDto>> findAllEmbargoedRaids() {
         return ResponseEntity.ok(raidService.findAllEmbargoed());
     }


### PR DESCRIPTION
## Summary

This is the main integration branch for RAID-461 (LinkML vocabulary enums) and related sub-tasks. Key changes:

- **LinkML enum types** (RAID-461, RAID-586): Replace string `schemaUri` fields with LinkML-generated enums across validators, factories, services, and tests. Adds SPARQL cache fallback (RAID-583) and datamodel module with code generation pipeline.
- **Content negotiation** (RAID-292): Restore RDF content negotiation (JSON-LD, Turtle, RDF/XML, N-Triples) with Schema.org DTOs and `RaidRdfService`.
- **Conditional access.statement validation** (RAID-697): Fix "field must be set" error when changing access type from Embargoed to Open Access. Changed `statement.required` from `true` to `false` in the LinkML data model so JSR 303 no longer rejects null statements before the custom `AccessValidator` applies conditional logic. Added 4 integration tests.
- **React hooks fix** (RAID-697): Move `useMemo` before conditional early returns in `RaidEdit.tsx` to comply with Rules of Hooks — was crashing the edit page.
- **Embargoed endpoint path** (RAID-461): Fix accidental path change from `/raid/all-embargoed` back to match the OpenAPI spec.
- **Jakarta validation response format** (RAID-607): Override `handleMethodArgumentNotValid` to return `ValidationFailureResponse` instead of default `ProblemDetail`.
- **Database migrations**: V41 cascade deletes, demo data cleanup, environment-specific migrations. Dynamic embargo expiry dates in E2E tests.
- **Misc fixes**: Race-safe `OrganisationRepository.findOrCreate`, omit empty identifier from mint payload, fix integration tests for enum changes.

## JIRA tickets

- [RAID-461](https://ardc.atlassian.net/browse/RAID-461) — LinkML vocabulary enums
- [RAID-697](https://ardc.atlassian.net/browse/RAID-697) — Fix access.statement conditional validation
- [RAID-292](https://ardc.atlassian.net/browse/RAID-292) — RDF content negotiation
- [RAID-583](https://ardc.atlassian.net/browse/RAID-583) — SPARQL retry/cache
- [RAID-584](https://ardc.atlassian.net/browse/RAID-584) — Fix integration tests for enum refactoring
- [RAID-586](https://ardc.atlassian.net/browse/RAID-586) — Schema URI enum types in tests/production code
- [RAID-607](https://ardc.atlassian.net/browse/RAID-607) — Jakarta validation response format

## Test plan

- [x] Unit tests pass (`./gradlew test`)
- [x] Integration tests pass (`./gradlew intTest`)
- [x] Frontend build passes (`yarn build`)
- [x] E2E tests pass in CI (GitHub Actions)
- [ ] Verify edit page: change access type from Embargoed → Open Access
- [ ] Verify `/raid/all-embargoed` endpoint returns embargoed raids
- [ ] Verify content negotiation: request RAiD with `Accept: application/ld+json`, `text/turtle`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)