### PR TITLE
RAID-721: Add idempotent scoped-admin migration endpoint

### DIFF
--- a/iam/doc/spis.md
+++ b/iam/doc/spis.md
@@ -21,6 +21,7 @@ Manages service point groups — the organisational units that users belong to i
 | GET    | `/user-groups`   | List groups for the current user             |
 | POST   | `/create`        | Create a new group                           |
 | DELETE | `/delete`        | Delete a group                               |
+| POST   | `/migrate-service-point-admins` | Backfill scoped `service-point-admin:<groupId>` roles for flat group-admin holders (operator only, idempotent) |
 
 ## RAiD Permissions Controller
 

--- a/iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java
@@ -650,4 +650,119 @@ public class GroupController {
                     .build();
         }
     }
+
+    @OPTIONS
+    @Path("/migrate-service-point-admins")
+    public Response migrateServicePointAdminsPreflight() {
+        return cors.buildOptionsResponse("POST", "OPTIONS");
+    }
+
+    /**
+     * One-off, idempotent backfill for RAID-712: grants the scoped
+     * "service-point-admin:&lt;groupId&gt;" realm role to every current holder of the legacy flat
+     * GROUP_ADMIN_ROLE_NAME, for each group they belong to. This preserves each flat
+     * group-admin's existing effective access while service points transition onto scoped roles
+     * (see role-permissions.md section 9).
+     *
+     * <p>Operator-only. Safe to re-run: users who already hold the scoped role for a group are
+     * counted as skipped rather than re-granted, and existing scoped roles are reused rather than
+     * recreated.
+     *
+     * <p>Note: this intentionally over-grants - a flat group-admin is granted the scoped admin
+     * role for every group they are a member of, not just the group(s) they were originally
+     * intended to administer. Pruning any resulting excess scoped grants is deferred to a future
+     * RAID-712 follow-up once service points have reviewed their membership.
+     */
+    @POST
+    @Path("/migrate-service-point-admins")
+    @Produces(MediaType.APPLICATION_JSON)
+    @SneakyThrows
+    public Response migrateServicePointAdmins() {
+        log.debug("Migrating flat group-admin holders to scoped service-point-admin roles");
+
+        if (this.auth == null) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        final var user = auth.session().getUser();
+        if (user == null) {
+            throw new NotAuthorizedException("Bearer");
+        }
+
+        if (!isOperator(user)) {
+            throw new NotAuthorizedException("Permission denied - not authorized to migrate service point admins");
+        }
+
+        final var realm = session.getContext().getRealm();
+        final var flatGroupAdminRole = realm.getRole(GROUP_ADMIN_ROLE_NAME);
+
+        if (flatGroupAdminRole == null) {
+            final var responseBody = new MigrationResult(0, 0, 0, 0,
+                    "Flat group-admin role not present; nothing to migrate");
+            return cors.buildCorsResponse("POST",
+                    Response.ok().entity(objectMapper.writeValueAsString(responseBody)));
+        }
+
+        try {
+            var flatGroupAdminUsers = 0;
+            var rolesCreated = 0;
+            var grantsAdded = 0;
+            var grantsSkipped = 0;
+
+            var firstResult = 0;
+            final var pageSize = 100;
+            while (true) {
+                final var page = session.users()
+                        .getRoleMembersStream(realm, flatGroupAdminRole, firstResult, pageSize)
+                        .toList();
+
+                if (page.isEmpty()) {
+                    break;
+                }
+
+                for (final var member : page) {
+                    flatGroupAdminUsers++;
+
+                    // Materialise before granting roles below - member.grantRole mutates this
+                    // user's role mappings, and we must not mutate them while consuming a live
+                    // stream over the same underlying data.
+                    final var groups = member.getGroupsStream().toList();
+
+                    for (final var group : groups) {
+                        final var roleName = servicePointAdminRoleName(group.getId());
+                        final var existed = realm.getRole(roleName) != null;
+                        final var scopedRole = getOrCreateServicePointAdminRole(realm, group.getId());
+
+                        if (!existed) {
+                            rolesCreated++;
+                        }
+
+                        if (member.hasDirectRole(scopedRole)) {
+                            grantsSkipped++;
+                        } else {
+                            member.grantRole(scopedRole);
+                            grantsAdded++;
+                        }
+                    }
+                }
+
+                firstResult += pageSize;
+            }
+
+            final var responseBody = new MigrationResult(
+                    flatGroupAdminUsers, rolesCreated, grantsAdded, grantsSkipped, "Migration complete");
+
+            return cors.buildCorsResponse("POST",
+                    Response.ok().entity(objectMapper.writeValueAsString(responseBody)));
+
+        } catch (Exception e) {
+            log.error("Error migrating service point admins: {}", e.getMessage(), e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("{\"error\": \"Failed to migrate service point admins\"}")
+                    .build();
+        }
+    }
+
+    private record MigrationResult(
+            int flatGroupAdminUsers, int rolesCreated, int grantsAdded, int grantsSkipped, String message) {}
 }

--- a/iam/src/test/java/au/org/raid/iam/provider/group/GroupControllerTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/group/GroupControllerTest.java
@@ -974,4 +974,177 @@ class GroupControllerTest {
             assertThat(response.getStatus(), is(200));
         }
     }
+
+    // --- migrateServicePointAdmins tests (RAID-721) ---
+
+    @Test
+    void migrate_returnsUnauthorizedWhenNotAuthenticated() {
+        var controller = createUnauthenticatedController();
+
+        var response = controller.migrateServicePointAdmins();
+        assertThat(response.getStatus(), is(401));
+    }
+
+    @Test
+    void migrate_throwsNotAuthorizedForNonOperator() {
+        var controller = createAuthenticatedController();
+        setupNoRoles();
+
+        assertThrows(NotAuthorizedException.class, controller::migrateServicePointAdmins);
+    }
+
+    @Test
+    void migrate_throwsNotAuthorizedForGroupAdmin() {
+        var controller = createAuthenticatedController();
+        setupGroupAdminRole();
+
+        assertThrows(NotAuthorizedException.class, controller::migrateServicePointAdmins);
+    }
+
+    @Test
+    void migrate_returnsZeroCountsWhenFlatRoleAbsent() {
+        var controller = createAuthenticatedController();
+        setupOperatorRole();
+        when(realm.getRole("group-admin")).thenReturn(null);
+
+        var response = controller.migrateServicePointAdmins();
+        assertThat(response.getStatus(), is(200));
+
+        var body = response.getEntity().toString();
+        assertThat(body, containsString("\"flatGroupAdminUsers\":0"));
+        assertThat(body, containsString("\"rolesCreated\":0"));
+        assertThat(body, containsString("\"grantsAdded\":0"));
+        assertThat(body, containsString("\"grantsSkipped\":0"));
+        assertThat(body, containsString("Flat group-admin role not present; nothing to migrate"));
+
+        verify(session, never()).users();
+    }
+
+    @Test
+    void migrate_grantsScopedRoleForEachGroupOfFlatAdmin() {
+        var controller = createAuthenticatedController();
+        setupOperatorRole();
+
+        var flatGroupAdminRole = mock(RoleModel.class);
+        when(realm.getRole("group-admin")).thenReturn(flatGroupAdminRole);
+
+        when(session.users()).thenReturn(userProvider);
+
+        var member = mock(UserModel.class);
+        when(userProvider.getRoleMembersStream(eq(realm), eq(flatGroupAdminRole), anyInt(), anyInt()))
+                .thenReturn(Stream.of(member), Stream.empty());
+
+        var g1 = mock(GroupModel.class);
+        when(g1.getId()).thenReturn("g1");
+        var g2 = mock(GroupModel.class);
+        when(g2.getId()).thenReturn("g2");
+        when(member.getGroupsStream()).thenAnswer(inv -> Stream.of(g1, g2));
+
+        when(realm.getRole("service-point-admin:g1")).thenReturn(null);
+        var scopedRole1 = mock(RoleModel.class);
+        when(realm.addRole("service-point-admin:g1")).thenReturn(scopedRole1);
+
+        when(realm.getRole("service-point-admin:g2")).thenReturn(null);
+        var scopedRole2 = mock(RoleModel.class);
+        when(realm.addRole("service-point-admin:g2")).thenReturn(scopedRole2);
+
+        when(member.hasDirectRole(scopedRole1)).thenReturn(false);
+        when(member.hasDirectRole(scopedRole2)).thenReturn(false);
+
+        var response = controller.migrateServicePointAdmins();
+        assertThat(response.getStatus(), is(200));
+
+        verify(member).grantRole(scopedRole1);
+        verify(member).grantRole(scopedRole2);
+        verify(realm).addRole("service-point-admin:g1");
+        verify(realm).addRole("service-point-admin:g2");
+        verify(realm, never()).addRole(anyString(), anyString());
+        verify(scopedRole1).setDescription("Service point admin for group g1");
+        verify(scopedRole2).setDescription("Service point admin for group g2");
+
+        var body = response.getEntity().toString();
+        assertThat(body, containsString("\"flatGroupAdminUsers\":1"));
+        assertThat(body, containsString("\"rolesCreated\":2"));
+        assertThat(body, containsString("\"grantsAdded\":2"));
+        assertThat(body, containsString("\"grantsSkipped\":0"));
+    }
+
+    @Test
+    void migrate_isIdempotentOnSecondRun() {
+        var controller = createAuthenticatedController();
+        setupOperatorRole();
+
+        var flatGroupAdminRole = mock(RoleModel.class);
+        when(realm.getRole("group-admin")).thenReturn(flatGroupAdminRole);
+
+        when(session.users()).thenReturn(userProvider);
+
+        var member = mock(UserModel.class);
+        when(userProvider.getRoleMembersStream(eq(realm), eq(flatGroupAdminRole), anyInt(), anyInt()))
+                .thenReturn(Stream.of(member), Stream.empty());
+
+        var g1 = mock(GroupModel.class);
+        when(g1.getId()).thenReturn("g1");
+        when(member.getGroupsStream()).thenAnswer(inv -> Stream.of(g1));
+
+        var scopedRole1 = mock(RoleModel.class);
+        when(realm.getRole("service-point-admin:g1")).thenReturn(scopedRole1);
+        when(member.hasDirectRole(scopedRole1)).thenReturn(true);
+
+        var response = controller.migrateServicePointAdmins();
+        assertThat(response.getStatus(), is(200));
+
+        verify(member, never()).grantRole(any(RoleModel.class));
+        verify(realm, never()).addRole(anyString());
+        verify(realm, never()).addRole(anyString(), anyString());
+
+        var body = response.getEntity().toString();
+        assertThat(body, containsString("\"flatGroupAdminUsers\":1"));
+        assertThat(body, containsString("\"rolesCreated\":0"));
+        assertThat(body, containsString("\"grantsAdded\":0"));
+        assertThat(body, containsString("\"grantsSkipped\":1"));
+    }
+
+    @Test
+    void migrate_addsGrantWhenScopedRoleAlreadyExists() {
+        var controller = createAuthenticatedController();
+        setupOperatorRole();
+
+        var flatGroupAdminRole = mock(RoleModel.class);
+        when(realm.getRole("group-admin")).thenReturn(flatGroupAdminRole);
+
+        when(session.users()).thenReturn(userProvider);
+
+        var member = mock(UserModel.class);
+        when(userProvider.getRoleMembersStream(eq(realm), eq(flatGroupAdminRole), anyInt(), anyInt()))
+                .thenReturn(Stream.of(member), Stream.empty());
+
+        var g1 = mock(GroupModel.class);
+        when(g1.getId()).thenReturn("g1");
+        when(member.getGroupsStream()).thenAnswer(inv -> Stream.of(g1));
+
+        var scopedRole1 = mock(RoleModel.class);
+        when(realm.getRole("service-point-admin:g1")).thenReturn(scopedRole1);
+        when(member.hasDirectRole(scopedRole1)).thenReturn(false);
+
+        var response = controller.migrateServicePointAdmins();
+        assertThat(response.getStatus(), is(200));
+
+        verify(member).grantRole(scopedRole1);
+        verify(realm, never()).addRole(anyString());
+        verify(realm, never()).addRole(anyString(), anyString());
+
+        var body = response.getEntity().toString();
+        assertThat(body, containsString("\"flatGroupAdminUsers\":1"));
+        assertThat(body, containsString("\"rolesCreated\":0"));
+        assertThat(body, containsString("\"grantsAdded\":1"));
+        assertThat(body, containsString("\"grantsSkipped\":0"));
+    }
+
+    @Test
+    void migratePreflight_returns200() {
+        var controller = createAuthenticatedController();
+        var response = controller.migrateServicePointAdminsPreflight();
+        assertThat(response.getStatus(), is(200));
+    }
 }


### PR DESCRIPTION
## Summary

Implements [RAID-721](https://ardc.atlassian.net/browse/RAID-721) (sub-task of [RAID-712](https://ardc.atlassian.net/browse/RAID-712)): an operator-only, idempotent SPI endpoint `POST /realms/raid/group/migrate-service-point-admins` that backfills scoped `service-point-admin:<groupId>` realm roles in deployed environments (test/stage/prod), where the dev realm-JSON seeding does not apply.

### Behaviour

- For every user holding the flat `group-admin` realm role: grant `service-point-admin:<groupId>` for **every** group the user belongs to, creating each scoped role if absent (reuses `getOrCreateServicePointAdminRole`). Over-granting is intentional - it preserves current effective access under the flat-role model; pruning is a deferred cleanup per RAID-712.
- Idempotent: `hasDirectRole` pre-checks skip existing grants; a re-run returns `rolesCreated: 0, grantsAdded: 0`.
- Response: JSON counts `{flatGroupAdminUsers, rolesCreated, grantsAdded, grantsSkipped, message}`.
- Missing flat `group-admin` role (fresh realm): 200 with zero counts, user store untouched.
- Operator-only (same auth pattern as `create`/`delete`); role members paged in batches of 100.

### Review

Designed by `iam-architect`, implemented by `iam-developer`, reviewed by `iam-code-reviewer`: **approved, no blocking issues**. Non-blocking observations deferred: a redundant `realm.getRole` lookup per group (double query, acceptable for a one-off admin operation), no test for the catch/500 path (consistent with existing endpoints), and doc table column alignment.

### Testing

- 8 new unit tests in `GroupControllerTest` (auth matrix, zero-work fresh realm, multi-group grant, idempotent re-run, role-exists/grant-missing, preflight), including the `addRole(id, name)` overload regression guard.
- `./gradlew :iam:test`: 61 tests in GroupControllerTest, 0 failures; full iam module suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)