### PR TITLE
Notification service uplift

### DIFF
--- a/raid-agency-app/src/components/alert-notifications/Notifications.tsx
+++ b/raid-agency-app/src/components/alert-notifications/Notifications.tsx
@@ -114,7 +114,7 @@ export const NotificationBell: React.FC<NotificationBellProps> = ({ className })
                 Notifications
               </Typography>
               <Typography variant="caption" color="text.secondary">
-                {totalCount} pending {totalCount === 1 ? 'item' : 'items'}
+                {totalCount} pending {totalCount === 1 ? 'request' : 'requests'}
               </Typography>
             </Box>
           </Box>

--- a/raid-agency-app/src/components/alert-notifications/Notifications.tsx
+++ b/raid-agency-app/src/components/alert-notifications/Notifications.tsx
@@ -31,10 +31,26 @@ interface NotificationBellProps {
 
 export const NotificationBell: React.FC<NotificationBellProps> = ({ className }) => {
   const [open, setOpen] = useState(false);
+  const [topOffset, setTopOffset] = useState(0);
   const [expandedSections, setExpandedSections] = useState<{ [key: string]: boolean }>({});
   const [selectedTab, setSelectedTab] = useState<string>('');
   const { notifications, totalCount } = useNotificationContext();
   const navigate = useNavigate();
+
+  const handleOpen = () => {
+    // Measure AppBar height + Banner height (if shown in non-prod) so the drawer starts below both
+    const appBar = document.querySelector<HTMLElement>('[data-testid="app-nav-bar"]');
+    let offset = 0;
+    if (appBar) {
+      offset = appBar.getBoundingClientRect().bottom;
+      const next = appBar.nextElementSibling as HTMLElement | null;
+      if (next?.classList.contains('notification-banner')) {
+        offset += next.getBoundingClientRect().height;
+      }
+    }
+    setTopOffset(Math.max(0, offset));
+    setOpen(true);
+  };
 
   // Group notifications by type; untyped entries fall back to 'general'
   const groupedNotifications = Object.entries(notifications).reduce(
@@ -59,7 +75,7 @@ export const NotificationBell: React.FC<NotificationBellProps> = ({ className })
 
   return (
     <Box className={className}>
-      <IconButton onClick={() => setOpen(true)} sx={{ color: 'grey' }}>
+      <IconButton onClick={handleOpen} sx={{ color: 'grey' }}>
         <Badge badgeContent={totalCount} color="error">
           <NotificationsIcon />
         </Badge>
@@ -70,7 +86,13 @@ export const NotificationBell: React.FC<NotificationBellProps> = ({ className })
         open={open}
         onClose={() => setOpen(false)}
         PaperProps={{
-          sx: { width: { xs: '100vw', sm: 480 }, display: 'flex', flexDirection: 'column' },
+          sx: {
+            width: { xs: '100vw', sm: 480 },
+            top: `${topOffset}px`,
+            height: `calc(100% - ${topOffset}px)`,
+            display: 'flex',
+            flexDirection: 'column',
+          },
         }}
       >
         {/* Header */}

--- a/raid-agency-app/src/components/alert-notifications/Notifications.tsx
+++ b/raid-agency-app/src/components/alert-notifications/Notifications.tsx
@@ -3,10 +3,8 @@ import {
   Badge,
   Box,
   Chip,
+  Drawer,
   IconButton,
-  Popper,
-  Paper,
-  ClickAwayListener,
   Typography,
   Divider,
   Accordion,
@@ -32,14 +30,13 @@ interface NotificationBellProps {
 }
 
 export const NotificationBell: React.FC<NotificationBellProps> = ({ className }) => {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [open, setOpen] = useState(false);
   const [expandedSections, setExpandedSections] = useState<{ [key: string]: boolean }>({});
   const [selectedTab, setSelectedTab] = useState<string>('');
   const { notifications, totalCount } = useNotificationContext();
-  const open = Boolean(anchorEl);
   const navigate = useNavigate();
 
-  // Group notifications by type; fall back to 'general' / 'General' for untyped entries
+  // Group notifications by type; untyped entries fall back to 'general'
   const groupedNotifications = Object.entries(notifications).reduce(
     (acc, [key, notification]) => {
       const typeKey = notification.type ?? 'general';
@@ -54,16 +51,7 @@ export const NotificationBell: React.FC<NotificationBellProps> = ({ className })
   );
 
   const tabKeys = Object.keys(groupedNotifications);
-  // Derive the active tab: keep the current selection if it still exists, else use the first tab
   const activeTab = (selectedTab && groupedNotifications[selectedTab]) ? selectedTab : (tabKeys[0] ?? '');
-
-  const handleClick = (event: React.MouseEvent<HTMLElement>): void => {
-    setAnchorEl(anchorEl ? null : event.currentTarget);
-  };
-
-  const handleClose = (): void => {
-    setAnchorEl(null);
-  };
 
   const handleAccordionChange = (key: string) => (_event: React.SyntheticEvent, isExpanded: boolean) => {
     setExpandedSections(prev => ({ ...prev, [key]: isExpanded }));
@@ -71,218 +59,212 @@ export const NotificationBell: React.FC<NotificationBellProps> = ({ className })
 
   return (
     <Box className={className}>
-      <IconButton onClick={handleClick} sx={{ position: 'relative', color: 'grey' }}>
+      <IconButton onClick={() => setOpen(true)} sx={{ color: 'grey' }}>
         <Badge badgeContent={totalCount} color="error">
           <NotificationsIcon />
         </Badge>
       </IconButton>
 
-      <Popper
+      <Drawer
+        anchor="right"
         open={open}
-        anchorEl={anchorEl}
-        placement="bottom-end"
-        sx={{ zIndex: 1300 }}
+        onClose={() => setOpen(false)}
+        PaperProps={{
+          sx: { width: { xs: '100vw', sm: 480 }, display: 'flex', flexDirection: 'column' },
+        }}
       >
-        <ClickAwayListener onClickAway={handleClose}>
-          <Paper
-            elevation={8}
-            sx={{
-              width: 420,
-              maxWidth: '90vw',
-              maxHeight: 600,
-              mt: 1,
-              borderRadius: 2,
-              overflow: 'hidden',
-              display: 'flex',
-              flexDirection: 'column',
-            }}
-          >
-            {/* Header */}
-            <Box
-              sx={{
-                p: 2,
-                background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-                color: 'white',
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-              }}
-            >
-              <Box>
-                <Typography variant="h6" fontWeight={700}>
-                  Notifications
-                </Typography>
-                <Typography variant="caption" sx={{ opacity: 0.9 }}>
-                  {totalCount} total notifications
-                </Typography>
-              </Box>
-              <IconButton size="small" onClick={handleClose} sx={{ color: 'white' }}>
-                <CloseIcon fontSize="small" />
-              </IconButton>
+        {/* Header */}
+        <Box
+          sx={{
+            px: 3,
+            py: 2.5,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            borderBottom: 1,
+            borderColor: 'divider',
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            <NotificationsIcon color="primary" />
+            <Box>
+              <Typography variant="h6" fontWeight={700} lineHeight={1.2}>
+                Notifications
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {totalCount} pending {totalCount === 1 ? 'item' : 'items'}
+              </Typography>
             </Box>
+          </Box>
+          <IconButton onClick={() => setOpen(false)} size="small">
+            <CloseIcon />
+          </IconButton>
+        </Box>
 
-            {/* Content */}
-            <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', bgcolor: 'background.default' }}>
-              {totalCount === 0 ? (
-                <Box sx={{ p: 8, textAlign: 'center' }}>
-                  <NotificationsIcon sx={{ fontSize: 64, color: 'action.disabled', mb: 2 }} />
-                  <Typography color="text.secondary">No notifications</Typography>
-                </Box>
-              ) : (
-                <>
-                  {/* Notification type tabs */}
-                  <Tabs
-                    value={activeTab}
-                    onChange={(_e, v) => setSelectedTab(v)}
-                    variant="scrollable"
-                    scrollButtons="auto"
-                    sx={{ borderBottom: 1, borderColor: 'divider', bgcolor: 'background.paper', minHeight: 48 }}
-                  >
-                    {tabKeys.map((typeKey) => {
-                      const group = groupedNotifications[typeKey];
-                      const count = Object.values(group.items).reduce(
-                        (sum, n) => sum + n.categories.length, 0,
-                      );
-                      return (
-                        <Tab
-                          key={typeKey}
-                          value={typeKey}
-                          label={
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-                              <Typography variant="body2" fontWeight={500}>
-                                {group.label}
-                              </Typography>
-                              <Chip
-                                label={count}
-                                size="small"
-                                color="primary"
-                                sx={{ height: 18, minWidth: 24, fontSize: '0.7rem' }}
-                              />
-                            </Box>
-                          }
-                          sx={{ minHeight: 48, textTransform: 'none' }}
+        {totalCount === 0 ? (
+          <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 2, color: 'text.disabled' }}>
+            <NotificationsIcon sx={{ fontSize: 56 }} />
+            <Typography variant="body1">No notifications</Typography>
+          </Box>
+        ) : (
+          <>
+            {/* Notification type tabs */}
+            <Tabs
+              value={activeTab}
+              onChange={(_e, v) => setSelectedTab(v)}
+              variant="scrollable"
+              scrollButtons="auto"
+              sx={{ px: 2, borderBottom: 1, borderColor: 'divider' }}
+            >
+              {tabKeys.map((typeKey) => {
+                const group = groupedNotifications[typeKey];
+                const count = Object.values(group.items).reduce(
+                  (sum, n) => sum + n.categories.length, 0,
+                );
+                return (
+                  <Tab
+                    key={typeKey}
+                    value={typeKey}
+                    sx={{ textTransform: 'none', minHeight: 52 }}
+                    label={
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography variant="body2" fontWeight={500}>
+                          {group.label}
+                        </Typography>
+                        <Chip
+                          label={count}
+                          size="small"
+                          color="primary"
+                          sx={{ height: 20, minWidth: 26, fontSize: '0.7rem' }}
                         />
-                      );
-                    })}
-                  </Tabs>
+                      </Box>
+                    }
+                  />
+                );
+              })}
+            </Tabs>
 
-                  {/* Items for the selected tab */}
-                  <Box sx={{ flex: 1, overflow: 'auto', p: 1 }}>
-                    {Object.entries(groupedNotifications[activeTab]?.items ?? {}).map(([key, notification]) => (
-                      <Accordion
-                        disableGutters
-                        key={key}
-                        expanded={expandedSections[key] !== false}
-                        onChange={handleAccordionChange(key)}
-                        sx={{ mb: 1, '&:before': { display: 'none' }, boxShadow: 1 }}
-                      >
-                        <AccordionSummary
-                          expandIcon={<ExpandMoreIcon />}
-                          sx={{
-                            borderLeft: `${expandedSections[key] !== false ? 4 : 0}px solid`,
-                            borderColor: 'primary.main',
-                            '&:hover': { bgcolor: 'action.hover' },
-                          }}
-                        >
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
-                            <Typography variant="subtitle1" fontWeight={600} sx={{ flex: 1 }}>
-                              {notification.title}
-                            </Typography>
-                            <Chip
-                              label={notification.categories.length}
-                              size="small"
-                              color="primary"
-                              sx={{ minWidth: 25 }}
-                            />
-                          </Box>
-                        </AccordionSummary>
-                        <AccordionDetails sx={{ p: 0, bgcolor: 'background.default' }}>
-                          <List
+            {/* Accordions for the selected tab */}
+            <Box sx={{ flex: 1, overflowY: 'auto', px: 2, py: 2 }}>
+              {Object.entries(groupedNotifications[activeTab]?.items ?? {}).map(([key, notification]) => (
+                <Accordion
+                  disableGutters
+                  key={key}
+                  expanded={expandedSections[key] === true}
+                  onChange={handleAccordionChange(key)}
+                  elevation={0}
+                  sx={{
+                    mb: 1.5,
+                    border: 1,
+                    borderColor: 'divider',
+                    borderRadius: '8px !important',
+                    '&:before': { display: 'none' },
+                    '&.Mui-expanded': { borderColor: 'primary.main' },
+                  }}
+                >
+                  <AccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    sx={{ px: 2, py: 0.5, borderRadius: 2 }}
+                  >
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, width: '100%', pr: 1 }}>
+                      <Typography variant="subtitle2" fontWeight={600} sx={{ flex: 1 }}>
+                        {notification.title}
+                      </Typography>
+                      <Chip
+                        label={`${notification.categories.length} pending`}
+                        size="small"
+                        variant="outlined"
+                        color="default"
+                        sx={{ fontSize: '0.7rem' }}
+                      />
+                    </Box>
+                  </AccordionSummary>
+
+                  <AccordionDetails sx={{ p: 0 }}>
+                    <Divider />
+                    <List disablePadding>
+                      {notification.categories.map((category, index) => (
+                        <React.Fragment key={index}>
+                          <ListItem
                             sx={{
-                              p: 1,
-                              maxHeight: 200,
-                              overflowY: 'auto',
-                              '&::-webkit-scrollbar': { width: '8px' },
-                              '&::-webkit-scrollbar-track': { backgroundColor: 'background.default', borderRadius: '4px' },
-                              '&::-webkit-scrollbar-thumb': {
-                                backgroundColor: 'action.hover',
-                                borderRadius: '4px',
-                                '&:hover': { backgroundColor: 'action.selected' },
-                              },
+                              px: 2,
+                              py: 1.5,
+                              gap: 1,
+                              '&:hover': { bgcolor: 'action.hover' },
                             }}
                           >
-                            {notification.categories.map((category, index) => (
-                              <ListItem
-                                key={index}
+                            <ListItemIcon sx={{ minWidth: 44 }}>
+                              <Box
                                 sx={{
-                                  bgcolor: 'background.paper',
-                                  mb: 1,
-                                  borderRadius: 1,
-                                  '&:hover': { boxShadow: 2 },
-                                  '&:last-child': { mb: 0 },
+                                  width: 36,
+                                  height: 36,
+                                  borderRadius: '50%',
+                                  bgcolor: 'primary.50',
+                                  color: 'primary.main',
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  justifyContent: 'center',
                                 }}
                               >
-                                <ListItemIcon sx={{ minWidth: 48 }}>
-                                  <Box
-                                    sx={{
-                                      width: 40,
-                                      height: 40,
-                                      borderRadius: '50%',
-                                      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-                                      color: 'white',
-                                      display: 'flex',
-                                      alignItems: 'center',
-                                      justifyContent: 'center',
-                                    }}
-                                  >
-                                    {category.titleIcon}
-                                  </Box>
-                                </ListItemIcon>
-                                <ListItemText
-                                  primary={
-                                    <Typography variant="body1" fontWeight={600} sx={{ wordBreak: 'break-word' }}>
-                                      {category.name}
-                                    </Typography>
-                                  }
-                                />
-                                {category.actions && (
-                                  <Box sx={{ display: 'flex', gap: 0.5, ml: 1 }}>
-                                    {category.actions}
-                                  </Box>
-                                )}
-                                {category.button && (
-                                  <Box sx={{ ml: 1 }}>
-                                    {category.button}
-                                  </Box>
-                                )}
-                                <Divider />
-                              </ListItem>
-                            ))}
-                          </List>
-                        </AccordionDetails>
-                      </Accordion>
-                    ))}
-                  </Box>
-                </>
-              )}
+                                {category.titleIcon}
+                              </Box>
+                            </ListItemIcon>
+                            <ListItemText
+                              primary={
+                                <Typography variant="body2" fontWeight={600}>
+                                  {category.name}
+                                </Typography>
+                              }
+                              secondary={
+                                category.email
+                                  ? <Typography variant="caption" color="text.secondary">{category.email}</Typography>
+                                  : undefined
+                              }
+                            />
+                            {category.actions && (
+                              <Box sx={{ display: 'flex', gap: 0.75, flexShrink: 0 }}>
+                                {category.actions}
+                              </Box>
+                            )}
+                            {category.button && (
+                              <Box sx={{ flexShrink: 0 }}>
+                                {category.button}
+                              </Box>
+                            )}
+                          </ListItem>
+                          {index < notification.categories.length - 1 && (
+                            <Divider variant="inset" component="li" />
+                          )}
+                        </React.Fragment>
+                      ))}
+                    </List>
+                  </AccordionDetails>
+                </Accordion>
+              ))}
             </Box>
 
             {/* Footer */}
-            {totalCount > 0 && (
-              <Box sx={{ p: 1.5, textAlign: 'center', bgcolor: 'background.paper' }}>
-                <Typography
-                  variant="body2"
-                  color="primary"
-                  sx={{ cursor: 'pointer' }}
-                  onClick={() => { navigate("/service-points"); }}
-                >
-                  View All Notifications
-                </Typography>
-              </Box>
-            )}
-          </Paper>
-        </ClickAwayListener>
-      </Popper>
+            <Box
+              sx={{
+                px: 3,
+                py: 2,
+                borderTop: 1,
+                borderColor: 'divider',
+                textAlign: 'center',
+              }}
+            >
+              <Typography
+                variant="body2"
+                color="primary"
+                sx={{ cursor: 'pointer', fontWeight: 500 }}
+                onClick={() => { setOpen(false); navigate("/service-points"); }}
+              >
+                View all in Service Points
+              </Typography>
+            </Box>
+          </>
+        )}
+      </Drawer>
     </Box>
   );
 };

--- a/raid-agency-app/src/components/alert-notifications/Notifications.tsx
+++ b/raid-agency-app/src/components/alert-notifications/Notifications.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 import {
   Badge,
+  Box,
+  Chip,
   IconButton,
   Popper,
   Paper,
   ClickAwayListener,
-  Box,
   Typography,
   Divider,
   Accordion,
@@ -15,7 +16,8 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  Chip,
+  Tab,
+  Tabs,
 } from '@mui/material';
 import {
   Notifications as NotificationsIcon,
@@ -32,9 +34,29 @@ interface NotificationBellProps {
 export const NotificationBell: React.FC<NotificationBellProps> = ({ className }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [expandedSections, setExpandedSections] = useState<{ [key: string]: boolean }>({});
+  const [selectedTab, setSelectedTab] = useState<string>('');
   const { notifications, totalCount } = useNotificationContext();
   const open = Boolean(anchorEl);
   const navigate = useNavigate();
+
+  // Group notifications by type; fall back to 'general' / 'General' for untyped entries
+  const groupedNotifications = Object.entries(notifications).reduce(
+    (acc, [key, notification]) => {
+      const typeKey = notification.type ?? 'general';
+      const typeLabel = notification.typeLabel ?? 'General';
+      if (!acc[typeKey]) {
+        acc[typeKey] = { label: typeLabel, items: {} };
+      }
+      acc[typeKey].items[key] = notification;
+      return acc;
+    },
+    {} as Record<string, { label: string; items: Record<string, typeof notifications[string]> }>,
+  );
+
+  const tabKeys = Object.keys(groupedNotifications);
+  // Derive the active tab: keep the current selection if it still exists, else use the first tab
+  const activeTab = (selectedTab && groupedNotifications[selectedTab]) ? selectedTab : (tabKeys[0] ?? '');
+
   const handleClick = (event: React.MouseEvent<HTMLElement>): void => {
     setAnchorEl(anchorEl ? null : event.currentTarget);
   };
@@ -43,11 +65,8 @@ export const NotificationBell: React.FC<NotificationBellProps> = ({ className })
     setAnchorEl(null);
   };
 
-  const handleAccordionChange = (key: string) => (event: React.SyntheticEvent, isExpanded: boolean) => {
-    setExpandedSections(prev => ({
-      ...prev,
-      [key]: isExpanded,
-    }));
+  const handleAccordionChange = (key: string) => (_event: React.SyntheticEvent, isExpanded: boolean) => {
+    setExpandedSections(prev => ({ ...prev, [key]: isExpanded }));
   };
 
   return (
@@ -58,10 +77,10 @@ export const NotificationBell: React.FC<NotificationBellProps> = ({ className })
         </Badge>
       </IconButton>
 
-      <Popper 
-        open={open} 
-        anchorEl={anchorEl} 
-        placement="bottom-end" 
+      <Popper
+        open={open}
+        anchorEl={anchorEl}
+        placement="bottom-end"
         sx={{ zIndex: 1300 }}
       >
         <ClickAwayListener onClickAway={handleClose}>
@@ -103,138 +122,163 @@ export const NotificationBell: React.FC<NotificationBellProps> = ({ className })
             </Box>
 
             {/* Content */}
-            <Box sx={{ flex: 1, overflow: 'auto', bgcolor: 'background.default' }}>
+            <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', bgcolor: 'background.default' }}>
               {totalCount === 0 ? (
                 <Box sx={{ p: 8, textAlign: 'center' }}>
                   <NotificationsIcon sx={{ fontSize: 64, color: 'action.disabled', mb: 2 }} />
                   <Typography color="text.secondary">No notifications</Typography>
                 </Box>
               ) : (
-                <Box sx={{ p: 1 }}>
-                  {Object.entries(notifications).map(([key, notification]) => (
-                    <Accordion
-                      disableGutters={true}
-                      key={key}
-                      expanded={expandedSections[key] !== false}
-                      onChange={handleAccordionChange(key)}
-                      sx={{
-                        mb: 1,
-                        '&:before': { display: 'none' },
-                        boxShadow: 1,
-                      }}
-                    >
-                      <AccordionSummary
-                        expandIcon={<ExpandMoreIcon />}
-                        sx={{
-                          borderLeft: `${expandedSections[key] ? 4 : 0}px solid`,
-                          borderColor: 'primary.main',
-                          '&:hover': { bgcolor: 'action.hover' },
-                        }}
+                <>
+                  {/* Notification type tabs */}
+                  <Tabs
+                    value={activeTab}
+                    onChange={(_e, v) => setSelectedTab(v)}
+                    variant="scrollable"
+                    scrollButtons="auto"
+                    sx={{ borderBottom: 1, borderColor: 'divider', bgcolor: 'background.paper', minHeight: 48 }}
+                  >
+                    {tabKeys.map((typeKey) => {
+                      const group = groupedNotifications[typeKey];
+                      const count = Object.values(group.items).reduce(
+                        (sum, n) => sum + n.categories.length, 0,
+                      );
+                      return (
+                        <Tab
+                          key={typeKey}
+                          value={typeKey}
+                          label={
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                              <Typography variant="body2" fontWeight={500}>
+                                {group.label}
+                              </Typography>
+                              <Chip
+                                label={count}
+                                size="small"
+                                color="primary"
+                                sx={{ height: 18, minWidth: 24, fontSize: '0.7rem' }}
+                              />
+                            </Box>
+                          }
+                          sx={{ minHeight: 48, textTransform: 'none' }}
+                        />
+                      );
+                    })}
+                  </Tabs>
+
+                  {/* Items for the selected tab */}
+                  <Box sx={{ flex: 1, overflow: 'auto', p: 1 }}>
+                    {Object.entries(groupedNotifications[activeTab]?.items ?? {}).map(([key, notification]) => (
+                      <Accordion
+                        disableGutters
+                        key={key}
+                        expanded={expandedSections[key] !== false}
+                        onChange={handleAccordionChange(key)}
+                        sx={{ mb: 1, '&:before': { display: 'none' }, boxShadow: 1 }}
                       >
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
-                          <Typography variant="subtitle1" fontWeight={600} sx={{ flex: 1 }}>
-                            {notification.title}
-                          </Typography>
-                          <Chip
-                            label={notification.categories.length}
-                            size="small"
-                            color="primary"
-                            sx={{ minWidth: 25 }}
-                          />
-                        </Box>
-                      </AccordionSummary>
-                      <AccordionDetails sx={{ p: 0, bgcolor: 'background.default' }}>
-                        <List
-                          sx={{ 
-                            p: 1,
-                            maxHeight: 200, // Set maximum height (adjust as needed)
-                            overflowY: 'auto', // Enable vertical scrolling
-                            '&::-webkit-scrollbar': {
-                              width: '8px',
-                            },
-                            '&::-webkit-scrollbar-track': {
-                              backgroundColor: 'background.default',
-                              borderRadius: '4px',
-                            },
-                            '&::-webkit-scrollbar-thumb': {
-                              backgroundColor: 'action.hover',
-                              borderRadius: '4px',
-                              '&:hover': {
-                                backgroundColor: 'action.selected',
-                              },
-                            },
+                        <AccordionSummary
+                          expandIcon={<ExpandMoreIcon />}
+                          sx={{
+                            borderLeft: `${expandedSections[key] !== false ? 4 : 0}px solid`,
+                            borderColor: 'primary.main',
+                            '&:hover': { bgcolor: 'action.hover' },
                           }}
                         >
-                          {notification.categories.map((category, index) => (
-                            <ListItem
-                              key={index}
-                              sx={{
-                                bgcolor: 'background.paper',
-                                mb: 1,
-                                borderRadius: 1,
-                                border: 0,
-                                borderColor: 'divider',
-                                '&:hover': {
-                                  boxShadow: 2,
-                                },
-                                '&:last-child': {
-                                  mb: 0,
-                                },
-                              }}
-                            >
-                              <ListItemIcon sx={{ minWidth: 48 }}>
-                                <Box
-                                  sx={{
-                                    width: 40,
-                                    height: 40,
-                                    borderRadius: '50%',
-                                    background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-                                    color: 'white',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                  }}
-                                >
-                                  {category.titleIcon}
-                                </Box>
-                              </ListItemIcon>
-                              <ListItemText
-                                primary={
-                                  <Typography variant="body1" fontWeight={600} sx={{ wordBreak: 'break-word' }}>
-                                    {category.name}
-                                  </Typography>
-                                }
-                              />
-                              {category.actions && (
-                                <Box sx={{ display: 'flex', gap: 0.5, ml: 1 }}>
-                                  {category.actions}
-                                </Box>
-                              )}
-                              {category.button && (
-                                <Box sx={{ ml: 1 }}>
-                                  {category.button}
-                                </Box>
-                              )}
-                              <Divider />
-                            </ListItem>
-                          ))}
-                        </List>
-                      </AccordionDetails>
-                    </Accordion>
-                  ))}
-                </Box>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+                            <Typography variant="subtitle1" fontWeight={600} sx={{ flex: 1 }}>
+                              {notification.title}
+                            </Typography>
+                            <Chip
+                              label={notification.categories.length}
+                              size="small"
+                              color="primary"
+                              sx={{ minWidth: 25 }}
+                            />
+                          </Box>
+                        </AccordionSummary>
+                        <AccordionDetails sx={{ p: 0, bgcolor: 'background.default' }}>
+                          <List
+                            sx={{
+                              p: 1,
+                              maxHeight: 200,
+                              overflowY: 'auto',
+                              '&::-webkit-scrollbar': { width: '8px' },
+                              '&::-webkit-scrollbar-track': { backgroundColor: 'background.default', borderRadius: '4px' },
+                              '&::-webkit-scrollbar-thumb': {
+                                backgroundColor: 'action.hover',
+                                borderRadius: '4px',
+                                '&:hover': { backgroundColor: 'action.selected' },
+                              },
+                            }}
+                          >
+                            {notification.categories.map((category, index) => (
+                              <ListItem
+                                key={index}
+                                sx={{
+                                  bgcolor: 'background.paper',
+                                  mb: 1,
+                                  borderRadius: 1,
+                                  '&:hover': { boxShadow: 2 },
+                                  '&:last-child': { mb: 0 },
+                                }}
+                              >
+                                <ListItemIcon sx={{ minWidth: 48 }}>
+                                  <Box
+                                    sx={{
+                                      width: 40,
+                                      height: 40,
+                                      borderRadius: '50%',
+                                      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                                      color: 'white',
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      justifyContent: 'center',
+                                    }}
+                                  >
+                                    {category.titleIcon}
+                                  </Box>
+                                </ListItemIcon>
+                                <ListItemText
+                                  primary={
+                                    <Typography variant="body1" fontWeight={600} sx={{ wordBreak: 'break-word' }}>
+                                      {category.name}
+                                    </Typography>
+                                  }
+                                />
+                                {category.actions && (
+                                  <Box sx={{ display: 'flex', gap: 0.5, ml: 1 }}>
+                                    {category.actions}
+                                  </Box>
+                                )}
+                                {category.button && (
+                                  <Box sx={{ ml: 1 }}>
+                                    {category.button}
+                                  </Box>
+                                )}
+                                <Divider />
+                              </ListItem>
+                            ))}
+                          </List>
+                        </AccordionDetails>
+                      </Accordion>
+                    ))}
+                  </Box>
+                </>
               )}
             </Box>
 
-            {/* Footer (Optional) */}
+            {/* Footer */}
             {totalCount > 0 && (
-              <>
-                <Box sx={{ p: 1.5, textAlign: 'center', bgcolor: 'background.paper' }}>
-                  <Typography variant="body2" color="primary" sx={{ cursor: 'pointer' }} onClick={() => {navigate("/service-points")}}>
-                    View All Notifications
-                  </Typography>
-                </Box>
-              </>
+              <Box sx={{ p: 1.5, textAlign: 'center', bgcolor: 'background.paper' }}>
+                <Typography
+                  variant="body2"
+                  color="primary"
+                  sx={{ cursor: 'pointer' }}
+                  onClick={() => { navigate("/service-points"); }}
+                >
+                  View All Notifications
+                </Typography>
+              </Box>
             )}
           </Paper>
         </ClickAwayListener>

--- a/raid-agency-app/src/components/alert-notifications/notification-context/inferface.ts
+++ b/raid-agency-app/src/components/alert-notifications/notification-context/inferface.ts
@@ -11,6 +11,10 @@ export interface NotificationCategory {
 
 export interface Notification {
   title: string;
+  /** Identifies which tab this notification belongs to, e.g. 'membership-requests' */
+  type?: string;
+  /** Human-readable label shown on the tab, e.g. 'Membership Requests' */
+  typeLabel?: string;
   categories: NotificationCategory[];
 }
 

--- a/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
+++ b/raid-agency-app/src/shared/service-point/service-point-pending-request.tsx
@@ -52,27 +52,38 @@ export const useServicePointPendingRequest = () => {
             ? servicePointsQuery.data
             : [servicePointsQuery.data];
 
-        const adminGroup = servicePoints.find((sp) => {
-            if (sp?.id.toString() === groupId) {
-                sp.members.forEach((member) => {
-                    member.groupId = groupId;
-                });
-                return true;
-            }
-            return false;
-        }) as ServicePointWithMembers | undefined;
-        const accumulatedMembers = servicePoints?.reduce<ServicePointMember[]>((acc, sp) => {
-            if (sp.members && sp.members.length > 0) {
-                const members = sp.members.map(member => ({
+        if (isOperator) {
+            // One notification per service point so operators can see which SP each request belongs to
+            servicePoints.forEach((sp) => {
+                const spMembers = (sp.members ?? []).map(member => ({
                     ...member,
                     groupId: sp.groupId,
-                } as unknown as ServicePointMember))
-                return [...acc, ...members];
-            }
-            return acc;
-        }, [] as ServicePointMember[]);
-        isOperator && transformMemberToNotification(accumulatedMembers as unknown as ServicePointMember[], token as string);
-        isGroupAdmin && transformMemberToNotification(adminGroup?.members  as unknown as ServicePointMember[] || [], token as string);
+                })) as unknown as ServicePointMember[];
+                transformMemberToNotification(
+                    spMembers,
+                    token as string,
+                    sp.name || 'Service Point',
+                    `servicePointRequests_${sp.groupId || sp.id}`,
+                );
+            });
+        } else if (isGroupAdmin) {
+            const adminGroup = servicePoints.find((sp) => {
+                if (sp?.id.toString() === groupId) {
+                    sp.members.forEach((member) => {
+                        member.groupId = groupId;
+                    });
+                    return true;
+                }
+                return false;
+            }) as ServicePointWithMembers | undefined;
+            const spName = adminGroup?.name || (servicePointsQuery.data as ServicePointWithMembers)?.name || 'Service Point';
+            transformMemberToNotification(
+                adminGroup?.members as unknown as ServicePointMember[] ?? [],
+                token as string,
+                spName,
+                `servicePointRequests_${groupId}`,
+            );
+        }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [servicePointsQuery.data, isOperator, isGroupAdmin]);
 

--- a/raid-agency-app/src/shared/service-point/servicePointNotificationService.tsx
+++ b/raid-agency-app/src/shared/service-point/servicePointNotificationService.tsx
@@ -44,7 +44,7 @@ export const useServicePointNotification = () => {
     const notification = {
       title: servicePointName,
       type: 'membership-requests',
-      typeLabel: 'Membership Requests',
+      typeLabel: 'Service Point Requests',
       categories: pendingMembers?.map(member => ({
         titleIcon: <PersonAddIcon />,
         name: `${member.attributes.username || ''} (${member.attributes.firstName || ''} ${member.attributes.lastName || ''})`.replace(/\(\s*\)/g, '').trim(),

--- a/raid-agency-app/src/shared/service-point/servicePointNotificationService.tsx
+++ b/raid-agency-app/src/shared/service-point/servicePointNotificationService.tsx
@@ -28,23 +28,21 @@ export const useServicePointNotification = () => {
   const IsnackBar = snackbar as { openSnackbar: (message: string, duration?: number, severity?: string) => void };
   const modifyUserAccessMutation = useModifyUserAccess(IsnackBar);
   const removeUserFromServicePointMutation = useRemoveUserFromServicePoint(IsnackBar);
-  const pendingMembers = [] as ServicePointMember[];
   // Transform service point members to notifications
-  const transformMemberToNotification = (data: ServicePointMember[], token: string) => {
-    // Filter members without 'service-point-user' role
+  const transformMemberToNotification = (data: ServicePointMember[], token: string, servicePointName: string, notificationKey: string) => {
+    // Filter members without any of the required roles
     const requiredRoles = ["service-point-user", "group-admin", "operator"];
-    pendingMembers.push(...data?.filter(
+    const pendingMembers = data?.filter(
       member => !member.roles.some(role => requiredRoles.includes(role))
-    ) || [] as ServicePointMember[]);
+    ) ?? [];
     // If no pending members, remove notification and return
-    if (pendingMembers?.length === 0) {
-      // Remove notification if no pending members
-      removeNotification('servicePointRequests');
+    if (pendingMembers.length === 0) {
+      removeNotification(notificationKey);
       return;
     }
     // Create notification object
     const notification = {
-      title: 'Service Point Pending Requests',
+      title: servicePointName,
       categories: pendingMembers?.map(member => ({
         titleIcon: <PersonAddIcon />,
         name: `${member.attributes.username || ''} (${member.attributes.firstName || ''} ${member.attributes.lastName || ''})`.replace(/\(\s*\)/g, '').trim(),
@@ -100,7 +98,7 @@ export const useServicePointNotification = () => {
       })),
     };
 
-    addNotification('servicePointRequests', notification);
+    addNotification(notificationKey, notification);
   };
 
   const handleApprove = ({ member, token }: {

--- a/raid-agency-app/src/shared/service-point/servicePointNotificationService.tsx
+++ b/raid-agency-app/src/shared/service-point/servicePointNotificationService.tsx
@@ -43,6 +43,8 @@ export const useServicePointNotification = () => {
     // Create notification object
     const notification = {
       title: servicePointName,
+      type: 'membership-requests',
+      typeLabel: 'Membership Requests',
       categories: pendingMembers?.map(member => ({
         titleIcon: <PersonAddIcon />,
         name: `${member.attributes.username || ''} (${member.attributes.firstName || ''} ${member.attributes.lastName || ''})`.replace(/\(\s*\)/g, '').trim(),


### PR DESCRIPTION
### Changes

- **`src/shared/service-point/servicePointNotificationService.tsx`**
  - Updated `transformMemberToNotification` to accept `servicePointName` and `notificationKey`
    parameters, replacing the hardcoded `'servicePointRequests'` key and `'Service Point Pending
    Requests'` title
  - Fixed a bug where `pendingMembers` was declared at hook scope and accumulated duplicate entries
    across every 30-second poll cycle; it is now computed fresh inside the function on each call

- **`src/shared/service-point/service-point-pending-request.tsx`**
  - Operator path: replaced the flat member accumulation with a per-service-point loop; each
    service point now registers its own notification entry using the SP name as the title and
    `servicePointRequests_<groupId>` as the key
  - Group admin path: updated to pass the SP name (from the API response) and a stable
    `servicePointRequests_<groupId>` key, matching the updated signature

### Behaviour

**Before:** All pending membership requests across all service points were merged into a single
accordion labelled "Service Point Pending Requests", with no indication of which service point
each request belonged to.

**After:** Each service point with pending requests renders as its own accordion in the
notification panel, labelled with the service point name (e.g. "University of Melbourne"). The
badge count and panel layout are unchanged.

### Bug fixed

The `pendingMembers` array was initialised once at hook mount and pushed to on every poll without
being reset. After multiple poll cycles the notification list contained duplicate entries for every
pending member. This is resolved by computing pending members inline on each call.