### PR TITLE
RAID-733: allow raid-dumper role to read GET /service-point/

### DIFF
--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/ServicePointIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/ServicePointIntegrationTest.java
@@ -3,12 +3,14 @@ package au.org.raid.inttest;
 import au.org.raid.idl.raidv2.api.ServicePointApi;
 import au.org.raid.idl.raidv2.model.ServicePointUpdateRequest;
 import au.org.raid.inttest.dto.UserContext;
+import feign.FeignException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ServicePointIntegrationTest extends AbstractIntegrationTest {
 
@@ -115,5 +117,37 @@ public class ServicePointIntegrationTest extends AbstractIntegrationTest {
                 .groupId(existing.getGroupId());
 
         operatorServicePointApi.updateServicePoint(existing.getId(), restoreRequest);
+    }
+
+    @Test
+    @DisplayName("raid-dumper role can read service points (needed for the service-points.json archive dump)")
+    void raidDumperCanFindAllServicePoints() {
+        final var dumperContext = userService.createUser("raid-au", "raid-dumper");
+
+        try {
+            final var response = testClient.servicePointApi(dumperContext.getToken()).findAllServicePoints();
+            final var servicePoints = response.getBody();
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(servicePoints).isNotNull();
+            assertThat(servicePoints).isNotEmpty();
+        } finally {
+            userService.deleteUser(dumperContext.getId());
+        }
+    }
+
+    @Test
+    @DisplayName("Caller without service-point-user, operator or raid-dumper role cannot read service points")
+    void insufficientRoleCannotFindAllServicePoints() {
+        final var unauthorisedContext = userService.createUser("raid-au", "raid-user");
+
+        try {
+            testClient.servicePointApi(unauthorisedContext.getToken()).findAllServicePoints();
+            fail("Expected findAllServicePoints to be forbidden for a caller without an authorised role");
+        } catch (FeignException e) {
+            assertThat(e.status()).isEqualTo(403);
+        } finally {
+            userService.deleteUser(unauthorisedContext.getId());
+        }
     }
 }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/SecurityConfig.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/SecurityConfig.java
@@ -101,7 +101,7 @@ public class SecurityConfig {
                 // Service Point API endpoints
                 .requestMatchers(PUT, SERVICE_POINT_API + "/**").hasRole(OPERATOR_ROLE)
                 .requestMatchers(POST, SERVICE_POINT_API + "/**").hasRole(OPERATOR_ROLE)
-                .requestMatchers(GET, SERVICE_POINT_API + "/**").hasAnyRole(SERVICE_POINT_USER_ROLE, OPERATOR_ROLE)
+                .requestMatchers(GET, SERVICE_POINT_API + "/**").hasAnyRole(SERVICE_POINT_USER_ROLE, OPERATOR_ROLE, RAID_DUMPER_ROLE)
 
                 // Admin endpoints
                 .requestMatchers(POST, "/admin/**").hasRole(OPERATOR_ROLE)


### PR DESCRIPTION
## Summary

- Adds `RAID_DUMPER_ROLE` to the `hasAnyRole(...)` list on the `GET /service-point/**` security matcher in `SecurityConfig`, alongside the existing `SERVICE_POINT_USER_ROLE` and `OPERATOR_ROLE`.
- Only the GET matcher is changed. The `PUT` and `POST /service-point/**` matchers are untouched, so the raid-dumper service account remains strictly read-only against this endpoint.

## Why

The raid-dumper Keycloak service account currently cannot call `GET /service-point/`. This is needed to support the `service-points.json` archive dump described in RAID-689 (parent ticket), which requires the dumper to enumerate service points as part of the monthly export.

## Least-privilege rationale

- raid-dumper is only added to the GET matcher, not PUT/POST, so it cannot create or modify service points.
- This mirrors the existing pattern for the RAiD API, where raid-dumper already has read-only access to `GET /raid/all-public` for the same class of bulk-export use case.

## Release timing

This must be released to production before the next monthly dumper run on **1 Aug 2026**, otherwise the `service-points.json` archive job will fail to authenticate against `GET /service-point/`.

## Test plan

- [x] Added `raidDumperCanFindAllServicePoints` to `ServicePointIntegrationTest` — a token with only the `raid-dumper` role can call `GET /service-point/` and gets a 200 with a non-empty list.
- [x] Added `insufficientRoleCannotFindAllServicePoints` — a caller with only `raid-user` (no `service-point-user`, `operator`, or `raid-dumper`) still gets a 403.
- [x] `./gradlew build` — unit tests pass.
- [x] `./gradlew :api-svc:raid-api:intTest` — full integration suite passes (150 tests, 0 failures), including the two new cases and existing `ServicePointIntegrationTest` PUT/find-by-id/find-all cases (confirming operator/service-point-user access and write behaviour are unaffected).

Parent: RAID-689

🤖 Generated with [Claude Code](https://claude.com/claude-code)