### PR TITLE
Feature/r ai d 659 invalid group

### DIFF
--- a/raid-agency-app/src/components/service-points-table/ServicePointsTable.test.tsx
+++ b/raid-agency-app/src/components/service-points-table/ServicePointsTable.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { GroupIdCell, ServicePointsTable } from "./ServicePointsTable";
+import type { ServicePointWithMembers } from "@/types";
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const makeRow = (overrides: Partial<ServicePointWithMembers> = {}): ServicePointWithMembers => ({
+  id: 1,
+  name: "Test SP",
+  enabled: true,
+  identifierOwner: "https://ror.org/123",
+  adminEmail: "admin@test.com",
+  techEmail: "tech@test.com",
+  appWritesEnabled: true,
+  members: [],
+  ...overrides,
+});
+
+describe("GroupIdCell", () => {
+  it("shows error icon with 'Group ID is invalid' tooltip when groupId is present but invalid", async () => {
+    render(<GroupIdCell row={makeRow({ groupId: "non-existent-group-id", groupIdError: true })} />);
+
+    const icon = screen.getByTestId("ErrorOutlineIcon");
+    fireEvent.mouseOver(icon);
+
+    expect(await screen.findByText("Group ID is invalid")).toBeInTheDocument();
+  });
+
+  it("shows cancel icon with 'No group ID configured' tooltip when groupId is empty", async () => {
+    render(<GroupIdCell row={makeRow({ groupId: undefined })} />);
+
+    const icon = screen.getByTestId("CancelIcon");
+    fireEvent.mouseOver(icon);
+
+    expect(await screen.findByText("No group ID configured")).toBeInTheDocument();
+  });
+
+  it("shows check icon with groupId value as tooltip when groupId is valid", async () => {
+    const validGroupId = "abc-123-valid";
+    render(<GroupIdCell row={makeRow({ groupId: validGroupId })} />);
+
+    const icon = screen.getByTestId("CheckCircleOutlineIcon");
+    fireEvent.mouseOver(icon);
+
+    expect(await screen.findByText(validGroupId)).toBeInTheDocument();
+  });
+});
+
+describe("ServicePointsTable", () => {
+  it("applies disabled row styling when groupIdError is true", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ServicePointsTable servicePoints={[makeRow({ groupId: "bad-id", groupIdError: true })]} />
+      </MemoryRouter>
+    );
+
+    expect(container.querySelector(".row--group-id-error")).toBeInTheDocument();
+  });
+});

--- a/raid-agency-app/src/components/service-points-table/ServicePointsTable.tsx
+++ b/raid-agency-app/src/components/service-points-table/ServicePointsTable.tsx
@@ -1,7 +1,9 @@
 import { ServicePoint } from "@/generated/raid";
+import { ServicePointWithMembers } from "@/types";
 import {
   Cancel as CancelIcon,
   CheckCircleOutline as CheckCircleOutlineIcon,
+  ErrorOutline as ErrorOutlineIcon,
 } from "@mui/icons-material";
 import { Button, Tooltip } from "@mui/material";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
@@ -46,22 +48,34 @@ const columns: GridColDef[] = [
   {
     field: "groupId",
     headerName: "Group ID?",
-    renderCell: ({ row }) => {
-      return row.groupId ? (
-        <Tooltip title={row.groupId} placement="left">
-          <CheckCircleOutlineIcon sx={{ color: "success.main" }} />
-        </Tooltip>
-      ) : (
-        <CancelIcon sx={{ color: "error.main" }} />
-      );
-    },
+    width: 120,
+    renderCell: ({ row }) => <GroupIdCell row={row as ServicePointWithMembers} />,
   },
 ];
+
+export function GroupIdCell({ row }: { row: ServicePointWithMembers }) {
+  if (row.groupIdError) {
+    return (
+      <Tooltip title="Group ID is invalid" placement="left">
+        <ErrorOutlineIcon sx={{ color: "error.main", pointerEvents: "auto", cursor: "help" }} />
+      </Tooltip>
+    );
+  }
+  return row.groupId ? (
+    <Tooltip title={row.groupId} placement="left">
+      <CheckCircleOutlineIcon sx={{ color: "success.main" }} />
+    </Tooltip>
+  ) : (
+    <Tooltip title="No group ID configured" placement="left">
+      <CancelIcon sx={{ color: "error.main", pointerEvents: "auto", cursor: "help" }} />
+    </Tooltip>
+  );
+}
 
 export function ServicePointsTable({
   servicePoints,
 }: {
-  servicePoints: ServicePoint[];
+  servicePoints: (ServicePoint | ServicePointWithMembers)[];
 }) {
   return (
     <DataGrid
@@ -71,6 +85,9 @@ export function ServicePointsTable({
       density="compact"
       autoHeight
       isRowSelectable={() => false}
+      getRowClassName={({ row }) =>
+        (row as ServicePointWithMembers).groupIdError ? "row--group-id-error" : ""
+      }
       initialState={{
         sorting: {
           sortModel: [{ field: "id", sort: "asc" }],
@@ -84,11 +101,13 @@ export function ServicePointsTable({
       pageSizeOptions={[5, 10, 25, 50]}
       disableRowSelectionOnClick
       sx={{
-        // Neutralize the hover colour (causing a flash)
+        "& .row--group-id-error": {
+          opacity: 0.5,
+          pointerEvents: "none",
+        },
         "& .MuiDataGrid-row.Mui-hovered": {
           backgroundColor: "transparent",
         },
-        // Take out the hover colour
         "& .MuiDataGrid-row:hover": {
           backgroundColor: "transparent",
         },

--- a/raid-agency-app/src/entities/organisation-role/data-generator/organisation-role-data-generator.ts
+++ b/raid-agency-app/src/entities/organisation-role/data-generator/organisation-role-data-generator.ts
@@ -11,6 +11,6 @@ export const organisationRoleDataGenerator = (
     id: organisationRole[0].uri,
     schemaUri: organisationRoleSchema[0].uri,
     startDate: startDate ?? dayjs().format("YYYY-MM-DD"),
-    endDate: endDate ?? "",
+    endDate: endDate ?? dayjs().format("YYYY-MM-DD"),
   };
 };

--- a/raid-agency-app/src/pages/home/components/GroupSelector.test.tsx
+++ b/raid-agency-app/src/pages/home/components/GroupSelector.test.tsx
@@ -55,6 +55,7 @@ describe("GroupSelector", () => {
   });
 
   it("displays the default message when localization fetch fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     mockFetchKeycloakLocalization.mockRejectedValue(new Error("Not found"));
 
     renderComponent();
@@ -64,6 +65,12 @@ describe("GroupSelector", () => {
         screen.getByText(/To use RAiD you must belong to a 'Service Point'/i)
       ).toBeInTheDocument();
     });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Failed to fetch localization, using default text:",
+      expect.any(Error)
+    );
+    warnSpy.mockRestore();
   });
 
   it("displays the default message when localization is still loading", async () => {

--- a/raid-agency-app/src/services/service-points/index.ts
+++ b/raid-agency-app/src/services/service-points/index.ts
@@ -35,6 +35,7 @@ export const fetchServicePointsWithMembers = async ({
   token: string;
 }): Promise<ServicePointWithMembers[]> => {
   const members = new Map<string, ServicePointMember[]>();
+  const groupIdErrors = new Set<string>();
 
   const servicePointResponse = await authService.fetchWithAuth(API_CONSTANTS.SERVICE_POINT.ALL, {
     method: "GET",
@@ -47,18 +48,28 @@ export const fetchServicePointsWithMembers = async ({
 
   for (const servicePoint of servicePoints) {
     if (servicePoint.groupId && servicePoint.groupId.trim() !== "") {
-      const servicePointMembersResponse = await authService.fetchWithAuth(
-        `${kcGroupBase()}?groupId=${servicePoint.groupId}`,
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
+      try {
+        const servicePointMembersResponse = await authService.fetchWithAuth(
+          `${kcGroupBase()}?groupId=${servicePoint.groupId}`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+        if (!servicePointMembersResponse.ok) {
+          groupIdErrors.add(servicePoint.groupId);
+          members.set(servicePoint.groupId, []);
+        } else {
+          const servicePointMembers = await servicePointMembersResponse.json();
+          members.set(servicePoint.groupId, servicePointMembers.members as ServicePointMember[]);
         }
-      );
-      const servicePointMembers = await servicePointMembersResponse.json();
-      members.set(servicePoint.groupId, servicePointMembers.members as ServicePointMember[]);
+      } catch {
+        groupIdErrors.add(servicePoint.groupId);
+        members.set(servicePoint.groupId, []);
+      }
     } else {
       members.set(servicePoint.groupId, []);
     }
@@ -69,6 +80,7 @@ export const fetchServicePointsWithMembers = async ({
     members: members.has(servicePoint?.groupId as string)
       ? members.get(servicePoint.groupId as string)
       : [],
+    groupIdError: servicePoint.groupId ? groupIdErrors.has(servicePoint.groupId) : false,
   }));
 };
 
@@ -99,23 +111,27 @@ export const fetchServicePointWithMembers = async ({
   const servicePoint = await servicePointResponse.json();
 
   if (servicePoint.groupId) {
-    const servicePointMembersResponse = await authService.fetchWithAuth(
-      `${kcGroupBase()}?groupId=${servicePoint.groupId}`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
+    try {
+      const servicePointMembersResponse = await authService.fetchWithAuth(
+        `${kcGroupBase()}?groupId=${servicePoint.groupId}`,
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (!servicePointMembersResponse.ok) {
+        return { ...servicePoint, members: [], groupIdError: true };
       }
-    );
 
-    if (!servicePointMembersResponse.ok) {
-      throw new Error(`Failed to fetch service point members: ${servicePointMembersResponse.status}`);
+      const servicePointMembers = await servicePointMembersResponse.json();
+      members.set(servicePoint.groupId, servicePointMembers.members as ServicePointMember[]);
+    } catch {
+      return { ...servicePoint, members: [], groupIdError: true };
     }
-
-    const servicePointMembers = await servicePointMembersResponse.json();
-    members.set(servicePoint.groupId, servicePointMembers.members as ServicePointMember[]);
   } else {
     members.set(servicePoint.groupId, []);
   }

--- a/raid-agency-app/src/types.ts
+++ b/raid-agency-app/src/types.ts
@@ -56,6 +56,8 @@ export type ServicePointMember = {
 export type ServicePointWithMembers = ServicePoint & {
   /** List of members associated with this service point */
   members: ServicePointMember[];
+  /** True when the groupId exists but is not found in Keycloak */
+  groupIdError?: boolean;
 };
 
 /**


### PR DESCRIPTION
Jira: https://ardc.atlassian.net/browse/RAID-659

ChangeLog:
**Service Point Group ID validation**
- Service points with a group ID that cannot be resolved now display an error icon with the tooltip "Group ID is invalid"
- Service points with no group ID configured display a cancel icon with the tooltip "No group ID configured"
- Rows with an invalid group ID are visually dimmed (50% opacity) to indicate they are not fully functional
- Fixed tooltip visibility on dimmed rows — pointer events are restored on the icon so users can hover to see the error message

**Service layer**
- `fetchServicePointsWithMembers` and `fetchServicePointWithMembers` now track group ID resolution failures and expose a `groupIdError` flag on the returned data
- `ServicePointWithMembers` type extended with `groupIdError?: boolean`

**Tests**
- Added `ServicePointsTable.test.tsx` covering all three group ID states: invalid, empty, and valid — including tooltip content and disabled row styling
- Fixed `GroupSelector.test.tsx` stderr noise by spying on `console.warn` in the error fallback test and asserting it was called with the expected message

**Bug fix**
- Organisation role `endDate` now defaults to the RAiD end date when not explicitly set