### PR TITLE
RAID-461: Remove broken raid from stage database

### DIFF
--- a/api-svc/db/src/main/resources/db/env/stage/V41.1__remove_broken_raid.sql
+++ b/api-svc/db/src/main/resources/db/env/stage/V41.1__remove_broken_raid.sql
@@ -1,0 +1,40 @@
+-- Remove raid 10.82841/5c9d5cd8 which has NULL start_date, end_date, and
+-- confidential fields, causing HTTP 500 on serialisation.
+
+DO $$
+DECLARE
+    v_handle CONSTANT VARCHAR := '10.82841/5c9d5cd8';
+BEGIN
+    -- Grandchild tables (depend on child table IDs)
+    DELETE FROM raid_contributor_position WHERE raid_contributor_id IN
+        (SELECT id FROM raid_contributor WHERE handle = v_handle);
+    DELETE FROM raid_contributor_role WHERE raid_contributor_id IN
+        (SELECT id FROM raid_contributor WHERE handle = v_handle);
+    DELETE FROM raid_organisation_role WHERE raid_organisation_id IN
+        (SELECT id FROM raid_organisation WHERE handle = v_handle);
+    DELETE FROM raid_related_object_category WHERE raid_related_object_id IN
+        (SELECT id FROM raid_related_object WHERE handle = v_handle);
+    DELETE FROM raid_spatial_coverage_place WHERE raid_spatial_coverage_id IN
+        (SELECT id FROM raid_spatial_coverage WHERE handle = v_handle);
+    DELETE FROM raid_subject_keyword WHERE raid_subject_id IN
+        (SELECT id FROM raid_subject WHERE handle = v_handle);
+
+    -- Child tables (FK on handle)
+    DELETE FROM raid_contributor WHERE handle = v_handle;
+    DELETE FROM raid_organisation WHERE handle = v_handle;
+    DELETE FROM raid_related_object WHERE handle = v_handle;
+    DELETE FROM raid_spatial_coverage WHERE handle = v_handle;
+    DELETE FROM raid_subject WHERE handle = v_handle;
+    DELETE FROM raid_title WHERE handle = v_handle;
+    DELETE FROM raid_description WHERE handle = v_handle;
+    DELETE FROM raid_alternate_identifier WHERE handle = v_handle;
+    DELETE FROM raid_alternate_url WHERE handle = v_handle;
+    DELETE FROM raid_traditional_knowledge_label WHERE handle = v_handle;
+    DELETE FROM related_raid WHERE handle = v_handle;
+
+    -- History
+    DELETE FROM raid_history WHERE handle = v_handle;
+
+    -- Parent
+    DELETE FROM raid WHERE handle = v_handle;
+END $$;


### PR DESCRIPTION
## Summary

- Adds stage-only Flyway migration `V41.1__remove_broken_raid.sql` to delete raid `10.82841/5c9d5cd8` which has NULL `start_date`, `end_date`, and `confidential` fields causing HTTP 500 on serialisation, and `biocultural-labels` in its metadata JSONB that `TraditionalKnowledgeLabelSchemaUriEnum` cannot deserialise

## Test plan

- [x] Verified locally against stage database dump: `/raid/` returns 200 with 42 remaining raids
- [x] Verified all 42 individual raids return 200
- [x] Confirmed `10.82841/5c9d5cd8` was the only raid with `biocultural-labels` in metadata
- [ ] Deploy to stage and verify `/raid/` endpoint returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)