### PR TITLE
RAID-707: Include all titles in schema.org JSON-LD name

### DIFF
--- a/raid-agency-app-static/src/utils/json-ld.test.ts
+++ b/raid-agency-app-static/src/utils/json-ld.test.ts
@@ -53,7 +53,7 @@ describe("buildResearchProjectJsonLd", () => {
     expect(result.headline).toBe("Researching the lived experience of First Nations Peoples");
   });
 
-  it("prefers primary title over alternative title", () => {
+  it("joins all titles with pipe separator in name, uses primary for headline", () => {
     const raid = minimalRaid();
     raid.title = [
       {
@@ -69,11 +69,11 @@ describe("buildResearchProjectJsonLd", () => {
     ];
 
     const result = buildResearchProjectJsonLd(raid);
-    expect(result.name).toBe("Primary name");
+    expect(result.name).toBe("Alternative name | Primary name");
     expect(result.headline).toBe("Primary name");
   });
 
-  it("falls back to first title when no primary title exists", () => {
+  it("falls back to first title for headline when no primary title exists", () => {
     const raid = minimalRaid();
     raid.title = [
       {

--- a/raid-agency-app-static/src/utils/json-ld.ts
+++ b/raid-agency-app-static/src/utils/json-ld.ts
@@ -192,16 +192,19 @@ export function buildResearchProjectJsonLd(raid: Partial<RaidDto>): ResearchProj
     inDefinedTermSet: subject.schemaUri,
   }));
 
-  const name = raid.title?.find((t) => t.type?.id === PRIMARY_TITLE_TYPE)?.text
+  const primaryTitle = raid.title?.find((t) => t.type?.id === PRIMARY_TITLE_TYPE)?.text
     ?? raid.title?.at(0)?.text
     ?? "";
+
+  const allTitles = raid.title?.map((t) => t.text).filter(Boolean) ?? [];
+  const name = allTitles.length > 0 ? allTitles.join(" | ") : "";
 
   return {
     "@context": "https://schema.org",
     "@type": "ResearchProject",
     "@id": raid.identifier?.id ?? "",
     name,
-    headline: name,
+    headline: primaryTitle,
     identifier: {
       "@type": "PropertyValue",
       propertyID: "https://registry.identifiers.org/registry/raid",


### PR DESCRIPTION
## Summary
- Join all RAiD titles with ` | ` separator in the schema.org JSON-LD `name` property, so search engines and structured-data consumers see every title (e.g. "NESP 2 | National Environmental Science Program Phase 2")
- `headline` now uses only the primary title, keeping it as a single descriptive value
- Prefer the primary title type over positional fallback when selecting `headline`

## Test plan
- [x] Unit tests pass (`vitest run src/utils/json-ld.test.ts` — 24 passing)
- [ ] Verify schema.org output on a rebuilt static site for a RAiD with multiple titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)