### PR TITLE
RAID-610: use RaidUpdateRequest for postToDatacite endpoint

### DIFF
--- a/api-svc/raid-api/src/main/java/au/org/raid/api/controller/RaidController.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/controller/RaidController.java
@@ -142,15 +142,14 @@ public class RaidController implements RaidApi {
     }
 
     @PostMapping("/raid/post-to-datacite")
-    public ResponseEntity<RaidDto> postToDatacite(@Valid @RequestBody final RaidDto raidDto) {
-        final var handle = new Handle(raidDto.getIdentifier().getId());
+    public ResponseEntity<Void> postToDatacite(@Valid @RequestBody final RaidUpdateRequest raid) {
+        final var handle = new Handle(raid.getIdentifier().getId());
 
-        // return bad request if not a doi
         if (!handle.toString().startsWith("10.")) {
             return ResponseEntity.badRequest().build();
         }
 
-        raidService.postToDatacite(raidDto);
+        raidService.postToDatacite(raid);
 
         return ResponseEntity.noContent().build();
     }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/raid/RaidService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/raid/RaidService.java
@@ -343,10 +343,8 @@ public class RaidService {
                 .organisations(organisations);
     }
 
-    public void postToDatacite(@Valid RaidDto raid) {
+    public void postToDatacite(RaidUpdateRequest raid) {
         final var handle = new Handle(raid.getIdentifier().getId());
-
-        //TODO: Check prefix
 
         final var servicePointId = raid.getIdentifier().getOwner().getServicePoint().longValueExact();
 

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/controller/RaidControllerTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/controller/RaidControllerTest.java
@@ -993,6 +993,51 @@ class RaidControllerTest {
                 .andExpect(jsonPath("$.organisations[1].servicePoints", Matchers.hasSize(2)));
     }
 
+    @Test
+    void postToDatacite_ReturnsNoContent() throws Exception {
+        final var input = APIFixtures.newUpdateRequest();
+        input.getIdentifier().setId("10.12345/abc123");
+
+        mockMvc.perform(post("/raid/post-to-datacite")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(input))
+                        .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+
+        verify(raidService).postToDatacite(any(RaidUpdateRequest.class));
+    }
+
+    @Test
+    void postToDatacite_NonDoiHandle_ReturnsBadRequest() throws Exception {
+        final var input = APIFixtures.newUpdateRequest();
+
+        mockMvc.perform(post("/raid/post-to-datacite")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(input))
+                        .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(raidService);
+    }
+
+    @Test
+    void postToDatacite_NullMetadata_ReturnsNoContent() throws Exception {
+        final var input = APIFixtures.newUpdateRequest();
+        input.getIdentifier().setId("10.12345/abc123");
+        input.setMetadata(null);
+
+        mockMvc.perform(post("/raid/post-to-datacite")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(input))
+                        .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+
+        verify(raidService).postToDatacite(any(RaidUpdateRequest.class));
+    }
+
     private RaidDto createRaidForGet(final String title, final LocalDate startDate) throws IOException {
         final String json = FileUtil.resourceContent("/fixtures/raid.json");
 

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/service/raid/RaidServiceTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/service/raid/RaidServiceTest.java
@@ -2,6 +2,7 @@ package au.org.raid.api.service.raid;
 
 import au.org.raid.api.client.ror.RorClient;
 import au.org.raid.api.dto.legacy.RaidDtoFactory;
+import au.org.raid.api.exception.ServicePointNotFoundException;
 import au.org.raid.api.exception.ValidationFailureException;
 import au.org.raid.api.factory.HandleFactory;
 import au.org.raid.api.factory.IdFactory;
@@ -816,6 +817,46 @@ class RaidServiceTest {
         assertThat(org.getServicePoints().get(1).getId(), is(20000002L));
         assertThat(org.getServicePoints().get(1).getName(), is("SP Two"));
         assertThat(org.getServicePoints().get(1).getCount(), is(25L));
+    }
+
+    @Test
+    @DisplayName("postToDatacite calls datacite update with correct handle, repositoryId and password")
+    void postToDatacite() {
+        final var servicePointId = 20_000_000L;
+        final var repositoryId = "repository-id";
+        final var password = "_password";
+
+        final var servicePointRecord = new ServicePointRecord()
+                .setRepositoryId(repositoryId)
+                .setPassword(password);
+
+        final var raid = new RaidUpdateRequest()
+                .identifier(new Id()
+                        .id("10.12345/abc123")
+                        .owner(new Owner()
+                                .servicePoint(BigDecimal.valueOf(servicePointId))));
+
+        when(servicePointRepository.findById(servicePointId)).thenReturn(Optional.of(servicePointRecord));
+
+        raidService.postToDatacite(raid);
+
+        verify(dataciteService).update(raid, "10.12345/abc123", repositoryId, password);
+    }
+
+    @Test
+    @DisplayName("postToDatacite throws ServicePointNotFoundException when service point not found")
+    void postToDatacite_throwsWhenServicePointNotFound() {
+        final var servicePointId = 99999L;
+
+        final var raid = new RaidUpdateRequest()
+                .identifier(new Id()
+                        .id("10.12345/abc123")
+                        .owner(new Owner()
+                                .servicePoint(BigDecimal.valueOf(servicePointId))));
+
+        when(servicePointRepository.findById(servicePointId)).thenReturn(Optional.empty());
+
+        assertThrows(ServicePointNotFoundException.class, () -> raidService.postToDatacite(raid));
     }
 
     private String raidJson() {


### PR DESCRIPTION
## Summary

- Changed `POST /raid/post-to-datacite` to accept `RaidUpdateRequest` instead of `RaidDto`, so old RAiDs with null `metadata` no longer fail Bean Validation during the DataCite backfill
- `RaidUpdateRequest` already marks `metadata` as optional, avoiding any change to the LinkML data model
- Fixed return type from `ResponseEntity<RaidDto>` to `ResponseEntity<Void>` to match the `noContent()` response

## Test plan

- [x] Unit tests pass (`./gradlew :api-svc:raid-api:test`)
- [ ] Deploy to demo and re-run `backfill-datacite.sh` to verify the 336 metadata-related 400 errors are resolved
- [ ] Run backfill against prod to register missing DOIs identified in RAID-554

🤖 Generated with [Claude Code](https://claude.com/claude-code)