### PR TITLE
remove end date validation and make orcid placeholder text configurable

### DIFF
--- a/raid-agency-app/public/app-config.json
+++ b/raid-agency-app/public/app-config.json
@@ -25,9 +25,10 @@
     "staticProd": "https://static.prod.raid.org.au",
     "staticBase": "https://static.{env}.raid.org.au"
   },
-  "app" :{
+  "app": {
     "orcid": {
-      "placeholder": "Enter valid sandbox ORCID iD"
+      "placeholder": "Enter valid sandbox ORCID iD",
+      "helpText": "Use the ORCID sandbox (https://orcid.org/sandbox)"
     }
   },
   "_brandingComment": "The branding section below is optional. Remove it or any of its fields to fall back to the built-in defaults.",

--- a/raid-agency-app/public/app-config.json
+++ b/raid-agency-app/public/app-config.json
@@ -25,6 +25,11 @@
     "staticProd": "https://static.prod.raid.org.au",
     "staticBase": "https://static.{env}.raid.org.au"
   },
+  "app" :{
+    "orcid": {
+      "placeholder": "Enter valid sandbox ORCID iD"
+    }
+  },
   "_brandingComment": "The branding section below is optional. Remove it or any of its fields to fall back to the built-in defaults.",
   "branding": {
     "default": false,

--- a/raid-agency-app/src/config/Configloader.ts
+++ b/raid-agency-app/src/config/Configloader.ts
@@ -76,6 +76,7 @@ export async function loadConfig(): Promise<{
     supportEmail: raw.supportEmail,
     googleAnalytics: raw.googleAnalytics ?? {},
     services: raw.services,
+    app: raw.app ?? {},
   };
 
   const branding = raw.branding ?? {};

--- a/raid-agency-app/src/config/RuntimeConfig.ts
+++ b/raid-agency-app/src/config/RuntimeConfig.ts
@@ -20,6 +20,7 @@ export interface RuntimeConfig {
   app: {
     orcid: {
       placeholder: string;
+      helpText: string;
     };
   };
 }

--- a/raid-agency-app/src/config/RuntimeConfig.ts
+++ b/raid-agency-app/src/config/RuntimeConfig.ts
@@ -17,4 +17,9 @@ export interface RuntimeConfig {
     staticProd: string;
     staticBase: string;
   };
+  app: {
+    orcid: {
+      placeholder: string;
+    };
+  };
 }

--- a/raid-agency-app/src/config/RuntimeConfigContext.test.ts
+++ b/raid-agency-app/src/config/RuntimeConfigContext.test.ts
@@ -16,6 +16,7 @@ const mockConfig: RuntimeConfig = {
   app: {
     orcid: {
       placeholder: "Enter ORCID iD (e.g., 0000-0002-1825-0097)",
+      helpText: "Enter a valid ORCID iD",
     },
   },
 };

--- a/raid-agency-app/src/config/RuntimeConfigContext.test.ts
+++ b/raid-agency-app/src/config/RuntimeConfigContext.test.ts
@@ -13,6 +13,11 @@ const mockConfig: RuntimeConfig = {
     staticProd: "https://static.prod.raid.org.au",
     staticBase: "https://static.{env}.raid.org.au",
   },
+  app: {
+    orcid: {
+      placeholder: "Enter ORCID iD (e.g., 0000-0002-1825-0097)",
+    },
+  },
 };
 
 // Reset the module before each test to clear the module-level _runtimeConfig variable

--- a/raid-agency-app/src/constants/apiConstants.test.ts
+++ b/raid-agency-app/src/constants/apiConstants.test.ts
@@ -8,13 +8,18 @@ vi.mock("@/config", () => ({
 import { getRuntimeConfig } from "@/config";
 import { API_CONSTANTS } from "./apiConstants";
 
-const mockConfig: Pick<RuntimeConfig, "apiBaseUrl" | "services"> = {
+const mockConfig: Pick<RuntimeConfig, "apiBaseUrl" | "services" | "app"> = {
   apiBaseUrl: "https://api.test.raid.org.au",
   services: {
     orcid: "https://orcid.test.raid.org.au",
     invite: "https://invite.test.raid.org.au",
     staticProd: "https://static.prod.raid.org.au",
     staticBase: "https://static.{env}.raid.org.au",
+  },
+  app: {
+    orcid: {
+      placeholder: "Enter ORCID iD (e.g., 0000-0002-1825-0097)",
+    },
   },
 };
 

--- a/raid-agency-app/src/constants/apiConstants.test.ts
+++ b/raid-agency-app/src/constants/apiConstants.test.ts
@@ -19,6 +19,7 @@ const mockConfig: Pick<RuntimeConfig, "apiBaseUrl" | "services" | "app"> = {
   app: {
     orcid: {
       placeholder: "Enter ORCID iD (e.g., 0000-0002-1825-0097)",
+      helpText: "Enter a valid ORCID iD",
     },
   },
 };

--- a/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
+++ b/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
@@ -287,7 +287,7 @@ export default function ORCIDLookup({
   const [cachedResult, setCachedResult] = useState<boolean>(false);
   const [resolvedName, setResolvedName] = useState<string | null>(null);
   const fieldName = path?.name;
-
+  const { orcid } = getRuntimeConfig().app;
   // Cleanup expired cache on mount
   React.useEffect(() => {
     orcidLookupCache.cleanup();
@@ -369,7 +369,7 @@ export default function ORCIDLookup({
 
   const searchConfig = {
     lookup: {
-      placeholder: 'Type to search',
+      placeholder: orcid.placeholder || 'Enter ORCID iD (e.g., 0000-0002-1825-0097)',
       endpoint: `https://${getOrcidEnv()}researchdata.ardc.edu.au/api/v2.0/orcid.jsonp/lookup/${encodeURIComponent(searchValue)}/?api_key=public&callback=?`,
       label: 'ORCID ID',
       description: 'Search by unique ORCID identifier',

--- a/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
+++ b/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
@@ -624,7 +624,7 @@ const selectOrcid = (item: OrcidData | SearchPerson) => {
 }
   const _errors = formMethods?.formState?.errors as Record<string, unknown> | undefined;
   const helperTextError = Array.isArray((_errors as Record<string, any>)?.contributor) && !!((_errors as Record<string, any>)[path.name]?.message) ?
-  "Enter a valid ORCID iD e.g. 0000-0002-1825-0097 or free text to search" as string : '';
+  (orcid.helpText || "Enter a valid ORCID iD e.g. 0000-0002-1825-0097 or free text to search") : '';
 
   return (
     <Box sx={{ p: 1 }}>
@@ -701,7 +701,7 @@ const selectOrcid = (item: OrcidData | SearchPerson) => {
         <Box sx={{mt: 1, mb: 1, display: 'flex', alignItems: 'center', width: '400px', justifyContent: 'space-between' }}>
           <FormHelperText sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
             {mode === 'validation-only'
-              ? 'Enter a valid ORCID iD, e.g. https://orcid.org/0000-0002-1825-0097'
+              ? (orcid.helpText || 'Enter a valid ORCID iD, e.g. https://orcid.org/0000-0002-1825-0097')
               : searchConfig?.genericPlaceholder}
           </FormHelperText>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/raid-agency-app/src/entities/contributor-position/forms/contributor-positions-form/ContributorPositionsForm.tsx
+++ b/raid-agency-app/src/entities/contributor-position/forms/contributor-positions-form/ContributorPositionsForm.tsx
@@ -104,7 +104,6 @@ export function ContributorPositionsForm({
           onClick={handleAddItem}
           onMouseEnter={() => setIsRowHighlighted(true)}
           onMouseLeave={() => setIsRowHighlighted(false)}
-          disabled={useEnableAddFields(positions as unknown as SubSections, isDirty)}
         >
           Add {label}
         </Button>

--- a/raid-agency-app/src/entities/organisation-role/forms/organisation-roles-form/OrganisationRolesForm.tsx
+++ b/raid-agency-app/src/entities/organisation-role/forms/organisation-roles-form/OrganisationRolesForm.tsx
@@ -104,7 +104,6 @@ export function OrganisationRolesForm({
           onClick={handleAddItem}
           onMouseEnter={() => setIsRowHighlighted(true)}
           onMouseLeave={() => setIsRowHighlighted(false)}
-          disabled={useEnableAddFields(orgRole as unknown as SubSections, isDirty)}
         >
           Add {label}
         </Button>


### PR DESCRIPTION
## Changelog

### RAiD-708 -- Remove End Date Validation & Configurable ORCID Widget Text

#### Changed

- Removed end date validation from contributor positions form and organisation roles
  form, allowing end dates to be left blank without triggering a validation error.

#### Added

- Added `app.orcid.placeholder` and `app.orcid.helpText` fields to `app-config.json`
  and the `RuntimeConfig` TypeScript type, making the ORCID widget's placeholder and
  helper text configurable at runtime without a rebuild.
- The ORCID widget now reads both `placeholder` and `helpText` from runtime config
  instead of hardcoded strings, with sensible fallback defaults if the fields are absent.

#### Fixed

- Updated test mocks in `RuntimeConfigContext.test.ts` and `apiConstants.test.ts` to
  include the new `helpText` field, resolving TypeScript compile errors.