### PR TITLE
RAID-722: Add scoped service-point-admin roles to dev realm config

### DIFF
--- a/iam/doc/role-permissions.md
+++ b/iam/doc/role-permissions.md
@@ -91,6 +91,23 @@ The RAID system uses a multi-layered authorization approach combining:
   - `POST /raid/post-to-datacite` - DataCite operations
 - Access to bulk public RAID data (`GET /raid/all-public`)
 
+### 9. **service-point-admin:\<groupId\>** (scoped service point admin)
+**Admin authority over a single service point** (RAID-712)
+
+Dynamic realm roles named `service-point-admin:<groupId>`, where `<groupId>` is the Keycloak group UUID of the service point (the same value as the group's `groupId` attribute, the `service_point_group_id` JWT claim, and the `service_point.group_id` database column).
+
+**Permissions:**
+- Manage members of that specific service point via the IAM group SPI: grant/revoke `service-point-user`, add/remove other service point admins, list group members
+- No admin authority over any other service point, even if the user is a member of it
+
+**Lifecycle:**
+- Created automatically (create-if-absent) when a group is created via the IAM group SPI; the creating user is granted the scoped role
+- Granted/revoked alongside the flat `group-admin` role (dual-write) while the transition to scoped roles is in progress
+
+**Relationship to the legacy `group-admin` role:** the flat `group-admin` realm role historically made a user an admin of *every* group they belonged to. During the transition, the SPI honours the flat role as a fallback (flat `group-admin` + group membership) when the `flat-group-admin-fallback` setting is enabled. Once the RAiD app consumes scoped roles, the fallback will be disabled and the flat role removed.
+
+**Deployment note:** `iam/realms/raid-realm.json` seeds the scoped roles for the two local dev groups only, and the realm JSON is imported on first boot only. In deployed environments (test/stage/prod) the scoped roles are backfilled with the operator-only idempotent migration endpoint `POST /realms/raid/group/migrate-service-point-admins` (RAID-721), which grants `service-point-admin:<groupId>` for every group each flat `group-admin` user belongs to (preserving current effective access).
+
 ## Special Authorization Cases
 
 ### Embargo Protection

--- a/iam/realms/raid-realm.json
+++ b/iam/realms/raid-realm.json
@@ -62,6 +62,22 @@
       "containerId" : "aacef42c-ba11-42f6-89de-89f3c8126f00",
       "attributes" : { }
     }, {
+      "id" : "c2be718a-9063-4cf8-8073-1f45e26c4104",
+      "name" : "service-point-admin:ba0b01a6-726f-464f-b501-454a10096826",
+      "description" : "Service point admin for group ba0b01a6-726f-464f-b501-454a10096826",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "aacef42c-ba11-42f6-89de-89f3c8126f00",
+      "attributes" : { }
+    }, {
+      "id" : "1b4bc00a-7946-4555-a3d0-4f92d22344b5",
+      "name" : "service-point-admin:169bd3f3-dd42-4ac0-b89a-fb49648e5eff",
+      "description" : "Service point admin for group 169bd3f3-dd42-4ac0-b89a-fb49648e5eff",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "aacef42c-ba11-42f6-89de-89f3c8126f00",
+      "attributes" : { }
+    }, {
       "id" : "0d7699fa-e553-496a-9d18-2dcf7f60f7cd",
       "name" : "service-point-user",
       "description" : "",
@@ -600,7 +616,7 @@
     } ],
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
-    "realmRoles" : [ "group-admin", "service-point-user", "default-roles-raid" ],
+    "realmRoles" : [ "group-admin", "service-point-admin:169bd3f3-dd42-4ac0-b89a-fb49648e5eff", "service-point-user", "default-roles-raid" ],
     "notBefore" : 0,
     "groups" : [ "/raid-au" ]
   }, {
@@ -669,7 +685,7 @@
     } ],
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
-    "realmRoles" : [ "group-admin", "service-point-user", "default-roles-raid", "operator" ],
+    "realmRoles" : [ "group-admin", "service-point-admin:ba0b01a6-726f-464f-b501-454a10096826", "service-point-admin:169bd3f3-dd42-4ac0-b89a-fb49648e5eff", "service-point-user", "default-roles-raid", "operator" ],
     "notBefore" : 0,
     "groups" : [ "/RAiD AU Test Registry 2", "/raid-au" ]
   }, {


### PR DESCRIPTION
Part 4 of 6 for RAID-712 (scope Service Point Admin role to a single service point).

## What
- Seeds `service-point-admin:<groupId>` realm roles for the two local dev groups (`RAiD AU Test Registry 2` and `raid-au`) in `iam/realms/raid-realm.json`
- Assigns them to the dev admin users (`raid-au-group-admin` gets the raid-au scoped role; `rob` gets both, mirroring the migration rule of one scoped role per group a flat `group-admin` belongs to)
- Documents the scoped role, its lifecycle, the `flat-group-admin-fallback` transition, and the deployed-environment migration path in `iam/doc/role-permissions.md`

## Why
The realm JSON is only imported on first boot, so this keeps local dev consistent with what the group SPI now creates on group creation (RAID-719). Test/stage/prod are instead backfilled via the idempotent migration endpoint (RAID-721).

JIRA: https://ardc.atlassian.net/browse/RAID-722

🤖 Generated with [Claude Code](https://claude.com/claude-code)