### PR TITLE
RAID-704: allow line breaks in Description text field

### DIFF
--- a/api-svc/datamodel/generated/v2/raid-jsonschema.json
+++ b/api-svc/datamodel/generated/v2/raid-jsonschema.json
@@ -356,7 +356,7 @@
         },
         "text": {
           "description": "the text of an access statement that explains any restrictions on access",
-          "pattern": "^\\s*\\S.*$",
+          "pattern": "^\\s*\\S[\\s\\S]*$",
           "type": "string"
         },
         "type": {

--- a/api-svc/datamodel/generated/v2/raid-strict-jsonschema.json
+++ b/api-svc/datamodel/generated/v2/raid-strict-jsonschema.json
@@ -396,7 +396,7 @@
         },
         "text": {
           "description": "the text of an access statement that explains any restrictions on access",
-          "pattern": "^\\s*\\S.*$",
+          "pattern": "^\\s*\\S[\\s\\S]*$",
           "type": "string"
         },
         "type": {

--- a/api-svc/datamodel/src/v2/raid-core.yaml
+++ b/api-svc/datamodel/src/v2/raid-core.yaml
@@ -311,7 +311,7 @@ classes:
         description: the text of an access statement that explains any restrictions on access
         range: string
         required: true
-        pattern: "^\\s*\\S.*$"
+        pattern: "^\\s*\\S[\\s\\S]*$"
         exact_mappings:
           - dct:description
           - schema:description

--- a/api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml
+++ b/api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml
@@ -943,7 +943,7 @@ components:
         text:
           description: "the text of an access statement that explains any restrictions\
             \ on access"
-          pattern: "^\\s*\\S.*$"
+          pattern: "^\\s*\\S[\\s\\S]*$"
           type: "string"
         type:
           $ref: "#/components/schemas/DescriptionType"

--- a/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
+++ b/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
@@ -976,7 +976,7 @@ components:
         text:
           description: "the text of an access statement that explains any restrictions\
             \ on access"
-          pattern: "^\\s*\\S.*$"
+          pattern: "^\\s*\\S[\\s\\S]*$"
           type: "string"
         type:
           $ref: "#/components/schemas/DescriptionType"

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/DescriptionIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/DescriptionIntegrationTest.java
@@ -512,6 +512,67 @@ public class DescriptionIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @DisplayName("Minting a RAiD with a multi-line description succeeds (RAID-704)")
+    void multiLineDescriptionMint() {
+        final var multiLineText = "First line of description.\nSecond line with more detail.\nThird line.";
+        createRequest.getDescription().get(0).setText(multiLineText);
+
+        try {
+            final var mintResponse = raidApi.mintRaid(createRequest);
+            final var mintedRaid = mintResponse.getBody();
+            assertThat(mintedRaid).isNotNull();
+
+            final var handle = new Handle(mintedRaid.getIdentifier().getId());
+            final var readResponse = raidApi.findRaidByName(handle.getPrefix(), handle.getSuffix());
+            assertThat(readResponse.getBody().getDescription().get(0).getText()).isEqualTo(multiLineText);
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Updating a RAiD description to multi-line text succeeds (RAID-704)")
+    void multiLineDescriptionUpdate() {
+        final var mintResponse = raidApi.mintRaid(createRequest);
+        final var mintedRaid = mintResponse.getBody();
+        final var handle = new Handle(mintedRaid.getIdentifier().getId());
+
+        final var multiLineText = "Updated first line.\nUpdated second line.\nUpdated third line.";
+        mintedRaid.getDescription().get(0).setText(multiLineText);
+
+        try {
+            final var updateResponse = raidApi.updateRaid(
+                    handle.getPrefix(), handle.getSuffix(), updateRequestFactory.create(mintedRaid)
+            );
+            final var updatedRaid = updateResponse.getBody();
+            assertThat(updatedRaid.getDescription().get(0).getText()).isEqualTo(multiLineText);
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Whitespace-only description text is still rejected after RAID-704 fix")
+    void whitespaceOnlyDescription() {
+        createRequest.getDescription().get(0).setText("   ");
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown with whitespace-only description");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures).contains(new ValidationFailure()
+                    .fieldId("description[0].text")
+                    .errorType("notSet")
+                    .message("field must be set")
+            );
+        } catch (Exception e) {
+            fail("Expected RaidApiValidationException");
+        }
+    }
+
+    @Test
     @DisplayName("Description should handle multiple updates")
     void multipleUpdates() {
         final var mintResponse = raidApi.mintRaid(createRequest);

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,23 @@
 See the [Changelog audience](#changelog-audience) section for info about
  the expected audience and content of the changelog.
 
+# 2.11.0
+
+## API
+* Description `text` field now accepts line breaks -- changed the validation pattern from
+  `^\s*\S.*$` to `^\s*\S[\s\S]*$` so that multi-line content is no longer rejected
+  (RAID-704, PR #534).
+* `metadata.created` is now immutable on update -- the API preserves the original creation
+  timestamp instead of allowing it to be overwritten (RAID-690, PR #525).
+
+## App-client UI
+* ORCID integration uplift -- contributor widget now validates ORCID iDs and displays the
+  resolved identity after lookup (RAID-676, PR #532).
+* New date picker component integrated throughout the RAiD form, replacing raw text inputs
+  (RAID-674, PR #521).
+* Contributor start and end dates now default to the RAiD's own start and end dates.
+* Corrected "Create API key" label to "Create API token".
+
 # 2.10.1
 
 > Note: 2.10.0 was never deployed to production. Its migration of `schemaUri` fields to typed

--- a/documentation/20260622-allow-description-line-breaks-raid-704.md
+++ b/documentation/20260622-allow-description-line-breaks-raid-704.md
@@ -1,0 +1,26 @@
+# RAID-704: Allow line breaks in Description text field
+
+## What changed
+
+The `Description.text` field in the RAiD API rejected values containing line breaks (`\n`). The root cause was the regex pattern `^\s*\S.*$` in the LinkML schema, where `.` does not match `\n` in ECMA 262 / Java regex. Changed the pattern to `^\s*\S[\s\S]*$` so that `[\s\S]` matches any character including newlines.
+
+### Files modified
+
+- `api-svc/datamodel/src/v2/raid-core.yaml` (source of truth)
+- `api-svc/datamodel/generated/v2/raid-jsonschema.json` (generated, committed)
+- `api-svc/datamodel/generated/v2/raid-strict-jsonschema.json` (generated, committed)
+- `api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml` (generated, committed)
+- `api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml` (generated, committed)
+- `api-svc/raid-api/src/intTest/java/au/org/raid/inttest/DescriptionIntegrationTest.java` (3 new tests)
+
+### Why only Description.text?
+
+13 fields in `raid-core.yaml` use the same `^\s*\S.*$` pattern. Only `Description.text` was changed because it is the only field where multi-line input is a valid use case. Other fields (titles, notes, identifiers) are single-line by design.
+
+## JIRA
+
+- [RAID-704](https://ardc.atlassian.net/browse/RAID-704)
+
+## PR
+
+- https://github.com/au-research/raid-au/pull/534


### PR DESCRIPTION
## Summary

- Fixed regex pattern for `Description.text` in the LinkML schema (`raid-core.yaml`) from `^\s*\S.*$` to `^\s*\S[\s\S]*$` so that `.` (which does not match `\n` in ECMA 262 / Java regex) is replaced with `[\s\S]` to permit line breaks
- Updated the four generated schema/spec files that propagate this pattern (JSON Schema, strict JSON Schema, OpenAPI public, OpenAPI internal)
- Added three integration tests: multi-line mint, multi-line update, and whitespace-only rejection

## Test plan

- [x] `./gradlew build` passes (unit tests)
- [x] `./gradlew intTest --tests '*DescriptionIntegrationTest*'` passes (21 tests, 18 passed, 3 pre-existing skips)
- [x] Multi-line description text can be minted and read back
- [x] Multi-line description text can be set via update and read back
- [x] Whitespace-only text is still rejected with `notSet` validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)