### PR TITLE
RAID-731: Skip DataCite error test when mockserver unavailable

### DIFF
--- a/api-svc/raid-api/docker-compose/mockserver/expectations.json
+++ b/api-svc/raid-api/docker-compose/mockserver/expectations.json
@@ -405,6 +405,27 @@
     }
   },
   {
+    "priority": 10,
+    "httpRequest": {
+      "method": "POST",
+      "path": "/dois",
+      "body": {
+        "type": "STRING",
+        "string": "RAID-731-DATACITE-ERROR",
+        "subString": true
+      }
+    },
+    "httpResponse": {
+      "statusCode": 429,
+      "headers": {
+        "Content-Type": ["application/json"]
+      },
+      "body": {
+        "errors": [{"status": "429", "title": "Too Many Requests"}]
+      }
+    }
+  },
+  {
     "httpRequest": {
       "method": "POST",
       "path": "/dois",

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/DataciteErrorIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/DataciteErrorIntegrationTest.java
@@ -1,59 +1,46 @@
 package au.org.raid.inttest;
 
 import feign.FeignException;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 public class DataciteErrorIntegrationTest extends AbstractIntegrationTest {
 
-    private static final String MOCKSERVER_EXPECTATION_URL = "http://localhost:1080/mockserver/expectation";
-    private static final String EXPECTATION_ID = "datacite-error-integration-test";
+    private static final String MOCKSERVER_HOST = "localhost";
+    private static final int MOCKSERVER_PORT = 1080;
+    private static final int MOCKSERVER_CONNECT_TIMEOUT_MILLIS = 2000;
 
-    @Autowired
-    private RestTemplate restTemplate;
+    // Sentinel matched by the static 429 expectation in docker-compose/mockserver/expectations.json
+    private static final String DATACITE_ERROR_TITLE_SENTINEL = "RAID-731-DATACITE-ERROR";
 
-    @AfterEach
-    void cleanUpMockServerExpectation() {
-        final var cleanup = """
-                [{
-                    "id": "%s",
-                    "priority": 0,
-                    "httpRequest": {
-                        "method": "POST",
-                        "path": "/dois"
-                    },
-                    "httpResponse": {
-                        "statusCode": 201
-                    },
-                    "times": {
-                        "remainingTimes": 0,
-                        "unlimited": false
-                    }
-                }]
-                """.formatted(EXPECTATION_ID);
+    @BeforeEach
+    void checkMockServerIsReachable() {
+        Assumptions.assumeTrue(isMockServerReachable(), "mockserver not reachable - skipping DataCite error test");
+    }
 
-        var headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        try {
-            restTemplate.put(MOCKSERVER_EXPECTATION_URL, new HttpEntity<>(cleanup, headers));
-        } catch (Exception ignored) {
+    private static boolean isMockServerReachable() {
+        try (var socket = new Socket()) {
+            socket.connect(new InetSocketAddress(MOCKSERVER_HOST, MOCKSERVER_PORT), MOCKSERVER_CONNECT_TIMEOUT_MILLIS);
+            return true;
+        } catch (IOException e) {
+            return false;
         }
     }
 
     @Test
     @DisplayName("Mint fails when DataCite returns an error")
     void mintFailsOnDataciteError() {
-        createDataciteErrorExpectation();
+        createRequest.getTitle().get(0).setText(DATACITE_ERROR_TITLE_SENTINEL + " " + UUID.randomUUID());
 
         try {
             raidApi.mintRaid(createRequest);
@@ -61,39 +48,5 @@ public class DataciteErrorIntegrationTest extends AbstractIntegrationTest {
         } catch (FeignException e) {
             assertThat(e.status()).isEqualTo(500);
         }
-    }
-
-    private void createDataciteErrorExpectation() {
-        final var expectation = """
-                [{
-                    "id": "%s",
-                    "priority": 10,
-                    "httpRequest": {
-                        "method": "POST",
-                        "path": "/dois",
-                        "headers": {
-                            "Authorization": ["Basic ZGF0YWNpdGUtdXNlcm5hbWU6ZGF0YWNpdGUtcGFzc3dvcmQ="],
-                            "Content-Type": ["application/json"]
-                        }
-                    },
-                    "httpResponse": {
-                        "statusCode": 429,
-                        "headers": {
-                            "Content-Type": ["application/json"]
-                        },
-                        "body": {
-                            "errors": [{"status": "429", "title": "Too Many Requests"}]
-                        }
-                    },
-                    "times": {
-                        "remainingTimes": 1,
-                        "unlimited": false
-                    }
-                }]
-                """.formatted(EXPECTATION_ID);
-
-        var headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        restTemplate.put(MOCKSERVER_EXPECTATION_URL, new HttpEntity<>(expectation, headers));
     }
 }


### PR DESCRIPTION
## What

Re-lands the RAID-731 fix for `DataciteErrorIntegrationTest` onto `main` (cherry-pick of `ba56b5f5`).

The test previously programmed a MockServer expectation at runtime via a hardcoded `http://localhost:1080/mockserver/expectation`. In the `Branch-Build-Deploy` pipeline no Docker stack runs, so that call fails with connection refused during test setup, failing `intTest` for the whole branch. This change defines the DataCite 429 expectation statically in `docker-compose/mockserver/expectations.json` (matched by a sentinel string in the raid title, priority 10 over the generic 201 expectations) and skips the test via JUnit `Assumptions` when MockServer at `localhost:1080` is unreachable.

## Why this PR exists

The fix was originally raised as PR #560, which was **closed without merging**. The commit only survived on the unmerged RAID-712 branch (PR #558), so `main` never received it. As a result every branch cut from `main` still runs the old hardcoded test and fails `intTest` in Branch-Build-Deploy — most recently the `feature/RAID-733` execution `cd33496f-48bc-4d32-83ac-4cc2ea5a6912`, where this was the only failing test (165/166 passed).

This PR decouples the test fix from the larger RAID-712 feature and lands it on `main` directly so all branch pipelines are unblocked.

## Verification

- Cherry-pick applied cleanly onto current `main`.
- `./gradlew :api-svc:raid-api:compileIntTestJava` succeeds (warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)