### PR TITLE
RAID-720: Enforce scoped service-point-admin role in group SPI

### DIFF
--- a/iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java
@@ -28,18 +28,43 @@ public class GroupController {
     private static final String GROUP_ADMIN_ROLE_NAME = "group-admin";
     private static final String SERVICE_POINT_USER_ROLE = "service-point-user";
     // Scoped role name format: "service-point-admin:<groupId>". Granted alongside the flat
-    // GROUP_ADMIN_ROLE_NAME on group creation (additive only - not yet enforced anywhere).
+    // GROUP_ADMIN_ROLE_NAME on group creation and group-admin grant (dual-write), and enforced as
+    // the primary authorization check in isGroupAdminOf below.
     private static final String SERVICE_POINT_ADMIN_ROLE_PREFIX = "service-point-admin";
+    // Config flag controlling whether the legacy flat GROUP_ADMIN_ROLE_NAME (plus group
+    // membership) still authorises group-admin operations. Keycloak's Config.Scope isn't wired
+    // through to this per-request resource today (GroupControllerResourceProviderFactory#init is
+    // unused and GroupControllerResourceProvider only forwards the KeycloakSession), so this is
+    // read directly from the environment, following Keycloak's own SPI env var naming convention
+    // in spirit. Defaults to true so existing flat group-admin role holders aren't locked out
+    // until service points finish migrating onto scoped roles.
+    private static final String FLAT_GROUP_ADMIN_FALLBACK_ENV_VAR = "RAID_FLAT_GROUP_ADMIN_FALLBACK";
     private final AuthenticationManager.AuthResult auth;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final KeycloakSession session;
     private final Cors cors;
+    private final boolean flatGroupAdminFallbackEnabled;
 
     public GroupController(final KeycloakSession session) {
+        this(session, resolveFlatGroupAdminFallbackEnabled());
+    }
+
+    // Package-private seam for tests: lets us set the fallback flag directly rather than having to
+    // mutate process environment variables, which the JVM does not support safely at runtime.
+    GroupController(final KeycloakSession session, final boolean flatGroupAdminFallbackEnabled) {
         this.session = session;
         this.auth = new AppAuthManager.BearerTokenAuthenticator(session).authenticate();
         this.cors = new Cors(session, objectMapper);
+        this.flatGroupAdminFallbackEnabled = flatGroupAdminFallbackEnabled;
+    }
+
+    private static boolean resolveFlatGroupAdminFallbackEnabled() {
+        final var value = System.getenv(FLAT_GROUP_ADMIN_FALLBACK_ENV_VAR);
+        if (value == null || value.isBlank()) {
+            return true;
+        }
+        return Boolean.parseBoolean(value);
     }
 
     @OPTIONS
@@ -99,32 +124,27 @@ public class GroupController {
         if (user == null) {
             throw new NotAuthorizedException("Bearer");
         }
-        if (!isGroupAdmin(user) && !isOperator(user)) {
-            throw new NotAuthorizedException("Permission denied");
-        }
-        
         // Return error if groupId not provided
         if (groupId == null || groupId.isEmpty()) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity("\"groupId parameter is required\"")
                 .build();
         }
-        
+
+        if (!isOperator(user) && !isGroupAdminOf(user, groupId)) {
+            throw new NotAuthorizedException("Permission denied - not an admin of this group");
+        }
+
         final var realm = session.getContext().getRealm();
         var group = session.groups().getGroupById(realm, groupId);
-        
+
         // Check if group exists
         if (group == null) {
             return Response.status(Response.Status.NOT_FOUND)
                 .entity("\"Group not found\"")
                 .build();
         }
-        
-        // Check if user has access to this group
-        if (!isOperator(user) && !user.getGroupsStream().anyMatch(g -> g.getId().equals(groupId))) {
-            throw new NotAuthorizedException("Permission denied for accessing this group");
-        }
-        
+
         final var responseBody = new HashMap<String, Object>();
         responseBody.put("id", group.getId());
         responseBody.put("name", group.getName());
@@ -166,12 +186,8 @@ public class GroupController {
             throw new NotAuthorizedException("Bearer");
         }
 
-        if (!isGroupAdmin(user) && !isOperator(user)) {
-            throw new NotAuthorizedException("Permission denied - not a group admin");
-        }
-
-        if (!isGroupMember(user, grant.getGroupId()) && !isOperator(user)) {
-            throw new NotAuthorizedException("Permission denied - not a group member");
+        if (!isOperator(user) && !isGroupAdminOf(user, grant.getGroupId())) {
+            throw new NotAuthorizedException("Permission denied - not an admin of this group");
         }
 
         final var realm = session.getContext().getRealm();
@@ -208,12 +224,8 @@ public class GroupController {
             throw new NotAuthorizedException("Bearer");
         }
 
-        if (!isGroupAdmin(user) && !isOperator(user)) {
-            throw new NotAuthorizedException("Permission denied - not a group admin");
-        }
-
-        if (!isGroupMember(user, grant.getGroupId()) && !isOperator(user)) {
-            throw new NotAuthorizedException("Permission denied - not a group member");
+        if (!isOperator(user) && !isGroupAdminOf(user, grant.getGroupId())) {
+            throw new NotAuthorizedException("Permission denied - not an admin of this group");
         }
 
         final var realm = session.getContext().getRealm();
@@ -250,12 +262,8 @@ public class GroupController {
             throw new NotAuthorizedException("Bearer");
         }
 
-        if (!isGroupAdmin(user) && !isOperator(user)) {
-            throw new NotAuthorizedException("Permission denied - not a group admin");
-        }
-
-        if (!isGroupMember(user, grant.getGroupId()) && !isOperator(user)) {
-            throw new NotAuthorizedException("Permission denied - not a group member");
+        if (!isOperator(user) && !isGroupAdminOf(user, grant.getGroupId())) {
+            throw new NotAuthorizedException("Permission denied - not an admin of this group");
         }
 
         final var realm = session.getContext().getRealm();
@@ -267,6 +275,13 @@ public class GroupController {
                 .orElseThrow(() -> new RoleNotFoundException(GROUP_ADMIN_ROLE_NAME));
 
         groupUser.deleteRoleMapping(groupAdminUserRole);
+
+        // Dual-revoke: also remove the scoped service-point-admin role for this group, if it
+        // exists, so admin access is fully withdrawn regardless of the fallback setting.
+        final var servicePointAdminRole = realm.getRole(servicePointAdminRoleName(grant.getGroupId()));
+        if (servicePointAdminRole != null) {
+            groupUser.deleteRoleMapping(servicePointAdminRole);
+        }
 
         return cors.buildCorsResponse("PUT",
                 Response.ok().entity("{}"));
@@ -286,12 +301,8 @@ public class GroupController {
             throw new NotAuthorizedException("Bearer");
         }
 
-        if (!isGroupAdmin(user) && !isOperator(user)) {
-            throw new NotAuthorizedException("Permission denied - not a group admin");
-        }
-
-        if (!isGroupMember(user, grant.getGroupId()) && !isOperator(user)) {
-            throw new NotAuthorizedException("Permission denied - not a group member");
+        if (!isOperator(user) && !isGroupAdminOf(user, grant.getGroupId())) {
+            throw new NotAuthorizedException("Permission denied - not an admin of this group");
         }
 
         final var realm = session.getContext().getRealm();
@@ -303,6 +314,10 @@ public class GroupController {
                 .orElseThrow(() -> new RoleNotFoundException(GROUP_ADMIN_ROLE_NAME));
 
         groupUser.grantRole(groupAdminUserRole);
+
+        // Dual-write: also grant the scoped service-point-admin role for this group so the
+        // grantee keeps admin access once the flat group-admin fallback is disabled.
+        groupUser.grantRole(getOrCreateServicePointAdminRole(realm, grant.getGroupId()));
 
         return cors.buildCorsResponse("PUT",
                 Response.ok().entity("{}"));
@@ -421,6 +436,23 @@ public class GroupController {
                 .toList().isEmpty();
     }
 
+    /**
+     * A user is an admin of the given group if they hold the scoped
+     * "service-point-admin:&lt;groupId&gt;" realm role, or - while the flat group-admin fallback is
+     * enabled - if they hold the legacy flat group-admin role and are a member of the group.
+     */
+    private boolean isGroupAdminOf(final UserModel user, final String groupId) {
+        final var scopedRoleName = servicePointAdminRoleName(groupId);
+        final var hasScopedRole = user.getRoleMappingsStream()
+                .anyMatch(r -> r.getName().equals(scopedRoleName));
+
+        if (hasScopedRole) {
+            return true;
+        }
+
+        return flatGroupAdminFallbackEnabled && isGroupAdmin(user) && isGroupMember(user, groupId);
+    }
+
     private boolean isGroupMember(final UserModel user, final String groupId) {
         return !user.getGroupsStream()
                 .filter(g -> g.getId().equals(groupId))
@@ -532,8 +564,8 @@ public class GroupController {
             }
 
             // Also grant the scoped service-point-admin role for the new group. This is a
-            // dual-write alongside the flat group-admin role above for backward compatibility -
-            // no enforcement changes are made as part of this ticket.
+            // dual-write alongside the flat group-admin role above for backward compatibility
+            // while the transition to scoped roles is in progress.
             final var servicePointAdminRole = getOrCreateServicePointAdminRole(realm, newGroup.getId());
             user.grantRole(servicePointAdminRole);
 

--- a/iam/src/test/java/au/org/raid/iam/provider/group/GroupControllerTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/group/GroupControllerTest.java
@@ -77,6 +77,18 @@ class GroupControllerTest {
         }
     }
 
+    // Uses the package-private test-seam constructor so the flat group-admin fallback flag can be
+    // set directly instead of via the RAID_FLAT_GROUP_ADMIN_FALLBACK environment variable.
+    private GroupController createAuthenticatedController(final boolean flatGroupAdminFallbackEnabled) {
+        try (MockedConstruction<AppAuthManager.BearerTokenAuthenticator> ignored =
+                     mockConstruction(AppAuthManager.BearerTokenAuthenticator.class,
+                             (mock, ctx) -> when(mock.authenticate()).thenReturn(authResult))) {
+            when(authResult.session()).thenReturn(userSession);
+            when(userSession.getUser()).thenReturn(user);
+            return new GroupController(session, flatGroupAdminFallbackEnabled);
+        }
+    }
+
     private void setupOperatorRole() {
         var operatorRole = mock(RoleModel.class);
         when(operatorRole.getName()).thenReturn("operator");
@@ -91,6 +103,33 @@ class GroupControllerTest {
 
     private void setupNoRoles() {
         when(user.getRoleMappingsStream()).thenAnswer(inv -> Stream.empty());
+    }
+
+    private void setupScopedServicePointAdminRole(final String groupId) {
+        var scopedRole = mock(RoleModel.class);
+        when(scopedRole.getName()).thenReturn("service-point-admin:" + groupId);
+        when(user.getRoleMappingsStream()).thenAnswer(inv -> Stream.of(scopedRole));
+    }
+
+    private void setupGroupMembership(final String groupId) {
+        var group = mock(GroupModel.class);
+        when(group.getId()).thenReturn(groupId);
+        when(user.getGroupsStream()).thenAnswer(inv -> Stream.of(group));
+    }
+
+    private void setupNoGroupMembership() {
+        when(user.getGroupsStream()).thenAnswer(inv -> Stream.empty());
+    }
+
+    private void setupServicePointUserRoleGrantTarget(final UserModel targetUser) {
+        when(session.users()).thenReturn(userProvider);
+        when(session.roles()).thenReturn(roleProvider);
+        when(userProvider.getUserById(realm, "u1")).thenReturn(targetUser);
+
+        var servicePointUserRole = mock(RoleModel.class);
+        when(servicePointUserRole.getName()).thenReturn("service-point-user");
+        when(roleProvider.getRealmRolesStream(eq(realm), any(), any()))
+                .thenAnswer(inv -> Stream.of(servicePointUserRole));
     }
 
     // --- getGroups tests ---
@@ -225,6 +264,130 @@ class GroupControllerTest {
         var response = controller.grant(grant);
         assertThat(response.getStatus(), is(200));
         verify(targetUser).grantRole(servicePointUserRole);
+    }
+
+    // --- scoped group-admin authorization tests (RAID-720) ---
+
+    @Test
+    void grant_allowsScopedServicePointAdminOfGroup() {
+        var controller = createAuthenticatedController();
+        setupScopedServicePointAdminRole("g1");
+        setupNoGroupMembership();
+
+        var targetUser = mock(UserModel.class);
+        setupServicePointUserRoleGrantTarget(targetUser);
+
+        var grant = new Grant();
+        grant.setUserId("u1");
+        grant.setGroupId("g1");
+
+        var response = controller.grant(grant);
+        assertThat(response.getStatus(), is(200));
+        verify(targetUser).grantRole(any(RoleModel.class));
+    }
+
+    @Test
+    void grant_deniesScopedServicePointAdminOfDifferentGroup() {
+        var controller = createAuthenticatedController();
+        setupScopedServicePointAdminRole("other-group");
+        setupNoGroupMembership();
+
+        var grant = new Grant();
+        grant.setUserId("u1");
+        grant.setGroupId("g1");
+
+        assertThrows(NotAuthorizedException.class, () -> controller.grant(grant));
+    }
+
+    @Test
+    void grant_allowsFlatGroupAdminMemberWhenFallbackEnabled() {
+        var controller = createAuthenticatedController(true);
+        setupGroupAdminRole();
+        setupGroupMembership("g1");
+
+        var targetUser = mock(UserModel.class);
+        setupServicePointUserRoleGrantTarget(targetUser);
+
+        var grant = new Grant();
+        grant.setUserId("u1");
+        grant.setGroupId("g1");
+
+        var response = controller.grant(grant);
+        assertThat(response.getStatus(), is(200));
+        verify(targetUser).grantRole(any(RoleModel.class));
+    }
+
+    @Test
+    void grant_deniesFlatGroupAdminNonMemberWhenFallbackEnabled() {
+        var controller = createAuthenticatedController(true);
+        setupGroupAdminRole();
+        setupNoGroupMembership();
+
+        var grant = new Grant();
+        grant.setUserId("u1");
+        grant.setGroupId("g1");
+
+        assertThrows(NotAuthorizedException.class, () -> controller.grant(grant));
+    }
+
+    @Test
+    void grant_deniesFlatGroupAdminMemberWhenFallbackDisabled() {
+        var controller = createAuthenticatedController(false);
+        setupGroupAdminRole();
+        setupGroupMembership("g1");
+
+        var grant = new Grant();
+        grant.setUserId("u1");
+        grant.setGroupId("g1");
+
+        assertThrows(NotAuthorizedException.class, () -> controller.grant(grant));
+    }
+
+    @Test
+    void grant_allowsScopedServicePointAdminWhenFallbackDisabled() {
+        var controller = createAuthenticatedController(false);
+        setupScopedServicePointAdminRole("g1");
+        setupNoGroupMembership();
+
+        var targetUser = mock(UserModel.class);
+        setupServicePointUserRoleGrantTarget(targetUser);
+
+        var grant = new Grant();
+        grant.setUserId("u1");
+        grant.setGroupId("g1");
+
+        var response = controller.grant(grant);
+        assertThat(response.getStatus(), is(200));
+        verify(targetUser).grantRole(any(RoleModel.class));
+    }
+
+    @Test
+    void get_allowsScopedServicePointAdminOfGroup() throws Exception {
+        var controller = createAuthenticatedController();
+        setupScopedServicePointAdminRole("g1");
+        setupNoGroupMembership();
+        when(session.groups()).thenReturn(groupProvider);
+        when(session.users()).thenReturn(userProvider);
+
+        var group = mock(GroupModel.class);
+        when(group.getId()).thenReturn("g1");
+        when(group.getName()).thenReturn("Test Group");
+        when(group.getAttributes()).thenReturn(Map.of());
+        when(groupProvider.getGroupById(realm, "g1")).thenReturn(group);
+        when(userProvider.getGroupMembersStream(realm, group)).thenReturn(Stream.empty());
+        when(user.getId()).thenReturn("current-user");
+
+        var response = controller.get("g1");
+        assertThat(response.getStatus(), is(200));
+    }
+
+    @Test
+    void get_deniesScopedServicePointAdminOfDifferentGroup() {
+        var controller = createAuthenticatedController();
+        setupScopedServicePointAdminRole("other-group");
+        setupNoGroupMembership();
+
+        assertThrows(NotAuthorizedException.class, () -> controller.get("g1"));
     }
 
     // --- revoke tests ---
@@ -585,7 +748,7 @@ class GroupControllerTest {
     // --- group-admin grant/revoke tests ---
 
     @Test
-    void grantGroupAdmin_grantsRole() throws Exception {
+    void grantGroupAdmin_grantsFlatAndScopedRoles() throws Exception {
         var controller = createAuthenticatedController();
         setupOperatorRole();
         when(session.users()).thenReturn(userProvider);
@@ -598,6 +761,10 @@ class GroupControllerTest {
         when(groupAdminRole.getName()).thenReturn("group-admin");
         when(roleProvider.getRealmRolesStream(eq(realm), any(), any()))
                 .thenReturn(Stream.of(groupAdminRole));
+
+        when(realm.getRole("service-point-admin:g1")).thenReturn(null);
+        var scopedRole = mock(RoleModel.class);
+        when(realm.addRole("service-point-admin:g1")).thenReturn(scopedRole);
 
         var request = new AddGroupAdminRequest();
         request.setUserId("u1");
@@ -606,10 +773,13 @@ class GroupControllerTest {
         var response = controller.grant(request);
         assertThat(response.getStatus(), is(200));
         verify(targetUser).grantRole(groupAdminRole);
+        verify(targetUser).grantRole(scopedRole);
+        verify(scopedRole).setDescription("Service point admin for group g1");
+        verify(realm, never()).addRole(anyString(), anyString());
     }
 
     @Test
-    void removeGroupAdmin_removesRole() throws Exception {
+    void grantGroupAdmin_reusesExistingScopedRole() throws Exception {
         var controller = createAuthenticatedController();
         setupOperatorRole();
         when(session.users()).thenReturn(userProvider);
@@ -623,6 +793,39 @@ class GroupControllerTest {
         when(roleProvider.getRealmRolesStream(eq(realm), any(), any()))
                 .thenReturn(Stream.of(groupAdminRole));
 
+        var scopedRole = mock(RoleModel.class);
+        when(realm.getRole("service-point-admin:g1")).thenReturn(scopedRole);
+
+        var request = new AddGroupAdminRequest();
+        request.setUserId("u1");
+        request.setGroupId("g1");
+
+        var response = controller.grant(request);
+        assertThat(response.getStatus(), is(200));
+        verify(targetUser).grantRole(groupAdminRole);
+        verify(targetUser).grantRole(scopedRole);
+        verify(realm, never()).addRole(anyString());
+        verify(realm, never()).addRole(anyString(), anyString());
+    }
+
+    @Test
+    void removeGroupAdmin_removesFlatAndScopedRoles() throws Exception {
+        var controller = createAuthenticatedController();
+        setupOperatorRole();
+        when(session.users()).thenReturn(userProvider);
+        when(session.roles()).thenReturn(roleProvider);
+
+        var targetUser = mock(UserModel.class);
+        when(userProvider.getUserById(realm, "u1")).thenReturn(targetUser);
+
+        var groupAdminRole = mock(RoleModel.class);
+        when(groupAdminRole.getName()).thenReturn("group-admin");
+        when(roleProvider.getRealmRolesStream(eq(realm), any(), any()))
+                .thenReturn(Stream.of(groupAdminRole));
+
+        var scopedRole = mock(RoleModel.class);
+        when(realm.getRole("service-point-admin:g1")).thenReturn(scopedRole);
+
         var request = new RemoveGroupAdminRequest();
         request.setUserId("u1");
         request.setGroupId("g1");
@@ -630,6 +833,34 @@ class GroupControllerTest {
         var response = controller.grant(request);
         assertThat(response.getStatus(), is(200));
         verify(targetUser).deleteRoleMapping(groupAdminRole);
+        verify(targetUser).deleteRoleMapping(scopedRole);
+    }
+
+    @Test
+    void removeGroupAdmin_skipsScopedRoleWhenAbsent() throws Exception {
+        var controller = createAuthenticatedController();
+        setupOperatorRole();
+        when(session.users()).thenReturn(userProvider);
+        when(session.roles()).thenReturn(roleProvider);
+
+        var targetUser = mock(UserModel.class);
+        when(userProvider.getUserById(realm, "u1")).thenReturn(targetUser);
+
+        var groupAdminRole = mock(RoleModel.class);
+        when(groupAdminRole.getName()).thenReturn("group-admin");
+        when(roleProvider.getRealmRolesStream(eq(realm), any(), any()))
+                .thenReturn(Stream.of(groupAdminRole));
+
+        when(realm.getRole("service-point-admin:g1")).thenReturn(null);
+
+        var request = new RemoveGroupAdminRequest();
+        request.setUserId("u1");
+        request.setGroupId("g1");
+
+        var response = controller.grant(request);
+        assertThat(response.getStatus(), is(200));
+        verify(targetUser).deleteRoleMapping(groupAdminRole);
+        verify(targetUser, times(1)).deleteRoleMapping(any(RoleModel.class));
     }
     // --- deleteGroup tests ---
 


### PR DESCRIPTION
## Summary

Implements [RAID-720](https://ardc.atlassian.net/browse/RAID-720) (sub-task of [RAID-712](https://ardc.atlassian.net/browse/RAID-712)): the IAM group SPI now authorises group-admin operations per service point instead of globally.

### Changes

- **New `isGroupAdminOf(user, groupId)` check** replaces the flat `isGroupAdmin(user)` check on member listing, `service-point-user` grant/revoke, and group-admin add/remove. A user administers a group if they:
  - hold the scoped `service-point-admin:<groupId>` realm role, **or**
  - (while the fallback is enabled) hold the legacy flat `group-admin` role **and** are a member of the group.
- **Operator bypass unchanged** - operators can still administer any group.
- **Flat fallback flag**: `RAID_FLAT_GROUP_ADMIN_FALLBACK` env var, default `true`. Keeps existing flat group-admins working until the app migrates to scoped roles, then the fallback can be disabled.
- **Dual-write on group-admin PUT**: grants both the flat `group-admin` role and the scoped role (create-if-absent). **Dual-revoke on DELETE**: removes both.

### Behaviour notes

- A flat `group-admin` who is *not* a member of a group can no longer administer it (previously the two separate checks allowed cross-group admin only if they were a member; the combined check preserves that boundary).
- The member-listing endpoint now validates `groupId` before authorisation, so a missing `groupId` returns 400 for all authenticated users.

### Testing

- 12 new/updated unit tests in `GroupControllerTest` covering the scoped/fallback authorisation matrix, dual-write, dual-revoke, and the `addRole` single-arg regression guard.
- All 100 iam module tests pass (`./gradlew :iam:test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)