### PR TITLE
RAID-719: Create scoped service-point-admin role on group creation (dual-write)

### DIFF
--- a/iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.ext.Provider;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.services.managers.AppAuthManager;
@@ -26,6 +27,9 @@ public class GroupController {
     private static final String OPERATOR_ROLE_NAME = "operator";
     private static final String GROUP_ADMIN_ROLE_NAME = "group-admin";
     private static final String SERVICE_POINT_USER_ROLE = "service-point-user";
+    // Scoped role name format: "service-point-admin:<groupId>". Granted alongside the flat
+    // GROUP_ADMIN_ROLE_NAME on group creation (additive only - not yet enforced anywhere).
+    private static final String SERVICE_POINT_ADMIN_ROLE_PREFIX = "service-point-admin";
     private final AuthenticationManager.AuthResult auth;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -429,6 +433,28 @@ public class GroupController {
                 .toList().isEmpty();
     }
 
+    /**
+     * Looks up the realm role scoped to a single service point group
+     * ("service-point-admin:<groupId>"), creating it if it does not already exist.
+     */
+    private RoleModel getOrCreateServicePointAdminRole(final RealmModel realm, final String groupId) {
+        final var roleName = servicePointAdminRoleName(groupId);
+        final var existingRole = realm.getRole(roleName);
+        if (existingRole != null) {
+            return existingRole;
+        }
+
+        // Note: RoleContainerModel#addRole(String, String) is (id, name) - not (name, description).
+        // Use the single-arg overload (generated id, given name) and set the description separately.
+        final var role = realm.addRole(roleName);
+        role.setDescription("Service point admin for group " + groupId);
+        return role;
+    }
+
+    private static String servicePointAdminRoleName(final String groupId) {
+        return SERVICE_POINT_ADMIN_ROLE_PREFIX + ":" + groupId;
+    }
+
     @OPTIONS
     @Path("/create")
     public Response createGroupPreflight() {
@@ -504,6 +530,12 @@ public class GroupController {
             if (groupAdminRole.isPresent()) {
                 user.grantRole(groupAdminRole.get());
             }
+
+            // Also grant the scoped service-point-admin role for the new group. This is a
+            // dual-write alongside the flat group-admin role above for backward compatibility -
+            // no enforcement changes are made as part of this ticket.
+            final var servicePointAdminRole = getOrCreateServicePointAdminRole(realm, newGroup.getId());
+            user.grantRole(servicePointAdminRole);
 
             // Prepare response
             CreateGroupResponse response = new CreateGroupResponse(

--- a/iam/src/test/java/au/org/raid/iam/provider/group/GroupControllerTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/group/GroupControllerTest.java
@@ -459,11 +459,118 @@ class GroupControllerTest {
         when(roleProvider.getRealmRolesStream(eq(realm), any(), any()))
                 .thenReturn(Stream.of(groupAdminRole));
 
+        when(realm.getRole("service-point-admin:new-id")).thenReturn(null);
+        var servicePointAdminRole = mock(RoleModel.class);
+        when(realm.addRole("service-point-admin:new-id"))
+                .thenReturn(servicePointAdminRole);
+
         var request = new CreateGroupRequest("New Group", "/new-group");
         var response = controller.createGroup(request);
         assertThat(response.getStatus(), is(201));
         verify(user).joinGroup(newGroup);
         verify(user).grantRole(groupAdminRole);
+        verify(user).grantRole(servicePointAdminRole);
+        verify(servicePointAdminRole).setDescription("Service point admin for group new-id");
+    }
+
+    @Test
+    void createGroup_grantsBothGroupAdminAndScopedServicePointAdminRoles() {
+        var controller = createAuthenticatedController();
+        setupOperatorRole();
+        when(session.groups()).thenReturn(groupProvider);
+        when(session.roles()).thenReturn(roleProvider);
+
+        when(groupProvider.getGroupsStream(realm)).thenReturn(Stream.empty());
+
+        var newGroup = mock(GroupModel.class);
+        when(newGroup.getId()).thenReturn("new-group-id");
+        when(newGroup.getName()).thenReturn("New Group");
+        when(newGroup.getAttributes()).thenReturn(Map.of());
+        when(groupProvider.createGroup(realm, "New Group")).thenReturn(newGroup);
+
+        var groupAdminRole = mock(RoleModel.class);
+        when(groupAdminRole.getName()).thenReturn("group-admin");
+        when(roleProvider.getRealmRolesStream(eq(realm), any(), any()))
+                .thenReturn(Stream.of(groupAdminRole));
+
+        when(realm.getRole("service-point-admin:new-group-id")).thenReturn(null);
+        var servicePointAdminRole = mock(RoleModel.class);
+        when(realm.addRole("service-point-admin:new-group-id"))
+                .thenReturn(servicePointAdminRole);
+
+        var request = new CreateGroupRequest("New Group", "/new-group");
+        var response = controller.createGroup(request);
+
+        assertThat(response.getStatus(), is(201));
+        verify(user).grantRole(groupAdminRole);
+        verify(user).grantRole(servicePointAdminRole);
+    }
+
+    @Test
+    void createGroup_createsScopedServicePointAdminRoleWhenAbsent() {
+        var controller = createAuthenticatedController();
+        setupOperatorRole();
+        when(session.groups()).thenReturn(groupProvider);
+        when(session.roles()).thenReturn(roleProvider);
+
+        when(groupProvider.getGroupsStream(realm)).thenReturn(Stream.empty());
+
+        var newGroup = mock(GroupModel.class);
+        when(newGroup.getId()).thenReturn("new-group-id");
+        when(newGroup.getName()).thenReturn("New Group");
+        when(newGroup.getAttributes()).thenReturn(Map.of());
+        when(groupProvider.createGroup(realm, "New Group")).thenReturn(newGroup);
+
+        when(roleProvider.getRealmRolesStream(eq(realm), any(), any()))
+                .thenReturn(Stream.empty());
+
+        when(realm.getRole("service-point-admin:new-group-id")).thenReturn(null);
+        var servicePointAdminRole = mock(RoleModel.class);
+        when(realm.addRole("service-point-admin:new-group-id"))
+                .thenReturn(servicePointAdminRole);
+
+        var request = new CreateGroupRequest("New Group", "/new-group");
+        var response = controller.createGroup(request);
+
+        assertThat(response.getStatus(), is(201));
+        // Verifies the single-arg addRole(name) overload is used - RoleContainerModel's two-arg
+        // overload is addRole(id, name), not addRole(name, description), so calling it with the
+        // role name and a description sentence would silently corrupt the role's id/name.
+        verify(realm).addRole("service-point-admin:new-group-id");
+        verify(realm, never()).addRole(anyString(), anyString());
+        verify(servicePointAdminRole).setDescription("Service point admin for group new-group-id");
+        verify(user).grantRole(servicePointAdminRole);
+    }
+
+    @Test
+    void createGroup_reusesExistingScopedServicePointAdminRole() {
+        var controller = createAuthenticatedController();
+        setupOperatorRole();
+        when(session.groups()).thenReturn(groupProvider);
+        when(session.roles()).thenReturn(roleProvider);
+
+        when(groupProvider.getGroupsStream(realm)).thenReturn(Stream.empty());
+
+        var newGroup = mock(GroupModel.class);
+        when(newGroup.getId()).thenReturn("new-group-id");
+        when(newGroup.getName()).thenReturn("New Group");
+        when(newGroup.getAttributes()).thenReturn(Map.of());
+        when(groupProvider.createGroup(realm, "New Group")).thenReturn(newGroup);
+
+        when(roleProvider.getRealmRolesStream(eq(realm), any(), any()))
+                .thenReturn(Stream.empty());
+
+        var existingServicePointAdminRole = mock(RoleModel.class);
+        when(realm.getRole("service-point-admin:new-group-id")).thenReturn(existingServicePointAdminRole);
+
+        var request = new CreateGroupRequest("New Group", "/new-group");
+        var response = controller.createGroup(request);
+
+        assertThat(response.getStatus(), is(201));
+        verify(realm, never()).addRole(anyString());
+        verify(realm, never()).addRole(anyString(), anyString());
+        verify(existingServicePointAdminRole, never()).setDescription(anyString());
+        verify(user).grantRole(existingServicePointAdminRole);
     }
 
     // --- preflight tests ---


### PR DESCRIPTION
## Summary

- **Part 1 of 6** for RAID-712: scope Service Point Admin role to a single service point
- Adds create-if-absent realm role `service-point-admin:<groupId>` granted to the group creator alongside the existing flat `group-admin`
- Dual-write for backward compatibility; no enforcement changes — enforcement lands in RAID-720

## Technical notes

- Fixed Keycloak `addRole(id, name)` overload gotcha with regression test
- Backward compatible: existing flat `group-admin` role still granted

## Testing

- 43 GroupControllerTest tests pass

## JIRA

https://ardc.atlassian.net/browse/RAID-719

🤖 Generated with [Claude Code](https://claude.com/claude-code)