### PR TITLE
Enabled caching and TTL for ORCID, ROR and service point fetch in the…

### DIFF
--- a/raid-agency-app-static/public/app-config.json
+++ b/raid-agency-app-static/public/app-config.json
@@ -12,7 +12,7 @@
   },
   "caching": {
     "enabled": true,
-    "ttlMs": 432000000
+    "ttlMs": 2592000000
   },
   "header": {
     "topBar": {

--- a/raid-agency-app-static/scripts/apiCache.js
+++ b/raid-agency-app-static/scripts/apiCache.js
@@ -1,18 +1,33 @@
 /**
  * API Response Cache Utility
- * 
+ *
  * Provides in-memory caching for ORCID and ROR API responses
- * to reduce redundant API calls and improve performance.
+ * with optional TTL enforcement and file persistence between builds.
  */
+
+import { readFile, writeFile } from 'fs/promises';
 
 class ApiCache {
   constructor() {
     this.cache = new Map();
+    this.ttlMs = 0; // 0 = no expiry (within-build dedup only)
     this.stats = {
       hits: 0,
       misses: 0,
       sets: 0
     };
+  }
+
+  /**
+   * Set TTL and other runtime options from config.
+   * Call this once after loadAppConfig(), before any get/set calls.
+   */
+  configure({ ttlMs }) {
+    this.ttlMs = ttlMs;
+  }
+
+  get size() {
+    return this.cache.size;
   }
 
   /**
@@ -23,34 +38,46 @@ class ApiCache {
   }
 
   /**
-   * Get cached value
+   * Get cached value. Returns null on miss or if the entry has expired.
    */
   get(key) {
     if (this.cache.has(key)) {
+      const entry = this.cache.get(key);
+      if (this.ttlMs > 0 && (Date.now() - entry.timestamp) >= this.ttlMs) {
+        this.cache.delete(key);
+        this.stats.misses++;
+        return null;
+      }
       this.stats.hits++;
-      return this.cache.get(key);
+      return entry.value;
     }
     this.stats.misses++;
     return null;
   }
 
   /**
-   * Set cached value
+   * Store a value with a timestamp so TTL can be checked later.
    */
   set(key, value) {
-    this.cache.set(key, value);
+    this.cache.set(key, { value, timestamp: Date.now() });
     this.stats.sets++;
   }
 
   /**
-   * Check if key exists
+   * Check if a non-expired entry exists for the key.
    */
   has(key) {
-    return this.cache.has(key);
+    if (!this.cache.has(key)) return false;
+    const entry = this.cache.get(key);
+    if (this.ttlMs > 0 && (Date.now() - entry.timestamp) >= this.ttlMs) {
+      this.cache.delete(key);
+      return false;
+    }
+    return true;
   }
 
   /**
-   * Clear all cache
+   * Clear all cache entries and reset stats.
    */
   clear() {
     this.cache.clear();
@@ -67,7 +94,7 @@ class ApiCache {
   getStats() {
     const total = this.stats.hits + this.stats.misses;
     const hitRate = total > 0 ? ((this.stats.hits / total) * 100).toFixed(2) : 0;
-    
+
     return {
       ...this.stats,
       size: this.cache.size,
@@ -86,9 +113,41 @@ class ApiCache {
     console.log(`  Misses: ${stats.misses}`);
     console.log(`  Hit Rate: ${stats.hitRate}`);
   }
+
+  /**
+   * Populate the cache from a JSON file written by saveToFile().
+   * Entries older than the configured TTL are skipped.
+   * Returns the number of entries loaded.
+   */
+  async loadFromFile(filePath) {
+    try {
+      const raw = await readFile(filePath, 'utf-8');
+      const data = JSON.parse(raw);
+      let loaded = 0;
+      for (const [key, entry] of Object.entries(data)) {
+        if (!this.ttlMs || (Date.now() - entry.timestamp) < this.ttlMs) {
+          this.cache.set(key, entry);
+          loaded++;
+        }
+      }
+      return loaded;
+    } catch {
+      return 0;
+    }
+  }
+
+  /**
+   * Persist the current cache to a JSON file so it can be reloaded
+   * on the next build. Returns the number of entries written.
+   */
+  async saveToFile(filePath) {
+    const data = Object.fromEntries(this.cache);
+    await writeFile(filePath, JSON.stringify(data, null, 2));
+    return this.cache.size;
+  }
 }
 
-// Singleton instances
+// Singleton instances shared across all fetcher modules
 const orcidCache = new ApiCache();
 const rorCache = new ApiCache();
 

--- a/raid-agency-app-static/scripts/fetch-raids.js
+++ b/raid-agency-app-static/scripts/fetch-raids.js
@@ -63,9 +63,16 @@ import { addRorDetailsToRaidData } from './fetch-ror.js';
 import { addServicePointNameToRaidData } from './fetch-sp.js';
 import { fetchEmbargoedRaids } from './fetch-embargoed-raids.js';
 import { loadAppConfig } from './loadAppConfig.js';
+import { orcidCache, rorCache } from './apiCache.js';
 
 // Load config from public/app-config.json (falls back to env vars)
 const config = loadAppConfig();
+
+// Configure ORCID and ROR caches with the TTL from app-config
+if (config.enableCaching) {
+  orcidCache.configure({ ttlMs: config.cachingTime });
+  rorCache.configure({ ttlMs: config.cachingTime });
+}
 
 // Simple in-memory cache for DOI citations
 const citationCache = new Map();
@@ -347,17 +354,35 @@ async function loadCache() {
     } catch (error) {
       // Cache file doesn't exist or is invalid, start fresh
     }
+
+    const orcidLoaded = await orcidCache.loadFromFile(path.join(config.dataDir, '.orcid-cache.json'));
+    if (orcidLoaded > 0) console.log(`ORCID cache loaded (${orcidLoaded} entries)`);
+
+    const rorLoaded = await rorCache.loadFromFile(path.join(config.dataDir, '.ror-cache.json'));
+    if (rorLoaded > 0) console.log(`ROR cache loaded (${rorLoaded} entries)`);
   }
 }
 
 // Load cache from file (if enabled and exists)
 // Save cache to file (if enabled)
 async function saveCache() {
-  if (config.enableCaching && citationCache.size > 0) {
-    const cacheFile = path.join(config.dataDir, '.citation-cache.json');
-    const cacheData = Object.fromEntries(citationCache);
-    await fs.writeFile(cacheFile, JSON.stringify(cacheData, null, 2));
-    console.log(`Citation cache saved (${citationCache.size} entries)`);
+  if (config.enableCaching) {
+    if (citationCache.size > 0) {
+      const cacheFile = path.join(config.dataDir, '.citation-cache.json');
+      const cacheData = Object.fromEntries(citationCache);
+      await fs.writeFile(cacheFile, JSON.stringify(cacheData, null, 2));
+      console.log(`Citation cache saved (${citationCache.size} entries)`);
+    }
+
+    if (orcidCache.size > 0) {
+      await orcidCache.saveToFile(path.join(config.dataDir, '.orcid-cache.json'));
+      console.log(`ORCID cache saved (${orcidCache.size} entries)`);
+    }
+
+    if (rorCache.size > 0) {
+      await rorCache.saveToFile(path.join(config.dataDir, '.ror-cache.json'));
+      console.log(`ROR cache saved (${rorCache.size} entries)`);
+    }
   }
 }
 // Main execution

--- a/raid-agency-app-static/scripts/fetch-sp.js
+++ b/raid-agency-app-static/scripts/fetch-sp.js
@@ -7,6 +7,9 @@
  * API: GET <apiEndpoint>/service-point
  */
 
+import { readFile, writeFile } from 'fs/promises';
+import path from 'path';
+
 /**
  * Fetch all service points and return a Map of id -> name.
  *
@@ -38,11 +41,38 @@ export async function fetchAllServicePoints({ makeRequestWithRetry, config }) {
   return servicePointMap;
 }
 
+const SP_CACHE_FILE = '.sp-cache.json';
+
+async function loadServicePointCache(config) {
+  if (!config.enableCaching) return null;
+  try {
+    const filePath = path.join(config.dataDir, SP_CACHE_FILE);
+    const raw = await readFile(filePath, 'utf-8');
+    const { timestamp, entries } = JSON.parse(raw);
+    if ((Date.now() - timestamp) < config.cachingTime) {
+      return new Map(entries);
+    }
+  } catch {
+    // File missing or expired — fall through to live fetch
+  }
+  return null;
+}
+
+async function saveServicePointCache(servicePointMap, config) {
+  if (!config.enableCaching) return;
+  const filePath = path.join(config.dataDir, SP_CACHE_FILE);
+  await writeFile(filePath, JSON.stringify({
+    timestamp: Date.now(),
+    entries: Array.from(servicePointMap.entries()),
+  }, null, 2));
+}
+
 /**
  * Enrich RAID data by adding the service point name to identifier.owner.
  *
- * Fetches all service points in one request, then applies names to
- * every RAID record.
+ * Loads from cache when caching is enabled and the cache is fresh;
+ * otherwise fetches all service points in one request, then applies
+ * names to every RAID record.
  *
  * @param {Array} raidData - Array of RAID records
  * @param {Function} makeRequestWithRetry - Shared HTTP helper
@@ -64,10 +94,14 @@ export async function addServicePointNameToRaidData(
   }
 
   try {
-    const servicePointMap = await fetchAllServicePoints({
-      makeRequestWithRetry,
-      config,
-    });
+    let servicePointMap = await loadServicePointCache(config);
+
+    if (servicePointMap) {
+      console.log(`Service point cache hit (${servicePointMap.size} entries)`);
+    } else {
+      servicePointMap = await fetchAllServicePoints({ makeRequestWithRetry, config });
+      await saveServicePointCache(servicePointMap, config);
+    }
 
     stats.totalServicePoints = servicePointMap.size;
     stats.successfulServicePointFetches = servicePointMap.size;


### PR DESCRIPTION
### `raid-agency-app-static`

- **`public/app-config.json`** — Updated default cache TTL from 5 days to 30 days
  (`2592000000 ms`). The `caching.enabled` and `caching.ttlMs` fields in
  `app-config.json` now control caching behaviour for all fetch modules.

- **`scripts/apiCache.js`** — Extended `ApiCache` with TTL enforcement, file
  persistence, and a `size` getter:
  - Added `configure({ ttlMs })` to apply the TTL from app-config at runtime.
  - Cache entries now store `{ value, timestamp }` so expiry can be checked on read.
  - Added `loadFromFile(filePath)` and `saveToFile(filePath)` to persist the cache
    between builds; stale entries (older than TTL) are discarded on load.

- **`scripts/fetch-raids.js`** — Wired ORCID and ROR caches into the build lifecycle:
  - Calls `orcidCache.configure()` and `rorCache.configure()` with the TTL from
    app-config after startup.
  - `loadCache()` now restores `.orcid-cache.json` and `.ror-cache.json` from disk
    at the start of each build.
  - `saveCache()` now persists both caches to disk at the end of each build.

- **`scripts/fetch-sp.js`** — Added file-based caching for service point data:
  - Loads `.sp-cache.json` if it exists and is within the configured TTL; skips the
    API call if the cache is still fresh.
  - Saves the full service point map to `.sp-cache.json` after a live fetch.