### PR TITLE
RAID-705: fix V41 migration for branch deployments

### DIFF
--- a/api-svc/db/src/main/resources/db/migration/V41__add_missing_cascade_deletes.sql
+++ b/api-svc/db/src/main/resources/db/migration/V41__add_missing_cascade_deletes.sql
@@ -1,34 +1,34 @@
 -- Add ON DELETE CASCADE to foreign keys that are missing it.
 
 -- raid_title: has FK to raid(handle) but without cascade
-alter table api_svc.raid_title
+alter table raid_title
     drop constraint raid_title_handle_fkey,
     add constraint raid_title_handle_fkey
-        foreign key (handle) references api_svc.raid (handle) on delete cascade;
+        foreign key (handle) references raid (handle) on delete cascade;
 
 -- raid_organisation: has no FK to raid(handle) at all
-alter table api_svc.raid_organisation
+alter table raid_organisation
     add constraint raid_organisation_handle_fkey
-        foreign key (handle) references api_svc.raid (handle) on delete cascade;
+        foreign key (handle) references raid (handle) on delete cascade;
 
 -- raid_subject_keyword: has FK to raid_subject(id) but without cascade
-alter table api_svc.raid_subject_keyword
+alter table raid_subject_keyword
     drop constraint raid_subject_keyword_raid_subject_id_fkey,
     add constraint raid_subject_keyword_raid_subject_id_fkey
-        foreign key (raid_subject_id) references api_svc.raid_subject (id) on delete cascade;
+        foreign key (raid_subject_id) references raid_subject (id) on delete cascade;
 
 -- Archive and remove all raids with handles beginning with '102.100' or '10378'.
 -- These are legacy handles from the old registration agency.
 
 -- Create archive tables (same structure as originals, without foreign keys)
-create table api_svc.raid_archive (
+create table raid_archive (
     handle              varchar(128) primary key not null,
     service_point_id    bigint not null,
     url                 varchar(512),
     url_index           integer,
     primary_title       varchar(256),
     confidential        boolean,
-    metadata_schema     api_svc.metaschema not null,
+    metadata_schema     metaschema not null,
     metadata            jsonb,
     start_date          date,
     date_created        timestamp without time zone not null,
@@ -45,7 +45,7 @@ create table api_svc.raid_archive (
     owner_organisation_id int
 );
 
-create table api_svc.raid_history_archive (
+create table raid_history_archive (
     handle      varchar(255) not null,
     revision    int not null,
     change_type varchar(8) not null,
@@ -55,18 +55,18 @@ create table api_svc.raid_history_archive (
 );
 
 -- Archive matching raids
-insert into api_svc.raid_archive
-select * from api_svc.raid
+insert into raid_archive
+select * from raid
 where handle like '102.100%' or handle like '10378%';
 
-insert into api_svc.raid_history_archive
-select * from api_svc.raid_history
+insert into raid_history_archive
+select * from raid_history
 where handle like '102.100%' or handle like '10378%';
 
 -- Delete raid_history (no FK to raid)
-delete from api_svc.raid_history
+delete from raid_history
 where handle like '102.100%' or handle like '10378%';
 
 -- Delete raids (cascades to all related tables)
-delete from api_svc.raid
+delete from raid
 where handle like '102.100%' or handle like '10378%';

--- a/api-svc/db/src/test/java/au/org/raid/db/migration/MigrationSchemaReferenceTest.java
+++ b/api-svc/db/src/test/java/au/org/raid/db/migration/MigrationSchemaReferenceTest.java
@@ -1,0 +1,57 @@
+package au.org.raid.db.migration;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MigrationSchemaReferenceTest {
+
+    private static final Pattern API_SVC_REFERENCE = Pattern.compile("\\bapi_svc\\.");
+
+    @Test
+    void noMigrationContainsHardcodedApiSvcSchemaReference() throws Exception {
+        var migrationDir = Paths.get(
+                getClass().getClassLoader().getResource("db/migration").toURI());
+
+        List<String> violations = new ArrayList<>();
+
+        try (Stream<Path> files = Files.list(migrationDir)) {
+            files
+                    .filter(p -> p.toString().endsWith(".sql"))
+                    .sorted()
+                    .forEach(path -> {
+                        try {
+                            var lines = Files.readAllLines(path);
+                            for (int i = 0; i < lines.size(); i++) {
+                                String line = lines.get(i);
+                                if (line.trim().startsWith("--")) {
+                                    continue;
+                                }
+                                Matcher matcher = API_SVC_REFERENCE.matcher(line);
+                                if (matcher.find()) {
+                                    violations.add("%s:%d: %s".formatted(
+                                            path.getFileName(), i + 1, line.trim()));
+                                }
+                            }
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        }
+
+        assertTrue(violations.isEmpty(),
+                "Migrations must not hardcode the api_svc schema — use unqualified names so "
+                        + "Flyway routes to the correct schema for branch deployments.\n\n"
+                        + "Violations:\n" + String.join("\n", violations));
+    }
+}


### PR DESCRIPTION
## Summary

- Removes hardcoded `api_svc.` schema prefixes from `V41__add_missing_cascade_deletes.sql`
- V41 was the only migration missed by RAID-661 (PR #468), which made V6-V40 schema-agnostic
- This caused all branch deployments to fail because V41 targeted the main `api_svc` schema instead of the branch schema
- Adds `MigrationSchemaReferenceTest` to prevent future regressions by scanning all migrations for `api_svc.` references

## Post-merge action required

V41's checksum will change. Environments where V41 has already run (test, demo, stage, prod) will need `flyway repair` to update the recorded checksum. Use the Repair-Database CodeBuild project or run `flyway repair` manually.

## Test plan

- [x] `MigrationSchemaReferenceTest` passes (confirms no `api_svc.` references remain)
- [ ] Verify branch deployment pipeline succeeds after merge
- [ ] Run `flyway repair` in test/demo after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)