### PR TITLE
Feature/r ai d 674 date picker component

### DIFF
--- a/raid-agency-app/package-lock.json
+++ b/raid-agency-app/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/icons-material": "5.16.7",
         "@mui/material": "5.16.7",
         "@mui/x-data-grid": "6.20.4",
+        "@mui/x-date-pickers": "^6.20.2",
         "@mui/x-tree-view": "^8.21.0",
         "@react-keycloak/web": "^3.4.0",
         "@tanstack/react-query": "5.99.0",
@@ -935,6 +936,38 @@
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
       "license": "MIT"
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
@@ -1053,6 +1086,89 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mui/base": {
+      "version": "5.0.0-dev.20240529-082515-213b5e33ab",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-dev.20240529-082515-213b5e33ab.tgz",
+      "integrity": "sha512-3ic6fc6BHstgM+MGqJEVx3zt9g5THxVXm3VVFUfdeplPqAWWgW2QoKfZDLT10s+pi+MAkpgEBP0kgRidf81Rsw==",
+      "deprecated": "This package has been replaced by @base-ui/react",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.6",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.14-dev.20240529-082515-213b5e33ab",
+        "@mui/utils": "^6.0.0-dev.20240529-082515-213b5e33ab",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/base/node_modules/@mui/types": {
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/base/node_modules/@mui/utils": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
+      "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/types": "~7.2.24",
+        "@types/prop-types": "^15.7.14",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/base/node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.18.0",
@@ -1342,6 +1458,72 @@
         "@mui/system": "^5.4.1",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.20.2.tgz",
+      "integrity": "sha512-x1jLg8R+WhvkmUETRfX2wC+xJreMii78EXKLl6r3G+ggcAZlPyt0myID1Amf6hvJb9CtR7CgUo8BwR+1Vx9Ggw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@mui/base": "^5.0.0-beta.22",
+        "@mui/utils": "^5.14.16",
+        "@types/react-transition-group": "^4.4.8",
+        "clsx": "^2.0.0",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.8.6",
+        "@mui/system": "^5.8.0",
+        "date-fns": "^2.25.0 || ^3.2.0",
+        "date-fns-jalali": "^2.13.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/x-internals": {

--- a/raid-agency-app/package.json
+++ b/raid-agency-app/package.json
@@ -19,6 +19,7 @@
     "@mui/icons-material": "5.16.7",
     "@mui/material": "5.16.7",
     "@mui/x-data-grid": "6.20.4",
+    "@mui/x-date-pickers": "^6.20.2",
     "@mui/x-tree-view": "^8.21.0",
     "@react-keycloak/web": "^3.4.0",
     "@tanstack/react-query": "5.99.0",

--- a/raid-agency-app/src/components/fields/DatePickerField.tsx
+++ b/raid-agency-app/src/components/fields/DatePickerField.tsx
@@ -1,11 +1,23 @@
 import { getErrorMessageForField } from "@/utils/data-utils";
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
-import { Grid, IconButton, InputAdornment, Popover, TextField } from "@mui/material";
+import {
+  Box,
+  Grid,
+  IconButton,
+  InputAdornment,
+  Popover,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
 import { DateCalendar, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs, { Dayjs } from "dayjs";
 import { memo, useState } from "react";
 import { useController } from "react-hook-form";
+
+type DatePrecision = "year" | "month" | "day";
 
 interface DatePickerFieldProps {
   name: string;
@@ -13,7 +25,48 @@ interface DatePickerFieldProps {
   required?: boolean;
   width?: number;
   disabled?: boolean;
+  /** Show the Year / Month / Day precision selector in the picker. Defaults to true. */
+  showPrecisionSelector?: boolean;
 }
+
+// Views shown in the calendar for each precision level
+const PRECISION_VIEWS: Record<
+  DatePrecision,
+  readonly ("year" | "month" | "day")[]
+> = {
+  year: ["year"],
+  month: ["year", "month"],
+  day: ["year", "month", "day"],
+};
+
+// ISO output format for each precision level
+const PRECISION_FORMAT: Record<DatePrecision, string> = {
+  year: "YYYY",
+  month: "YYYY-MM",
+  day: "YYYY-MM-DD",
+};
+
+// Infer precision from an existing field value so the popover opens at the right level
+function derivePrecision(value: unknown): DatePrecision {
+  if (typeof value !== "string") return "day";
+  if (/^\d{4}$/.test(value)) return "year";
+  if (/^\d{4}-\d{2}$/.test(value)) return "month";
+  return "day";
+}
+
+// Shared sx applied to every ToggleButton so the selected state uses the brand colour
+const toggleButtonSx = {
+  flexDirection: "column",
+  py: 0.75,
+  gap: 0.25,
+  "&.Mui-selected": {
+    bgcolor: "primary.main",
+    color: "primary.contrastText",
+    "&:hover": { bgcolor: "primary.dark" },
+    // Keep the format hint readable against the coloured background
+    "& .MuiTypography-root": { opacity: 1 },
+  },
+} as const;
 
 const DatePickerField = memo(function DatePickerField({
   name,
@@ -21,8 +74,10 @@ const DatePickerField = memo(function DatePickerField({
   required = false,
   width = 12,
   disabled,
+  showPrecisionSelector = true,
 }: DatePickerFieldProps) {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const [precision, setPrecision] = useState<DatePrecision>("day");
 
   const {
     field,
@@ -34,15 +89,13 @@ const DatePickerField = memo(function DatePickerField({
   const open = Boolean(anchorEl);
 
   const handleCalendarOpen = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setPrecision(derivePrecision(field.value));
     setAnchorEl(e.currentTarget);
   };
 
-  const handleCalendarClose = () => {
-    setAnchorEl(null);
-  };
+  const handleCalendarClose = () => setAnchorEl(null);
 
-  // Parse the current field value for the calendar display.
-  // Partial dates (YYYY or YYYY-MM) are expanded so dayjs can parse them.
+  // Expand partial dates so dayjs can parse and highlight them in the calendar
   const calendarValue: Dayjs | null = (() => {
     if (!field.value || typeof field.value !== "string") return null;
     const v = field.value.trim();
@@ -95,18 +148,91 @@ const DatePickerField = memo(function DatePickerField({
           anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
           transformOrigin={{ vertical: "top", horizontal: "left" }}
         >
-          <DateCalendar
-            value={calendarValue}
-            onChange={(date: Dayjs | null, selectionState) => {
-              if (date?.isValid()) {
-                field.onChange(date.format("YYYY-MM-DD"));
-              }
-              // Close only once a day has been fully selected (not while navigating year/month views)
-              if (selectionState === "finish") {
-                handleCalendarClose();
-              }
-            }}
-          />
+          <Box sx={{ width: 320 }}>
+            {showPrecisionSelector && (
+              <Box sx={{ px: 1.5, pt: 1.5, pb: 0.5 }}>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block", mb: 0.75, fontWeight: 500 }}
+                >
+                  Select date precision
+                </Typography>
+                <ToggleButtonGroup
+                  value={precision}
+                  exclusive
+                  fullWidth
+                  size="small"
+                  onChange={(_, next: DatePrecision | null) => {
+                    if (next) setPrecision(next);
+                  }}
+                  sx={{
+                    boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+                    borderRadius: 1,
+                  }}
+                >
+                  <ToggleButton value="year" sx={toggleButtonSx}>
+                    <Typography
+                      variant="caption"
+                      fontWeight={600}
+                      lineHeight={1}
+                    >
+                      Year
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{ fontSize: "0.62rem", opacity: 0.55, lineHeight: 1 }}
+                    >
+                      YYYY
+                    </Typography>
+                  </ToggleButton>
+                  <ToggleButton value="month" sx={toggleButtonSx}>
+                    <Typography
+                      variant="caption"
+                      fontWeight={600}
+                      lineHeight={1}
+                    >
+                      Month
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{ fontSize: "0.62rem", opacity: 0.55, lineHeight: 1 }}
+                    >
+                      YYYY-MM
+                    </Typography>
+                  </ToggleButton>
+                  <ToggleButton value="day" sx={toggleButtonSx}>
+                    <Typography
+                      variant="caption"
+                      fontWeight={600}
+                      lineHeight={1}
+                    >
+                      Day
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{ fontSize: "0.62rem", opacity: 0.55, lineHeight: 1 }}
+                    >
+                      YYYY-MM-DD
+                    </Typography>
+                  </ToggleButton>
+                </ToggleButtonGroup>
+              </Box>
+            )}
+            {/* key forces calendar to reinitialise when precision changes, resetting the active view */}
+            <DateCalendar
+              key={precision}
+              value={calendarValue}
+              views={PRECISION_VIEWS[precision]}
+              openTo={precision}
+              onChange={(date: Dayjs | null, selectionState) => {
+                if (date?.isValid() && selectionState === "finish") {
+                  field.onChange(date.format(PRECISION_FORMAT[precision]));
+                  handleCalendarClose();
+                }
+              }}
+            />
+          </Box>
         </Popover>
       </LocalizationProvider>
     </Grid>

--- a/raid-agency-app/src/components/fields/DatePickerField.tsx
+++ b/raid-agency-app/src/components/fields/DatePickerField.tsx
@@ -1,0 +1,117 @@
+import { getErrorMessageForField } from "@/utils/data-utils";
+import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
+import { Grid, IconButton, InputAdornment, Popover, TextField } from "@mui/material";
+import { DateCalendar, LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import dayjs, { Dayjs } from "dayjs";
+import { memo, useState } from "react";
+import { useController } from "react-hook-form";
+
+interface DatePickerFieldProps {
+  name: string;
+  label: string;
+  required?: boolean;
+  width?: number;
+  disabled?: boolean;
+}
+
+const DatePickerField = memo(function DatePickerField({
+  name,
+  label,
+  required = false,
+  width = 12,
+  disabled,
+}: DatePickerFieldProps) {
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  const {
+    field,
+    formState: { errors },
+  } = useController({ name });
+
+  const errorMessage = getErrorMessageForField(errors, field.name);
+  const hasError = Boolean(errorMessage);
+  const open = Boolean(anchorEl);
+
+  const handleCalendarOpen = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(e.currentTarget);
+  };
+
+  const handleCalendarClose = () => {
+    setAnchorEl(null);
+  };
+
+  // Parse the current field value for the calendar display.
+  // Partial dates (YYYY or YYYY-MM) are expanded so dayjs can parse them.
+  const calendarValue: Dayjs | null = (() => {
+    if (!field.value || typeof field.value !== "string") return null;
+    const v = field.value.trim();
+    if (/^\d{4}$/.test(v)) return dayjs(`${v}-01-01`);
+    if (/^\d{4}-\d{2}$/.test(v)) return dayjs(`${v}-01`);
+    const parsed = dayjs(v);
+    return parsed.isValid() ? parsed : null;
+  })();
+
+  return (
+    <Grid item xs={width}>
+      <LocalizationProvider
+        dateAdapter={AdapterDayjs}
+        adapterLocale={navigator.language}
+      >
+        <TextField
+          {...field}
+          id={field.name}
+          size="small"
+          error={hasError}
+          fullWidth
+          helperText={
+            errorMessage ? errorMessage.message : "YYYY, YYYY-MM, or YYYY-MM-DD"
+          }
+          label={label}
+          placeholder="YYYY-MM-DD"
+          required={Boolean(required)}
+          variant="filled"
+          disabled={disabled}
+          sx={{ boxShadow: 0 }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  onClick={handleCalendarOpen}
+                  disabled={disabled}
+                  size="small"
+                  aria-label="open date picker"
+                >
+                  <CalendarTodayIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+        <Popover
+          open={open}
+          anchorEl={anchorEl}
+          onClose={handleCalendarClose}
+          anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+          transformOrigin={{ vertical: "top", horizontal: "left" }}
+        >
+          <DateCalendar
+            value={calendarValue}
+            onChange={(date: Dayjs | null, selectionState) => {
+              if (date?.isValid()) {
+                field.onChange(date.format("YYYY-MM-DD"));
+              }
+              // Close only once a day has been fully selected (not while navigating year/month views)
+              if (selectionState === "finish") {
+                handleCalendarClose();
+              }
+            }}
+          />
+        </Popover>
+      </LocalizationProvider>
+    </Grid>
+  );
+});
+
+DatePickerField.displayName = "DatePickerField";
+export { DatePickerField };

--- a/raid-agency-app/src/entities/access/forms/access-form/AccessForm.tsx
+++ b/raid-agency-app/src/entities/access/forms/access-form/AccessForm.tsx
@@ -1,3 +1,4 @@
+import { DatePickerField } from "@/components/fields/DatePickerField";
 import LanguageSelector from "@/components/fields/LanguageSelector";
 import { TextInputField } from "@/components/fields/TextInputField";
 import { TextSelectField } from "@/components/fields/TextSelectField";
@@ -111,10 +112,9 @@ const AccessForm = memo(
                   width={6}
                 />
 
-                <TextInputField
+                <DatePickerField
                   name={`access.embargoExpiry`}
                   label="Embargo Expiry Date"
-                  placeholder="Embargo Expiry Date"
                   required={true}
                   width={6}
                 />

--- a/raid-agency-app/src/entities/contributor-position/data-generator/contributor-position-data-generator.ts
+++ b/raid-agency-app/src/entities/contributor-position/data-generator/contributor-position-data-generator.ts
@@ -5,12 +5,13 @@ import dayjs from "dayjs";
 import { ContributorPosition } from "@/generated/raid";
 
 export const contributorPositionDataGenerator = (
-  startDate?: string
+  startDate?: string,
+  endDate?: string
 ): ContributorPosition => {
   return {
     schemaUri: contributorPositionSchema[0].uri,
     id: contributorPosition[0].uri,
     startDate: startDate ?? dayjs().format("YYYY-MM-DD"),
-    endDate: "",
+    endDate: endDate ?? "",
   };
 };

--- a/raid-agency-app/src/entities/contributor-position/data-generator/contributor-position-data-generator.ts
+++ b/raid-agency-app/src/entities/contributor-position/data-generator/contributor-position-data-generator.ts
@@ -4,11 +4,13 @@ import dayjs from "dayjs";
 
 import { ContributorPosition } from "@/generated/raid";
 
-export const contributorPositionDataGenerator = (): ContributorPosition => {
+export const contributorPositionDataGenerator = (
+  startDate?: string
+): ContributorPosition => {
   return {
     schemaUri: contributorPositionSchema[0].uri,
     id: contributorPosition[0].uri,
-    startDate: dayjs().format("YYYY-MM-DD"),
+    startDate: startDate ?? dayjs().format("YYYY-MM-DD"),
     endDate: "",
   };
 };

--- a/raid-agency-app/src/entities/contributor-position/forms/contributor-position-details-form/ContributorPositionDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor-position/forms/contributor-position-details-form/ContributorPositionDetailsForm.tsx
@@ -1,4 +1,4 @@
-import { TextInputField } from "@/components/fields/TextInputField";
+import { DatePickerField } from "@/components/fields/DatePickerField";
 import { TextSelectField } from "@/components/fields/TextSelectField";
 import generalMapping from "@/mapping/data/general-mapping.json";
 import { IndeterminateCheckBox } from "@mui/icons-material";
@@ -32,17 +32,15 @@ function FieldGrid({
         required={true}
         width={6}
       />
-      <TextInputField
+      <DatePickerField
         name={`contributor.${parentIndex}.position.${index}.startDate`}
         label="Start Date"
-        placeholder="Start Date"
         required={true}
         width={3}
       />
-      <TextInputField
+      <DatePickerField
         name={`contributor.${parentIndex}.position.${index}.endDate`}
         label="End Date"
-        placeholder="End Date"
         width={3}
       />
     </Grid>

--- a/raid-agency-app/src/entities/contributor-position/forms/contributor-positions-form/ContributorPositionsForm.tsx
+++ b/raid-agency-app/src/entities/contributor-position/forms/contributor-positions-form/ContributorPositionsForm.tsx
@@ -47,11 +47,17 @@ export function ContributorPositionsForm({
     name: `${parentKey}.${parentIndex}.${key}`,
   });
 
+  const { formState, watch, getValues } = useFormContext<RaidDto>();
+
   const handleAddItem = () => {
-    append(generator());
+    append(
+      generator(
+        getValues("date.startDate") || undefined,
+        getValues("date.endDate") || undefined
+      )
+    );
     trigger(`${parentKey}.${parentIndex}.${key}`);
   };
-  const { formState, watch } = useFormContext<RaidDto>();
   const positions = watch([`${parentKey}.${parentIndex}.${key}`]) as ContributorPosition[][];
   const isDirty = formState.isDirty;
 

--- a/raid-agency-app/src/entities/contributor/data-generator/contributor-data-generator.ts
+++ b/raid-agency-app/src/entities/contributor/data-generator/contributor-data-generator.ts
@@ -9,13 +9,14 @@ type ContributorExtended = Contributor &
   );
 
 export const contributorDataGenerator = (
-  startDate?: string
+  startDate?: string,
+  endDate?: string
 ): ContributorExtended => {
   const baseData: Omit<Contributor, "id" | "uuid"> = {
     leader: true,
     contact: true,
     schemaUri: "https://orcid.org/",
-    position: [contributorPositionDataGenerator(startDate)],
+    position: [contributorPositionDataGenerator(startDate, endDate)],
     role: [contributorRoleDataGenerator(), contributorRoleDataGenerator()],
   };
 

--- a/raid-agency-app/src/entities/contributor/data-generator/contributor-data-generator.ts
+++ b/raid-agency-app/src/entities/contributor/data-generator/contributor-data-generator.ts
@@ -8,12 +8,14 @@ type ContributorExtended = Contributor &
     | { id: string; uuid?: never }
   );
 
-export const contributorDataGenerator = (): ContributorExtended => {
+export const contributorDataGenerator = (
+  startDate?: string
+): ContributorExtended => {
   const baseData: Omit<Contributor, "id" | "uuid"> = {
     leader: true,
     contact: true,
     schemaUri: "https://orcid.org/",
-    position: [contributorPositionDataGenerator()],
+    position: [contributorPositionDataGenerator(startDate)],
     role: [contributorRoleDataGenerator(), contributorRoleDataGenerator()],
   };
 

--- a/raid-agency-app/src/entities/contributor/forms/contributors-form/ContributorsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributors-form/ContributorsForm.tsx
@@ -50,7 +50,12 @@ export function ContributorsForm({
   const errorMessage = errors[key]?.message;
 
   const handleAddItem = () => {
-    append(generator(getValues("date.startDate") || undefined));
+    append(
+      generator(
+        getValues("date.startDate") || undefined,
+        getValues("date.endDate") || undefined
+      )
+    );
     trigger(key);
   };
 

--- a/raid-agency-app/src/entities/contributor/forms/contributors-form/ContributorsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributors-form/ContributorsForm.tsx
@@ -17,6 +17,7 @@ import {
   FieldErrors,
   UseFormTrigger,
   useFieldArray,
+  useFormContext,
 } from "react-hook-form";
 
 import { ContributorPositionsForm } from "@/entities/contributor-position/forms/contributor-positions-form";
@@ -45,10 +46,11 @@ export function ContributorsForm({
 
   const [isRowHighlighted, setIsRowHighlighted] = useState(false);
   const { fields, append, remove } = useFieldArray({ control, name: key });
+  const { getValues } = useFormContext();
   const errorMessage = errors[key]?.message;
 
   const handleAddItem = () => {
-    append(generator());
+    append(generator(getValues("date.startDate") || undefined));
     trigger(key);
   };
 

--- a/raid-agency-app/src/entities/date/forms/date-form/DateForm.tsx
+++ b/raid-agency-app/src/entities/date/forms/date-form/DateForm.tsx
@@ -1,4 +1,4 @@
-import { TextInputField } from "@/components/fields/TextInputField";
+import { DatePickerField } from "@/components/fields/DatePickerField";
 import { RaidDto } from "@/generated/raid";
 import { Card, CardContent, CardHeader, Grid, Stack } from "@mui/material";
 import { memo, useContext } from "react";
@@ -41,13 +41,13 @@ const DateForm = memo(
         </Stack>
         <CardContent>
           <Grid container spacing={2}>
-            <TextInputField
+            <DatePickerField
               name="date.startDate"
               label="Start Date"
               required={true}
               width={3}
             />
-            <TextInputField
+            <DatePickerField
               name="date.endDate"
               label="End Date"
               required={false}

--- a/raid-agency-app/src/entities/organisation-role/data-generator/organisation-role-data-generator.ts
+++ b/raid-agency-app/src/entities/organisation-role/data-generator/organisation-role-data-generator.ts
@@ -3,11 +3,14 @@ import organisationRole from "@/references/organisation_role.json";
 import organisationRoleSchema from "@/references/organisation_role_schema.json";
 import dayjs from "dayjs";
 
-export const organisationRoleDataGenerator = (): OrganisationRole => {
+export const organisationRoleDataGenerator = (
+  startDate?: string,
+  endDate?: string
+): OrganisationRole => {
   return {
     id: organisationRole[0].uri,
     schemaUri: organisationRoleSchema[0].uri,
-    startDate: dayjs().format("YYYY-MM-DD"),
-    endDate: "",
+    startDate: startDate ?? dayjs().format("YYYY-MM-DD"),
+    endDate: endDate ?? "",
   };
 };

--- a/raid-agency-app/src/entities/organisation-role/forms/organisation-role-details-form/OrganisationRoleDetailsForm.tsx
+++ b/raid-agency-app/src/entities/organisation-role/forms/organisation-role-details-form/OrganisationRoleDetailsForm.tsx
@@ -1,4 +1,4 @@
-import { TextInputField } from "@/components/fields/TextInputField";
+import { DatePickerField } from "@/components/fields/DatePickerField";
 import { TextSelectField } from "@/components/fields/TextSelectField";
 import generalMapping from "@/mapping/data/general-mapping.json";
 import { IndeterminateCheckBox } from "@mui/icons-material";
@@ -36,18 +36,15 @@ function FieldGrid({
         required={true}
         width={6}
       />
-      <TextInputField
+      <DatePickerField
         name={`organisation.${parentIndex}.role.${index}.startDate`}
         label="Start Date"
-        placeholder="Start Date"
         required={true}
         width={3}
       />
-      <TextInputField
+      <DatePickerField
         name={`organisation.${parentIndex}.role.${index}.endDate`}
         label="End Date"
-        placeholder="End Date"
-        required={false}
         width={3}
       />
     </Grid>

--- a/raid-agency-app/src/entities/organisation-role/forms/organisation-roles-form/OrganisationRolesForm.tsx
+++ b/raid-agency-app/src/entities/organisation-role/forms/organisation-roles-form/OrganisationRolesForm.tsx
@@ -47,12 +47,17 @@ export function OrganisationRolesForm({
     name: `${parentKey}.${parentIndex}.${key}`,
   });
 
+  const { formState, watch, getValues } = useFormContext<RaidDto>();
+
   const handleAddItem = () => {
-    append(generator());
+    append(
+      generator(
+        getValues("date.startDate") || undefined,
+        getValues("date.endDate") || undefined
+      )
+    );
     trigger(`${parentKey}.${parentIndex}.${key}`);
   };
-
-  const { formState, watch } = useFormContext<RaidDto>();
   const orgRole = watch([`${parentKey}.${parentIndex}.${key}`]) as OrganisationRole[][]; // Adjust type to OrganisationRole[]
   const isDirty = formState.isDirty;
 

--- a/raid-agency-app/src/entities/title/data-generator/title-data-generator.ts
+++ b/raid-agency-app/src/entities/title/data-generator/title-data-generator.ts
@@ -28,10 +28,14 @@ export const dateGenerator = (fields: [Title]): string => {
   return dayjs(lastEndDate || new Date()).format("YYYY-MM-DD");
 }
 
-export const titleDataGenerator = (fields: [Title]): Title => ({
+export const titleDataGenerator = (
+  fields: [Title],
+  startDate?: string,
+  endDate?: string
+): Title => ({
   text: "",
   type: titleTypeGenerator(),
   language: undefined,
-  startDate: dateGenerator(fields),
-  endDate: dayjs(new Date()).add(1, "year").format("YYYY-MM-DD"),
+  startDate: startDate ?? dateGenerator(fields),
+  endDate: endDate ?? dayjs(new Date()).add(1, "year").format("YYYY-MM-DD"),
 });

--- a/raid-agency-app/src/entities/title/forms/title-details-form/TitleDetailsForm.tsx
+++ b/raid-agency-app/src/entities/title/forms/title-details-form/TitleDetailsForm.tsx
@@ -1,3 +1,4 @@
+import { DatePickerField } from "@/components/fields/DatePickerField";
 import LanguageSelector from "@/components/fields/LanguageSelector";
 import { TextInputField } from "@/components/fields/TextInputField";
 import { TextSelectField } from "@/components/fields/TextSelectField";
@@ -62,18 +63,16 @@ function FieldGrid({
 
       <LanguageSelector name={`title.${index}.language.id`} width={3} />
 
-      <TextInputField
+      <DatePickerField
         name={`title.${index}.startDate`}
         label="Start Date"
-        placeholder="Start Date"
         required
         width={3}
       />
 
-      <TextInputField
+      <DatePickerField
         name={`title.${index}.endDate`}
         label="End Date"
-        placeholder="End Date"
         width={3}
       />
     </Grid>

--- a/raid-agency-app/src/entities/title/forms/titles-form/TitlesForm.tsx
+++ b/raid-agency-app/src/entities/title/forms/titles-form/TitlesForm.tsx
@@ -18,6 +18,7 @@ import {
   FieldErrors,
   UseFormTrigger,
   useFieldArray,
+  useFormContext,
 } from "react-hook-form";
 import { Title} from "@/generated/raid";
 import { MetadataContext } from "@/components/raid-form/RaidForm";
@@ -40,9 +41,17 @@ export function TitlesForm({
 
   const [isRowHighlighted, setIsRowHighlighted] = useState(false);
   const { fields, append, remove } = useFieldArray({ control, name: key });
+  const { getValues } = useFormContext();
   const errorMessage = errors[key]?.message;
+
   const handleAddItem = () => {
-    append(generator(fields as unknown as [Title]));
+    append(
+      generator(
+        fields as unknown as [Title],
+        getValues("date.startDate") || undefined,
+        getValues("date.endDate") || undefined
+      )
+    );
     trigger(key);
   };
   const metadata = useContext(MetadataContext);


### PR DESCRIPTION
Jira: https://ardc.atlassian.net/browse/RAID-674

**Change Log:** 
New component
DatePickerField (src/components/fields/DatePickerField.tsx)

- A custom MUI date picker field built on @mui/x-date-pickers (v6) with dayjs adapter. Replaces plain text inputs for all date fields across the RAiD form.

Features:

- Filled-variant text input matching the existing form style, with a calendar icon that opens a date picker popover
- Manual entry supported — accepts YYYY, YYYY-MM, or YYYY-MM-DD; validation delegates to the existing Zod combinedPattern
- Precision selector — Year / Month / Day toggle at the top of the popover, labelled with the corresponding ISO format (YYYY / YYYY-MM / YYYY-MM-DD), so users can pick the level of date detail they need via the calendar
- Selected precision button highlighted with the application primary brand colour (#8E489B)
- Locale-aware calendar using navigator.language
- showPrecisionSelector prop (default true) to hide the toggle on forms that only need full dates
- React Hook Form integration via useController, consistent with all other field components