### PR TITLE
RAID-707: prefer primary title type in JSON-LD mapping

### DIFF
--- a/raid-agency-app-static/src/utils/json-ld.test.ts
+++ b/raid-agency-app-static/src/utils/json-ld.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildResearchProjectJsonLd } from "./json-ld";
 import type { RaidDto } from "@/generated/raid";
 
+const PRIMARY_TITLE_TYPE = "https://vocabulary.raid.org/title.type.schema/5";
 const PRIMARY_DESCRIPTION_TYPE = "https://vocabulary.raid.org/description.type.schema/318";
 const FUNDER_ORGANISATION_ROLE = "https://vocabulary.raid.org/organisation.role.schema/186";
 
@@ -41,7 +42,7 @@ describe("buildResearchProjectJsonLd", () => {
     raid.title = [
       {
         text: "Researching the lived experience of First Nations Peoples",
-        type: { id: "https://vocabulary.raid.org/title.type.schema/5", schemaUri: "" },
+        type: { id: PRIMARY_TITLE_TYPE, schemaUri: "" },
         startDate: "2025-01-01",
         language: { id: "eng", schemaUri: "https://www.iso.org/standard/74575.html" },
       },
@@ -50,6 +51,41 @@ describe("buildResearchProjectJsonLd", () => {
     const result = buildResearchProjectJsonLd(raid);
     expect(result.name).toBe("Researching the lived experience of First Nations Peoples");
     expect(result.headline).toBe("Researching the lived experience of First Nations Peoples");
+  });
+
+  it("prefers primary title over alternative title", () => {
+    const raid = minimalRaid();
+    raid.title = [
+      {
+        text: "Alternative name",
+        type: { id: "https://vocabulary.raid.org/title.type.schema/4", schemaUri: "" },
+        startDate: "2025-01-01",
+      },
+      {
+        text: "Primary name",
+        type: { id: PRIMARY_TITLE_TYPE, schemaUri: "" },
+        startDate: "2025-01-01",
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.name).toBe("Primary name");
+    expect(result.headline).toBe("Primary name");
+  });
+
+  it("falls back to first title when no primary title exists", () => {
+    const raid = minimalRaid();
+    raid.title = [
+      {
+        text: "Alternative name",
+        type: { id: "https://vocabulary.raid.org/title.type.schema/4", schemaUri: "" },
+        startDate: "2025-01-01",
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.name).toBe("Alternative name");
+    expect(result.headline).toBe("Alternative name");
   });
 
   it("defaults name and headline to empty string when no title", () => {

--- a/raid-agency-app-static/src/utils/json-ld.ts
+++ b/raid-agency-app-static/src/utils/json-ld.ts
@@ -1,5 +1,6 @@
 import type { Contributor, Organisation, RaidDto, RelatedRaid } from "@/generated/raid";
 
+const PRIMARY_TITLE_TYPE = "https://vocabulary.raid.org/title.type.schema/5";
 const PRIMARY_DESCRIPTION_TYPE = "https://vocabulary.raid.org/description.type.schema/318";
 const FUNDER_ORGANISATION_ROLE = "https://vocabulary.raid.org/organisation.role.schema/186";
 
@@ -191,7 +192,9 @@ export function buildResearchProjectJsonLd(raid: Partial<RaidDto>): ResearchProj
     inDefinedTermSet: subject.schemaUri,
   }));
 
-  const name = raid.title?.at(0)?.text ?? "";
+  const name = raid.title?.find((t) => t.type?.id === PRIMARY_TITLE_TYPE)?.text
+    ?? raid.title?.at(0)?.text
+    ?? "";
 
   return {
     "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- Updated `buildResearchProjectJsonLd` to prefer the primary title type (`title.type.schema/5`) for the `name` and `headline` fields in the JSON-LD output, with a fallback to the first title if no primary title exists
- Added two new unit tests covering primary title preference and fallback behaviour

## Test plan
- [x] All 24 existing JSON-LD unit tests pass
- [x] New test: primary title is selected over alternative title when both are present
- [x] New test: first title is used as fallback when no primary title exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)