### PR TITLE
RAID-756: include resolved vocabulary labels in schema.org output

### DIFF
--- a/documentation/20260722-vocab-labels-schema-org-raid-756.md
+++ b/documentation/20260722-vocab-labels-schema-org-raid-756.md
@@ -1,0 +1,52 @@
+# RAID-756: Include resolved vocabulary labels in schema.org output
+
+- **JIRA:** [RAID-756](https://ardc.atlassian.net/browse/RAID-756) (Story)
+- **PR:** [au-research/raid-au#574](https://github.com/au-research/raid-au/pull/574)
+- **Date:** 2026-07-22
+
+## What changed and why
+
+RDA (Melanie Barlow) is mapping RAiD's schema.org output for the NESP Domain
+Data Portal and flagged that vocabulary-backed fields exposed only the raw
+vocabulary URI, with no resolved label. Consumers had to resolve the URIs
+themselves, which RDA described as cumbersome. The RAiD UI already displays
+resolved labels; this change brings the harvestable schema.org output in line.
+
+All changes are in `raid-agency-app-static/src/utils/json-ld.ts`. Labels are
+resolved **at build time** from the same static mapping files the UI renders
+from (`src/mapping/data/general-mapping.json`, `subject-mapping.json`), so no
+runtime fetching or new data dependency is introduced.
+
+### Field groups (all four implemented together, per AC4)
+
+| Field group | Change | Label source |
+|---|---|---|
+| contributor.position | `Role.roleName` now the resolved label (`@id` keeps the URI) | `general-mapping.json` (`key === id`) |
+| contributor.role (CRediT) | `roleName` derived from the URI slug via `kebabToTitle` | mirrors `contributor-roles.astro`; not present in general-mapping.json |
+| organisation.role | `Role.roleName` now the resolved label | `general-mapping.json` |
+| subject (ANZSRC FoR) | `knowsAbout` DefinedTerm gains a `name` property | `subject-mapping.json` (`definition === id`) |
+| relatedRaid.type (isRelatedTo) | adds `relationshipTypeName` alongside the existing `relationshipType` URI | `general-mapping.json` |
+
+### Design decisions
+
+- **Roles:** `@id` keeps the vocabulary URI; `roleName` carries the resolved
+  label (schema.org `roleName` accepts text). No information is lost.
+- **relatedRaid.type:** used a non-breaking sibling field
+  (`relationshipTypeName`) rather than restructuring `relationshipType` into a
+  nested object, so any existing consumer reading it as a string keeps working.
+- **Graceful degradation:** `roleName` falls back to the URI when a term is
+  unmapped; subject `name` and `relationshipTypeName` are omitted when unmapped
+  (no redundant URI duplication).
+
+### Out of scope (per ticket)
+
+title.type, description.type, access.type, traditionalKnowledge, and
+relatedObject (the last is a separate missing-data concern, RAID-757).
+
+## Testing
+
+- `npx vitest run src/utils/json-ld.test.ts` — 38 passing. Existing assertions
+  updated for the new labels; new cases added for multi-word CRediT slug
+  derivation, subject-name omission on an unmapped code, `relationshipTypeName`
+  omission on an unmapped type, and `roleName` URI fallback.
+- `npx tsc --noEmit` — 0 errors.

--- a/raid-agency-app-static/src/utils/json-ld.test.ts
+++ b/raid-agency-app-static/src/utils/json-ld.test.ts
@@ -179,8 +179,8 @@ describe("buildResearchProjectJsonLd", () => {
         ],
         role: [
           {
-            schemaUri: "https://vocabulary.raid.org",
-            id: "https://vocabulary.raid.org/contributor.role.schema/conceptualization",
+            schemaUri: "https://credit.niso.org",
+            id: "https://credit.niso.org/contributor-roles/data-curation/",
           },
         ],
       },
@@ -192,7 +192,7 @@ describe("buildResearchProjectJsonLd", () => {
     const positionRole = result.member[0];
     expect(positionRole["@type"]).toBe("Role");
     expect(positionRole["@id"]).toBe("https://vocabulary.raid.org/contributor.position.schema/307");
-    expect(positionRole.roleName).toBe("https://vocabulary.raid.org/contributor.position.schema/307");
+    expect(positionRole.roleName).toBe("Principal or Chief Investigator");
     expect(positionRole.startDate).toBe("2025-01-01");
     expect(positionRole.endDate).toBe("2025-12-31");
     expect(positionRole.member).toEqual({
@@ -208,8 +208,53 @@ describe("buildResearchProjectJsonLd", () => {
 
     const creditRole = result.member[1];
     expect(creditRole["@type"]).toBe("Role");
-    expect(creditRole.roleName).toBe("https://vocabulary.raid.org/contributor.role.schema/conceptualization");
+    expect(creditRole["@id"]).toBe("https://credit.niso.org/contributor-roles/data-curation/");
+    expect(creditRole.roleName).toBe("Data curation");
     expect(creditRole.member["@type"]).toBe("Person");
+  });
+
+  it("derives multi-word CRediT role labels from the URI slug", () => {
+    const raid = minimalRaid();
+    raid.contributor = [
+      {
+        id: "https://orcid.org/0000-0002-4582-7728",
+        schemaUri: "https://orcid.org",
+        role: [
+          {
+            schemaUri: "https://credit.niso.org",
+            id: "https://credit.niso.org/contributor-roles/funding-acquisition/",
+          },
+        ],
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.member[0].roleName).toBe("Funding acquisition");
+  });
+
+  it("falls back to the position URI in roleName when the vocab term is unmapped", () => {
+    const raid = minimalRaid();
+    raid.contributor = [
+      {
+        id: "https://orcid.org/0000-0002-4582-7728",
+        schemaUri: "https://orcid.org",
+        position: [
+          {
+            schemaUri: "https://vocabulary.raid.org",
+            id: "https://vocabulary.raid.org/contributor.position.schema/999",
+            startDate: "2025-01-01",
+          },
+        ],
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.member[0]["@id"]).toBe(
+      "https://vocabulary.raid.org/contributor.position.schema/999"
+    );
+    expect(result.member[0].roleName).toBe(
+      "https://vocabulary.raid.org/contributor.position.schema/999"
+    );
   });
 
   it("maps non-funder organisations to member roles", () => {
@@ -235,6 +280,7 @@ describe("buildResearchProjectJsonLd", () => {
     const orgRole = result.member[0];
     expect(orgRole["@type"]).toBe("Role");
     expect(orgRole["@id"]).toBe("https://vocabulary.raid.org/organisation.role.schema/185");
+    expect(orgRole.roleName).toBe("Contractor");
     expect(orgRole.member).toEqual({
       "@type": "Organization",
       "@id": "https://ror.org/04yx6dh41",
@@ -314,9 +360,26 @@ describe("buildResearchProjectJsonLd", () => {
       {
         "@type": "DefinedTerm",
         "@id": "https://linked.data.gov.au/def/anzsrc-for/2020/420399",
+        name: "Health services and systems not elsewhere classified",
         inDefinedTermSet: "https://vocabs.ardc.edu.au/viewById/316",
       },
     ]);
+  });
+
+  it("omits subject name when the FoR code is not in the mapping", () => {
+    const raid = minimalRaid();
+    raid.subject = [
+      {
+        id: "https://linked.data.gov.au/def/anzsrc-for/2020/000000",
+        schemaUri: "https://vocabs.ardc.edu.au/viewById/316",
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.knowsAbout[0]).not.toHaveProperty("name");
+    expect(result.knowsAbout[0]["@id"]).toBe(
+      "https://linked.data.gov.au/def/anzsrc-for/2020/000000"
+    );
   });
 
   it("handles empty/missing optional fields", () => {
@@ -644,8 +707,28 @@ describe("buildResearchProjectJsonLd", () => {
         "@id": "https://raid.org/10.26259/efgh5678",
         identifier: "https://raid.org/10.26259/efgh5678",
         relationshipType: "https://vocabulary.raid.org/relatedRaid.type.schema/204",
+        relationshipTypeName: "Continues",
       },
     ]);
+  });
+
+  it("omits relationshipTypeName when the relationship type is not in the mapping", () => {
+    const raid = minimalRaid();
+    raid.relatedRaid = [
+      {
+        id: "https://raid.org/10.26259/efgh5678",
+        type: {
+          id: "https://vocabulary.raid.org/relatedRaid.type.schema/999",
+          schemaUri: "https://vocabulary.raid.org/relatedRaid.type.schema",
+        },
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.isRelatedTo?.[0].relationshipType).toBe(
+      "https://vocabulary.raid.org/relatedRaid.type.schema/999"
+    );
+    expect(result.isRelatedTo?.[0]).not.toHaveProperty("relationshipTypeName");
   });
 
   it("groups multiple related raids under correct properties", () => {

--- a/raid-agency-app-static/src/utils/json-ld.ts
+++ b/raid-agency-app-static/src/utils/json-ld.ts
@@ -1,5 +1,8 @@
 import type { Contributor, Organisation, RaidDto, RelatedRaid } from "@/generated/raid";
 import type { RelatedObjectWithCitation } from "@/model/raid";
+import generalMapping from "@/mapping/data/general-mapping.json";
+import subjectMapping from "@/mapping/data/subject-mapping.json";
+import { kebabToTitle } from "@/utils";
 
 const PRIMARY_TITLE_TYPE = "https://vocabulary.raid.org/title.type.schema/5";
 const PRIMARY_DESCRIPTION_TYPE = "https://vocabulary.raid.org/description.type.schema/318";
@@ -19,6 +22,33 @@ const RELATED_OBJECT_IDENTIFIER_TYPES: Record<string, { propertyID: string; name
   "https://arks.org/": { propertyID: "https://registry.identifiers.org/registry/ark", name: "ARK" },
   "https://www.isbn-international.org/": { propertyID: "https://registry.identifiers.org/registry/isbn", name: "ISBN" },
 };
+
+// Resolves a RAiD vocabulary URI (contributor.position, organisation.role,
+// relatedRaid.type) to its human-readable label using the same static mapping
+// the UI renders from. Returns undefined when the URI is not in the mapping so
+// callers can decide whether to fall back to the raw URI or omit the label.
+function lookupVocabLabel(uri: string): string | undefined {
+  return generalMapping.find((entry) => entry.key === uri)?.value;
+}
+
+// CRediT contributor roles are not in general-mapping.json; the label is
+// derived from the URI slug, mirroring contributor-roles.astro (e.g.
+// https://credit.niso.org/contributor-roles/data-curation/ -> "Data curation").
+function resolveCreditRoleLabel(uri: string): string {
+  try {
+    const slug = new URL(uri).pathname.split("/").slice(-2, -1)[0];
+    return kebabToTitle(slug) || uri;
+  } catch {
+    return uri;
+  }
+}
+
+// ANZSRC FoR subjects are keyed in subject-mapping.json by the numeric code,
+// with the full linked.data.gov.au URI held on `definition`. The RaidDto
+// subject id is that full URI, so it is matched against `definition`.
+function lookupSubjectLabel(uri: string): string | undefined {
+  return subjectMapping.find((entry) => entry.definition === uri)?.value;
+}
 
 interface PropertyValue {
   "@type": "PropertyValue";
@@ -43,6 +73,7 @@ interface Role {
 interface DefinedTerm {
   "@type": "DefinedTerm";
   "@id": string;
+  name?: string;
   inDefinedTermSet: string;
 }
 
@@ -51,6 +82,7 @@ interface RelatedResearchProject {
   "@id": string;
   identifier: string;
   relationshipType?: string;
+  relationshipTypeName?: string;
 }
 
 interface CreativeWorkReference {
@@ -101,7 +133,7 @@ function buildContributorRoles(contributor: Contributor): Role[] {
   const positionRoles: Role[] = (contributor.position ?? []).map((position) => ({
     "@type": "Role",
     "@id": position.id,
-    roleName: position.id,
+    roleName: lookupVocabLabel(position.id) ?? position.id,
     startDate: position.startDate,
     endDate: position.endDate,
     member: person,
@@ -110,7 +142,7 @@ function buildContributorRoles(contributor: Contributor): Role[] {
   const creditRoles: Role[] = (contributor.role ?? []).map((role) => ({
     "@type": "Role",
     "@id": role.id,
-    roleName: role.id,
+    roleName: resolveCreditRoleLabel(role.id),
     member: person,
   }));
 
@@ -121,7 +153,7 @@ function buildOrganisationRole(organisation: Organisation, orgRole: { id: string
   return {
     "@type": "Role",
     "@id": orgRole.id,
-    roleName: orgRole.id,
+    roleName: lookupVocabLabel(orgRole.id) ?? orgRole.id,
     startDate: orgRole.startDate,
     endDate: orgRole.endDate,
     member: {
@@ -175,6 +207,10 @@ function buildRelatedRaidProperties(relatedRaids: RelatedRaid[]): Pick<ResearchP
     };
     if (property === "isRelatedTo" && related.type?.id) {
       entry.relationshipType = related.type.id;
+      const label = lookupVocabLabel(related.type.id);
+      if (label) {
+        entry.relationshipTypeName = label;
+      }
     }
     (groups[property] ??= []).push(entry);
   }
@@ -262,11 +298,15 @@ export function buildResearchProjectJsonLd(raid: Partial<RaidDto>): ResearchProj
     funderRoles.push(...buildFunderRoles(organisation));
   }
 
-  const subjects: DefinedTerm[] = (raid.subject ?? []).map((subject) => ({
-    "@type": "DefinedTerm",
-    "@id": subject.id,
-    inDefinedTermSet: subject.schemaUri,
-  }));
+  const subjects: DefinedTerm[] = (raid.subject ?? []).map((subject) => {
+    const label = lookupSubjectLabel(subject.id);
+    return {
+      "@type": "DefinedTerm",
+      "@id": subject.id,
+      ...(label && { name: label }),
+      inDefinedTermSet: subject.schemaUri,
+    };
+  });
 
   const citations = buildRelatedObjectCitations(
     (raid.relatedObject ?? []) as RelatedObjectWithCitation[]


### PR DESCRIPTION
## What & why

RDA (Melanie Barlow) flagged that the Astro static site's schema.org JSON-LD exposes vocabulary URIs (contributor roles, organisation roles, subjects, related-RAiD relationship types) without the resolved label, making the output cumbersome for the NESP Domain Data Portal to consume. The RAiD UI already shows resolved labels; this brings the harvestable schema.org output in line.

All changes are in `raid-agency-app-static/src/utils/json-ld.ts`. Labels are resolved at build time from the same static mapping files the UI renders from, so no fetching or new data dependency is introduced.

## Changes (all four field groups, per AC4 decision to do them together)

| Field group | Change | Label source |
|---|---|---|
| contributor.position | `Role.roleName` now the resolved label (`@id` keeps the URI) | `general-mapping.json` (`key === id`) |
| contributor.role (CRediT) | `roleName` derived from URI slug via `kebabToTitle` | mirrors `contributor-roles.astro` |
| organisation.role | `Role.roleName` now the resolved label | `general-mapping.json` |
| subject (ANZSRC FoR) | `knowsAbout` DefinedTerm gains a `name` property | `subject-mapping.json` (`definition === id`) |
| relatedRaid.type (isRelatedTo) | adds `relationshipTypeName` alongside the existing `relationshipType` URI | `general-mapping.json` |

Graceful degradation: `roleName` falls back to the URI when a term is unmapped; subject `name` and `relationshipTypeName` are omitted when unmapped (so no redundant URI duplication).

The `relatedRaid` label uses a non-breaking sibling field (`relationshipTypeName`) rather than restructuring `relationshipType` into an object.

## Acceptance criteria

- [x] AC1 — Role node includes resolved label alongside the URI (contributor position, CRediT role, organisation role)
- [x] AC2 — subject DefinedTerm in `knowsAbout` includes `name` with the resolved label
- [x] AC3 — isRelatedTo relationship type includes the resolved label alongside the URI
- [x] AC4 — confirmed: all four field groups implemented in one piece of work

## Testing

- `vitest run src/utils/json-ld.test.ts` — 38 passing (existing assertions updated for the new labels; new cases for CRediT slug derivation, and unmapped-term fallback/omission)
- `tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)