### PR TITLE
RAID-757: add related objects to schema.org output

### DIFF
--- a/documentation/20260721-related-objects-schema-org-raid-757.md
+++ b/documentation/20260721-related-objects-schema-org-raid-757.md
@@ -25,6 +25,10 @@ node carries:
 - `additionalType` — the RAiD category id(s) (Input `.../191`, Output
   `.../190`, Internal process document `.../192`), a scalar when there is one
   and an array when there are several.
+- `name` — the formatted (APA) citation text, when present. This is the same
+  string the landing page shows in its "Citation" field, fetched from DOI.org
+  by the `fetch-raids.js` build step and attached to each related object as
+  `citation.text`. Omitted when no citation text was resolved.
 
 ## Why
 

--- a/documentation/20260721-related-objects-schema-org-raid-757.md
+++ b/documentation/20260721-related-objects-schema-org-raid-757.md
@@ -1,0 +1,67 @@
+# RAID-757: Related objects missing from schema.org output
+
+- **JIRA:** [RAID-757](https://ardc.atlassian.net/browse/RAID-757) (Bug)
+- **Related:** HELP-2753 (RAiD Metadata in RDA — NESP Domain Data Portal)
+- **PR:** [au-research/raid-au#572](https://github.com/au-research/raid-au/pull/572)
+- **Date:** 2026-07-21
+
+## What changed
+
+Related objects (inputs and outputs) that appear on a RAiD landing page were
+completely absent from the static site's schema.org JSON-LD. `json-ld.ts`
+emitted contributors and organisations (via `member`) and related RAiDs (via
+`isPartOf`/`hasPart`/`isBasedOn`/`isRelatedTo`), but had no handling for
+`relatedObject` at all.
+
+`buildResearchProjectJsonLd` now emits every related object as a schema.org
+`CreativeWork` node in a flat `citation` array on the `ResearchProject`. Each
+node carries:
+
+- `@id` — the object's identifier URL.
+- `identifier` — a `PropertyValue` whose `propertyID`/`name` are derived from
+  the object's `schemaUri`. DOI, ARK and ISBN are typed explicitly (mirroring
+  the backend DataCite export in `DataciteRelatedIdentifierFactory`); every
+  other scheme falls back to a plain URL identifier.
+- `additionalType` — the RAiD category id(s) (Input `.../191`, Output
+  `.../190`, Internal process document `.../192`), a scalar when there is one
+  and an array when there are several.
+
+## Why
+
+RDA flagged the gap while mapping RAiD records into their metadata pipeline
+(HELP-2753). Example: `https://raid.org/10.83062/32801913` shows two outputs on
+its landing page but neither appeared in its schema.org output, so downstream
+harvesters could not discover a record's outputs.
+
+## Design decision
+
+Related objects are emitted as a single flat `citation` list rather than split
+across distinct schema.org properties by category. This was chosen (over a
+category-aware mapping such as Output→`subjectOf`) because it matches the flat
+landing-page list, is the most reliably harvested schema.org shape, and avoids
+a debatable Output→`subjectOf` semantic. `citation` is strictly a `CreativeWork`
+property while `ResearchProject` descends from `Organization`; this deviation is
+deliberate and consistent with the file's existing loose use of CreativeWork
+properties on the project. A code comment records this so it is not "corrected"
+later.
+
+## Testing
+
+`npx vitest run src/utils/json-ld.test.ts` — 32 passing (9 new), covering a
+single citation, a mixed input/output flat list, DOI/ARK/ISBN typing, the URL
+fallback, the multi-category `additionalType` array, no-category omission,
+no-id skip, and empty-array omission.
+
+## Verifying after deploy
+
+Re-check `10.83062/32801913` (or an equivalent record with outputs) and confirm
+its outputs appear in the `citation` array of the rendered
+`application/ld+json` block.
+
+## Notes
+
+- The local fetched dataset (`src/raw-data/raids.json`, 42 records) contains no
+  related objects, so verification relies on the unit tests plus a
+  post-deploy check against a real record.
+- `tsc --noEmit` reports one pre-existing, unrelated error (missing
+  build-generated `raw-data/embargoed-raids.json`); the change itself is clean.

--- a/raid-agency-app-static/src/utils/json-ld.test.ts
+++ b/raid-agency-app-static/src/utils/json-ld.test.ts
@@ -374,6 +374,46 @@ describe("buildResearchProjectJsonLd", () => {
     ]);
   });
 
+  it("carries the formatted citation text on name when present", () => {
+    const raid = minimalRaid();
+    const relatedObject = {
+      id: "https://doi.org/10.1007/s00442-014-2977-8",
+      schemaUri: "https://doi.org/",
+      type: { id: "https://vocabulary.raid.org/relatedObject.type.schema/250", schemaUri: "" },
+      category: [
+        { id: "https://vocabulary.raid.org/relatedObject.category.id/190", schemaUri: "" },
+      ],
+      citation: {
+        text: "Smith, J. (2014). A study of things. Oecologia, 176(2), 1-10.",
+      },
+    };
+    // citation is added to relatedObject at build time by fetch-raids.js and is
+    // not part of the generated RelatedObject type, so cast through unknown.
+    raid.relatedObject = [relatedObject as unknown as (typeof raid.relatedObject)[number]];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.citation?.[0].name).toBe(
+      "Smith, J. (2014). A study of things. Oecologia, 176(2), 1-10."
+    );
+  });
+
+  it("omits name when the related object has no citation text", () => {
+    const raid = minimalRaid();
+    raid.relatedObject = [
+      {
+        id: "https://doi.org/10.1007/no-citation",
+        schemaUri: "https://doi.org/",
+        type: { id: "https://vocabulary.raid.org/relatedObject.type.schema/250", schemaUri: "" },
+        category: [
+          { id: "https://vocabulary.raid.org/relatedObject.category.id/190", schemaUri: "" },
+        ],
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.citation?.[0]).not.toHaveProperty("name");
+  });
+
   it("includes both outputs and inputs in a single flat citation list", () => {
     const raid = minimalRaid();
     raid.relatedObject = [

--- a/raid-agency-app-static/src/utils/json-ld.test.ts
+++ b/raid-agency-app-static/src/utils/json-ld.test.ts
@@ -336,6 +336,184 @@ describe("buildResearchProjectJsonLd", () => {
     expect(result).not.toHaveProperty("hasPart");
     expect(result).not.toHaveProperty("isBasedOn");
     expect(result).not.toHaveProperty("isRelatedTo");
+    expect(result).not.toHaveProperty("citation");
+  });
+
+  it("maps related objects to citation CreativeWork nodes", () => {
+    const raid = minimalRaid();
+    raid.relatedObject = [
+      {
+        id: "https://doi.org/10.1007/s00442-014-2977-8",
+        schemaUri: "https://doi.org/",
+        type: {
+          id: "https://vocabulary.raid.org/relatedObject.type.schema/250",
+          schemaUri: "https://vocabulary.raid.org/relatedObject.type.schema",
+        },
+        category: [
+          {
+            id: "https://vocabulary.raid.org/relatedObject.category.id/190",
+            schemaUri: "https://vocabulary.raid.org/relatedObject.category.schema",
+          },
+        ],
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.citation).toEqual([
+      {
+        "@type": "CreativeWork",
+        "@id": "https://doi.org/10.1007/s00442-014-2977-8",
+        identifier: {
+          "@type": "PropertyValue",
+          propertyID: "https://registry.identifiers.org/registry/doi",
+          name: "DOI",
+          value: "https://doi.org/10.1007/s00442-014-2977-8",
+        },
+        additionalType: "https://vocabulary.raid.org/relatedObject.category.id/190",
+      },
+    ]);
+  });
+
+  it("includes both outputs and inputs in a single flat citation list", () => {
+    const raid = minimalRaid();
+    raid.relatedObject = [
+      {
+        id: "https://doi.org/10.1007/s00442-014-2977-8",
+        schemaUri: "https://doi.org/",
+        type: { id: "https://vocabulary.raid.org/relatedObject.type.schema/250", schemaUri: "" },
+        category: [
+          { id: "https://vocabulary.raid.org/relatedObject.category.id/190", schemaUri: "" },
+        ],
+      },
+      {
+        id: "https://doi.org/10.4227/05/598bd8a2e9e76",
+        schemaUri: "https://doi.org/",
+        type: { id: "https://vocabulary.raid.org/relatedObject.type.schema/269", schemaUri: "" },
+        category: [
+          { id: "https://vocabulary.raid.org/relatedObject.category.id/191", schemaUri: "" },
+        ],
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.citation).toHaveLength(2);
+    expect(result.citation?.map((c) => c["@id"])).toEqual([
+      "https://doi.org/10.1007/s00442-014-2977-8",
+      "https://doi.org/10.4227/05/598bd8a2e9e76",
+    ]);
+    expect(result.citation?.[0].additionalType).toBe(
+      "https://vocabulary.raid.org/relatedObject.category.id/190"
+    );
+    expect(result.citation?.[1].additionalType).toBe(
+      "https://vocabulary.raid.org/relatedObject.category.id/191"
+    );
+  });
+
+  it("falls back to a URL identifier for a schemaUri outside the DOI/ARK/ISBN set", () => {
+    const raid = minimalRaid();
+    raid.relatedObject = [
+      {
+        id: "https://scicrunch.org/resolver/RRID:SCR_000000",
+        schemaUri: "https://scicrunch.org/resolver/",
+        type: { id: "https://vocabulary.raid.org/relatedObject.type.schema/266", schemaUri: "" },
+        category: [
+          { id: "https://vocabulary.raid.org/relatedObject.category.id/190", schemaUri: "" },
+        ],
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.citation?.[0].identifier).toEqual({
+      "@type": "PropertyValue",
+      propertyID: "https://scicrunch.org/resolver/",
+      name: "URL",
+      value: "https://scicrunch.org/resolver/RRID:SCR_000000",
+    });
+  });
+
+  it("maps ARK and ISBN schemaUris to their identifier types", () => {
+    const raid = minimalRaid();
+    raid.relatedObject = [
+      {
+        id: "https://arks.org/12345/abcde",
+        schemaUri: "https://arks.org/",
+        type: { id: "https://vocabulary.raid.org/relatedObject.type.schema/250", schemaUri: "" },
+      },
+      {
+        id: "https://www.isbn-international.org/978-3-16-148410-0",
+        schemaUri: "https://www.isbn-international.org/",
+        type: { id: "https://vocabulary.raid.org/relatedObject.type.schema/258", schemaUri: "" },
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.citation?.[0].identifier.propertyID).toBe(
+      "https://registry.identifiers.org/registry/ark"
+    );
+    expect(result.citation?.[0].identifier.name).toBe("ARK");
+    expect(result.citation?.[1].identifier.propertyID).toBe(
+      "https://registry.identifiers.org/registry/isbn"
+    );
+    expect(result.citation?.[1].identifier.name).toBe("ISBN");
+  });
+
+  it("emits additionalType as an array when a related object has multiple categories", () => {
+    const raid = minimalRaid();
+    raid.relatedObject = [
+      {
+        id: "https://doi.org/10.1007/example",
+        schemaUri: "https://doi.org/",
+        type: { id: "https://vocabulary.raid.org/relatedObject.type.schema/250", schemaUri: "" },
+        category: [
+          { id: "https://vocabulary.raid.org/relatedObject.category.id/190", schemaUri: "" },
+          { id: "https://vocabulary.raid.org/relatedObject.category.id/192", schemaUri: "" },
+        ],
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.citation?.[0].additionalType).toEqual([
+      "https://vocabulary.raid.org/relatedObject.category.id/190",
+      "https://vocabulary.raid.org/relatedObject.category.id/192",
+    ]);
+  });
+
+  it("omits additionalType when a related object has no category", () => {
+    const raid = minimalRaid();
+    raid.relatedObject = [
+      {
+        id: "https://doi.org/10.1007/no-category",
+        schemaUri: "https://doi.org/",
+        type: { id: "https://vocabulary.raid.org/relatedObject.type.schema/250", schemaUri: "" },
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.citation?.[0]).not.toHaveProperty("additionalType");
+  });
+
+  it("skips related objects without an id", () => {
+    const raid = minimalRaid();
+    raid.relatedObject = [
+      {
+        schemaUri: "https://doi.org/",
+        type: { id: "https://vocabulary.raid.org/relatedObject.type.schema/250", schemaUri: "" },
+        category: [
+          { id: "https://vocabulary.raid.org/relatedObject.category.id/190", schemaUri: "" },
+        ],
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result).not.toHaveProperty("citation");
+  });
+
+  it("omits citation when relatedObject is empty", () => {
+    const raid = minimalRaid();
+    raid.relatedObject = [];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result).not.toHaveProperty("citation");
   });
 
   it("maps IsPartOf related raid to isPartOf", () => {

--- a/raid-agency-app-static/src/utils/json-ld.ts
+++ b/raid-agency-app-static/src/utils/json-ld.ts
@@ -1,4 +1,4 @@
-import type { Contributor, Organisation, RaidDto, RelatedRaid } from "@/generated/raid";
+import type { Contributor, Organisation, RaidDto, RelatedObject, RelatedRaid } from "@/generated/raid";
 
 const PRIMARY_TITLE_TYPE = "https://vocabulary.raid.org/title.type.schema/5";
 const PRIMARY_DESCRIPTION_TYPE = "https://vocabulary.raid.org/description.type.schema/318";
@@ -7,6 +7,17 @@ const FUNDER_ORGANISATION_ROLE = "https://vocabulary.raid.org/organisation.role.
 const RELATED_RAID_TYPE_IS_PART_OF = "https://vocabulary.raid.org/relatedRaid.type.schema/202";
 const RELATED_RAID_TYPE_HAS_PART = "https://vocabulary.raid.org/relatedRaid.type.schema/201";
 const RELATED_RAID_TYPE_IS_DERIVED_FROM = "https://vocabulary.raid.org/relatedRaid.type.schema/200";
+
+// Maps a related object's schemaUri to the identifier metadata used in the
+// schema.org PropertyValue. Mirrors the backend DataCite export, which only
+// treats ARK/DOI/ISBN as distinct identifier types; every other scheme
+// (Handle, web.archive.org, SciCrunch, etc.) is a plain URL and falls through
+// to the generic URL fallback below.
+const RELATED_OBJECT_IDENTIFIER_TYPES: Record<string, { propertyID: string; name: string }> = {
+  "https://doi.org/": { propertyID: "https://registry.identifiers.org/registry/doi", name: "DOI" },
+  "https://arks.org/": { propertyID: "https://registry.identifiers.org/registry/ark", name: "ARK" },
+  "https://www.isbn-international.org/": { propertyID: "https://registry.identifiers.org/registry/isbn", name: "ISBN" },
+};
 
 interface PropertyValue {
   "@type": "PropertyValue";
@@ -41,6 +52,13 @@ interface RelatedResearchProject {
   relationshipType?: string;
 }
 
+interface CreativeWorkReference {
+  "@type": "CreativeWork";
+  "@id": string;
+  identifier: PropertyValue;
+  additionalType?: string | string[];
+}
+
 interface ResearchProjectJsonLd {
   "@context": "https://schema.org";
   "@type": "ResearchProject";
@@ -59,6 +77,7 @@ interface ResearchProjectJsonLd {
   member: Role[];
   funder: Role[];
   knowsAbout: DefinedTerm[];
+  citation?: CreativeWorkReference[];
   isPartOf?: RelatedResearchProject[];
   hasPart?: RelatedResearchProject[];
   isBasedOn?: RelatedResearchProject[];
@@ -166,6 +185,51 @@ function buildRelatedRaidProperties(relatedRaids: RelatedRaid[]): Pick<ResearchP
   };
 }
 
+// Related objects (inputs/outputs) are emitted as a flat list of schema.org
+// CreativeWork nodes under `citation`. `citation` is strictly a CreativeWork
+// property whereas ResearchProject descends from Organization, but this file
+// already uses CreativeWork properties (isPartOf/hasPart/isBasedOn) on the
+// project loosely, consistent with how harvesters consume the output. The
+// category (Input/Output/Internal) is preserved on `additionalType` rather
+// than split across distinct schema.org properties (see RAID-757).
+function buildRelatedObjectCitations(relatedObjects: RelatedObject[]): CreativeWorkReference[] {
+  const citations: CreativeWorkReference[] = [];
+
+  for (const related of relatedObjects) {
+    if (!related.id) continue;
+
+    const identifierType = RELATED_OBJECT_IDENTIFIER_TYPES[related.schemaUri ?? ""] ?? {
+      propertyID: related.schemaUri ?? "",
+      name: "URL",
+    };
+
+    const categoryIds = (related.category ?? [])
+      .map((c) => c.id)
+      .filter((id): id is string => Boolean(id));
+
+    const citation: CreativeWorkReference = {
+      "@type": "CreativeWork",
+      "@id": related.id,
+      identifier: {
+        "@type": "PropertyValue",
+        propertyID: identifierType.propertyID,
+        name: identifierType.name,
+        value: related.id,
+      },
+    };
+
+    if (categoryIds.length === 1) {
+      citation.additionalType = categoryIds[0];
+    } else if (categoryIds.length > 1) {
+      citation.additionalType = categoryIds;
+    }
+
+    citations.push(citation);
+  }
+
+  return citations;
+}
+
 export function buildResearchProjectJsonLd(raid: Partial<RaidDto>): ResearchProjectJsonLd {
   const registrationAgencyId = raid.identifier?.registrationAgency?.id ?? "";
 
@@ -191,6 +255,8 @@ export function buildResearchProjectJsonLd(raid: Partial<RaidDto>): ResearchProj
     "@id": subject.id,
     inDefinedTermSet: subject.schemaUri,
   }));
+
+  const citations = buildRelatedObjectCitations(raid.relatedObject ?? []);
 
   const primaryTitle = raid.title?.find((t) => t.type?.id === PRIMARY_TITLE_TYPE)?.text
     ?? raid.title?.at(0)?.text
@@ -227,6 +293,7 @@ export function buildResearchProjectJsonLd(raid: Partial<RaidDto>): ResearchProj
     member: memberRoles,
     funder: funderRoles,
     knowsAbout: subjects,
+    ...(citations.length > 0 && { citation: citations }),
     ...buildRelatedRaidProperties(raid.relatedRaid ?? []),
   };
 }

--- a/raid-agency-app-static/src/utils/json-ld.ts
+++ b/raid-agency-app-static/src/utils/json-ld.ts
@@ -1,4 +1,5 @@
-import type { Contributor, Organisation, RaidDto, RelatedObject, RelatedRaid } from "@/generated/raid";
+import type { Contributor, Organisation, RaidDto, RelatedRaid } from "@/generated/raid";
+import type { RelatedObjectWithCitation } from "@/model/raid";
 
 const PRIMARY_TITLE_TYPE = "https://vocabulary.raid.org/title.type.schema/5";
 const PRIMARY_DESCRIPTION_TYPE = "https://vocabulary.raid.org/description.type.schema/318";
@@ -55,6 +56,7 @@ interface RelatedResearchProject {
 interface CreativeWorkReference {
   "@type": "CreativeWork";
   "@id": string;
+  name?: string;
   identifier: PropertyValue;
   additionalType?: string | string[];
 }
@@ -192,7 +194,12 @@ function buildRelatedRaidProperties(relatedRaids: RelatedRaid[]): Pick<ResearchP
 // project loosely, consistent with how harvesters consume the output. The
 // category (Input/Output/Internal) is preserved on `additionalType` rather
 // than split across distinct schema.org properties (see RAID-757).
-function buildRelatedObjectCitations(relatedObjects: RelatedObject[]): CreativeWorkReference[] {
+//
+// The formatted citation text (APA string fetched from DOI.org by the
+// fetch-raids build step, and shown on the landing page) is carried on `name`
+// when present, so harvesters get the same human-readable reference the page
+// displays rather than a bare identifier.
+function buildRelatedObjectCitations(relatedObjects: RelatedObjectWithCitation[]): CreativeWorkReference[] {
   const citations: CreativeWorkReference[] = [];
 
   for (const related of relatedObjects) {
@@ -217,6 +224,11 @@ function buildRelatedObjectCitations(relatedObjects: RelatedObject[]): CreativeW
         value: related.id,
       },
     };
+
+    const citationText = related.citation?.text?.trim();
+    if (citationText) {
+      citation.name = citationText;
+    }
 
     if (categoryIds.length === 1) {
       citation.additionalType = categoryIds[0];
@@ -256,7 +268,9 @@ export function buildResearchProjectJsonLd(raid: Partial<RaidDto>): ResearchProj
     inDefinedTermSet: subject.schemaUri,
   }));
 
-  const citations = buildRelatedObjectCitations(raid.relatedObject ?? []);
+  const citations = buildRelatedObjectCitations(
+    (raid.relatedObject ?? []) as RelatedObjectWithCitation[]
+  );
 
   const primaryTitle = raid.title?.find((t) => t.type?.id === PRIMARY_TITLE_TYPE)?.text
     ?? raid.title?.at(0)?.text


### PR DESCRIPTION
## Summary

Fixes [RAID-757](https://ardc.atlassian.net/browse/RAID-757). Related objects (inputs/outputs) shown on a RAiD landing page were completely absent from the static site's schema.org JSON-LD (`json-ld.ts`). RDA flagged this while mapping RAiD records into their metadata pipeline (HELP-2753): e.g. `10.83062/32801913` shows two outputs on its landing page but neither appeared in its schema.org output. Contributors and organisations were unaffected (already emitted via `member`); only `relatedObject` had no corresponding field.

## Change

`buildResearchProjectJsonLd` now emits every related object as a schema.org `CreativeWork` node in a flat `citation` array on the `ResearchProject`. Each node has:

- `@id` — the object's identifier URL
- `identifier` — a `PropertyValue` with `propertyID`/`name` derived from the object's `schemaUri`. DOI/ARK/ISBN are typed explicitly (mirroring the backend DataCite export); every other scheme falls back to a plain URL identifier.
- `additionalType` — the RAiD category id(s) (Input/Output/Internal), scalar when one, array when several.

Per the design decision on the ticket, related objects are kept as a single flat list rather than split across distinct schema.org properties by category. A code comment documents why `citation` (a CreativeWork property) is used on a ResearchProject, consistent with the existing `isPartOf`/`hasPart` usage in the same file.

## Testing

`npx vitest run src/utils/json-ld.test.ts` — 32 passing (9 new), covering: single citation, mixed input/output flat list, DOI/ARK/ISBN typing, URL fallback, multi-category `additionalType` array, no-category omission, no-id skip, and empty-array omission.

## Verifying the fix

After deploy, re-check `10.83062/32801913` (or an equivalent record with outputs) and confirm its outputs appear in the `citation` array of the rendered `application/ld+json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)