### PR TITLE
Implemented the ROR validation and also uplifted the ROR widget

### DIFF
--- a/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
+++ b/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
@@ -115,6 +115,7 @@ export default function CustomizedInputBase({
 }: CustomizedInputBaseProps) {
   const [searchText, clearSearchText] = React.useState(false);
   const [inputText, setInputText] = React.useState(defaultValue || '');
+  const isSelected = React.useRef(!!defaultValue);
   const [dropBox, setDropBox] = React.useState(false);
   const { watch, formState: { isDirty } } = useFormContext();
   const value = watch(`${name}`);
@@ -155,16 +156,18 @@ export default function CustomizedInputBase({
       e.preventDefault();
       e.stopPropagation();
       if (inputText.trim()) {
+        isSelected.current = false;
         searchMutation.mutate(inputText.trim());
         setDropBox(true);
       }
     };
-  
+
     const handleListItemClick = (org: GroupedOrganization) => {
       setDropBox(false);
       setSelectedValue({ id: org.id.trim(), name: org.displayName });
       clearSearchText(true);
       setInputText(org.id.trim());
+      isSelected.current = true;
     };
   
     const formatSecondaryText = (links: RORLink[]) => {
@@ -223,7 +226,13 @@ export default function CustomizedInputBase({
           placeholder={`Search Text or lookup ROR ID ${required ? '*' : ''}`}
           inputProps={{ 'aria-label': 'Search Text or lookup ROR ID' }}
           value={inputText}
-          onChange={(e) => {setInputText(e.target.value),clearSearchText(true)}}
+          onChange={(e) => {
+            setInputText(e.target.value);
+            clearSearchText(true);
+            if (isSelected.current) {
+              setSelectedValue({ id: e.target.value });
+            }
+          }}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
               handleSearch(e);
@@ -231,7 +240,7 @@ export default function CustomizedInputBase({
           }}
           required={required}
         />
-        {searchText && <CloseRoundedIcon onClick={() => {clearSearchText(false), setInputText('')}} />}
+        {searchText && <CloseRoundedIcon onClick={() => { clearSearchText(false); setInputText(''); setSelectedValue(null); isSelected.current = false; }} />}
         <Divider sx={{ height: 28, m: 0.5 }} orientation="vertical" />
         <IconButton  onClick={(e) => handleSearch(e)}  color="primary" sx={{ p: '10px' }} aria-label="directions">
           {searchMutation.status === 'pending' ? <ClipLoader color="#36a5dd" size={25}/> : <TravelExploreIcon />}

--- a/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
+++ b/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
@@ -162,9 +162,9 @@ export default function CustomizedInputBase({
   
     const handleListItemClick = (org: GroupedOrganization) => {
       setDropBox(false);
-      setSelectedValue({ id: org.id, name: org.displayName });
+      setSelectedValue({ id: org.id.trim(), name: org.displayName });
       clearSearchText(true);
-      setInputText(org.id);
+      setInputText(org.id.trim());
     };
   
     const formatSecondaryText = (links: RORLink[]) => {

--- a/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
+++ b/raid-agency-app/src/containers/organisation-lookup/RORCustomComponent.tsx
@@ -97,7 +97,7 @@ const transformToGroupedData = (items: RORItem[] = []): GroupedData => {
 
 
 interface CustomizedInputBaseProps {
-  setSelectedValue: React.Dispatch<React.SetStateAction<{ id: string; name?: string } | null>>;
+  setSelectedValue: (value: { id: string; name?: string } | null) => void;
   name: string;
   defaultValue?: string;
   styles?: React.CSSProperties;

--- a/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointCreateForm.tsx
@@ -66,6 +66,15 @@ export const ServicePointCreateForm = () => {
     defaultValues: { ...initalServicePointValues },
   });
 
+  const handleSetSelectedValue = (value: { id: string; name?: string } | null) => {
+    setSelectedValue(value);
+    form.setValue(
+      'servicePointCreateRequest.identifierOwner',
+      value?.id ?? '',
+      { shouldValidate: true }
+    );
+  };
+
   const handleCreateSuccess = async () => {
     queryClient.invalidateQueries({ queryKey: ["createServicePoint"] });
     // Show success snackbar
@@ -99,12 +108,6 @@ export const ServicePointCreateForm = () => {
   });
 
 const onSubmit = (item: CreateServicePointRequest) => {
-  // Set identifier owner if selected
-  if (selectedValue) {
-    item.servicePointCreateRequest.identifierOwner = selectedValue.id;
-  }
-
-  // Proceed with mutation
   createServicePointMutation.mutate(item);
   setAppState({ ...appState, loading: true });
 };
@@ -193,7 +196,7 @@ const onSubmit = (item: CreateServicePointRequest) => {
                     >
                       <div>
                         <CustomizedInputBase
-                          setSelectedValue={setSelectedValue}
+                          setSelectedValue={handleSetSelectedValue}
                           name={`servicePointCreateRequest.identifierOwner`}
                           defaultValue={selectedValue?.id || ""}
                           styles={{ width: '100%' }}

--- a/raid-agency-app/src/pages/service-point/components/ServicePointUpdateForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointUpdateForm.tsx
@@ -69,6 +69,15 @@ export const ServicePointUpdateForm = ({
     defaultValues: { ...initalServicePointValues },
   });
 
+  const handleSetSelectedValue = (value: { id: string; name?: string } | null) => {
+    setSelectedValue(value);
+    form.setValue(
+      'servicePointUpdateRequest.identifierOwner',
+      value?.id ?? '',
+      { shouldValidate: true }
+    );
+  };
+
   const handleUpdateSuccess = async() => {
     await queryClient.invalidateQueries({
       queryKey: ["servicePoints", servicePoint.id.toString()],
@@ -102,9 +111,6 @@ export const ServicePointUpdateForm = ({
   });
 
   const onSubmit = (item: UpdateServicePointRequest) => {
-    if (selectedValue) {
-      item.servicePointUpdateRequest.identifierOwner = selectedValue.id;
-    }
     setAppState({ ...appState, loading: true });
     updateServicePointMutation.mutate(item);
   };
@@ -180,7 +186,7 @@ export const ServicePointUpdateForm = ({
                             >
                                 <div>
                                     <CustomizedInputBase
-                                        setSelectedValue={setSelectedValue}
+                                        setSelectedValue={handleSetSelectedValue}
                                         name={`servicePointUpdateRequest.identifierOwner`}
                                         defaultValue={form.getValues("servicePointUpdateRequest.identifierOwner")}
                                         styles={{width: '100%'}}

--- a/raid-agency-app/src/pages/service-point/validation/Rules.tsx
+++ b/raid-agency-app/src/pages/service-point/validation/Rules.tsx
@@ -5,7 +5,13 @@ import { z } from "zod";
 // Base schema for the service point fields
 const servicePointBaseSchema = z.object({
   name: z.string().min(3, "Name must be at least 3 characters"),
-  identifierOwner: z.string(),
+  identifierOwner: z.string()
+    .trim()
+    .min(1, "Identifier owner is required")
+    .regex(
+      /^https:\/\/ror\.org\/[a-z0-9]{9}$/,
+      "Must be a valid ROR URL (e.g. https://ror.org/038sjwq14)"
+    ),
   adminEmail: z.string()
     .min(1, "Admin email is required")
     .email("Invalid email format"),

--- a/raid-agency-app/src/pages/service-point/validation/Rules.tsx
+++ b/raid-agency-app/src/pages/service-point/validation/Rules.tsx
@@ -6,7 +6,6 @@ import { z } from "zod";
 const servicePointBaseSchema = z.object({
   name: z.string().min(3, "Name must be at least 3 characters"),
   identifierOwner: z.string()
-    .trim()
     .min(1, "Identifier owner is required")
     .regex(
       /^https:\/\/ror\.org\/[a-z0-9]{9}$/,


### PR DESCRIPTION
## Changes

- Added `.trim()` to selected ROR value in `RORCustomComponent` to strip accidental whitespace before it propagates to the form
- Upgraded `identifierOwner` Zod validation in service-point schema from an unvalidated `z.string()` to enforce:
  - Field is required
  - Whitespace is stripped before validation
  - Value must match the canonical ROR URL format (`https://ror.org/<9-char-id>`)
- Validation applies to both create and update service-point forms via the shared base schema