### PR TITLE
RAID-778: complete researchproject.yaml LinkML schema to match json-ld.ts

### DIFF
--- a/api-svc/datamodel/generated/v2/researchproject.json
+++ b/api-svc/datamodel/generated/v2/researchproject.json
@@ -8,6 +8,53 @@
             "title": "AlternativeIdentifierPropertyEnum",
             "type": "string"
         },
+        "CreativeWork": {
+            "additionalProperties": false,
+            "description": "A related research object (input/output) referenced by the project under the citation slot. See RAID-757.",
+            "properties": {
+                "@id": {
+                    "description": "The identifier of the related object (DOI, ARK, ISBN or URL)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "@type": {
+                    "description": "The schema.org type",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "additionalType": {
+                    "description": "The related object's category id(s) (Input/Output/Internal). In the live output a single category is emitted as a scalar and multiple categories as a list; the schema models this as multivalued. See RAID-757.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "identifier": {
+                    "$ref": "#/$defs/PropertyValue",
+                    "description": "Structured identifier carrying the scheme's propertyID and name. DOI/ARK/ISBN are recognised; every other scheme falls back to a generic URL identifier."
+                },
+                "name": {
+                    "description": "The formatted citation text (APA string fetched from the identifier at build time) when available; omitted otherwise.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "@id",
+                "identifier"
+            ],
+            "title": "CreativeWork",
+            "type": "object"
+        },
         "DefinedTerm": {
             "additionalProperties": false,
             "description": "A term from a controlled vocabulary",
@@ -101,15 +148,17 @@
                 },
                 "identifier": {
                     "$ref": "#/$defs/PropertyValue",
-                    "description": "Extended identifier information"
+                    "description": "Extended identifier information (the agency ROR as a PropertyValue)"
                 },
                 "name": {
-                    "description": "Name of the organization",
-                    "type": "string"
+                    "description": "Name of the organization. Optional: the live parentOrganization emitter carries only the ROR identifier, not a name.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "required": [
-                "name",
                 "identifier"
             ],
             "title": "Organization",
@@ -199,6 +248,52 @@
             "title": "PropertyValue",
             "type": "object"
         },
+        "RelatedResearchProject": {
+            "additionalProperties": false,
+            "description": "A related RAiD referenced from isPartOf/hasPart/isBasedOn/isRelatedTo. Its identifier is the plain RAiD URI string, not a PropertyValue. See RAID-706.",
+            "properties": {
+                "@id": {
+                    "description": "The related RAiD identifier",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "@type": {
+                    "description": "The schema.org type",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "identifier": {
+                    "description": "The related RAiD identifier as a plain URI string",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "relationshipType": {
+                    "description": "The raw relatedRaid.type vocabulary URI. Emitted only under isRelatedTo; the other three properties encode the relationship in the property name itself. Serialized as a bare key resolved under the schema.org @vocab in the live output.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "relationshipTypeName": {
+                    "description": "The resolved human-readable label for relationshipType, when available. Emitted only under isRelatedTo. See RAID-706/756.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "@id"
+            ],
+            "title": "RelatedResearchProject",
+            "type": "object"
+        },
         "ResearchProject": {
             "additionalProperties": false,
             "description": "A research project with contributors and organizational relationships",
@@ -221,6 +316,16 @@
                     "description": "The schema.org type",
                     "type": [
                         "string",
+                        "null"
+                    ]
+                },
+                "citation": {
+                    "description": "Related objects (research inputs/outputs) emitted as a flat list of CreativeWork references. The category is preserved on additionalType rather than split across distinct properties. See RAID-757.",
+                    "items": {
+                        "$ref": "#/$defs/CreativeWork"
+                    },
+                    "type": [
+                        "array",
                         "null"
                     ]
                 },
@@ -257,8 +362,55 @@
                         "null"
                     ]
                 },
+                "hasPart": {
+                    "description": "Related RAiDs that are part of this project (relatedRaid.type.schema/201). See RAID-706.",
+                    "items": {
+                        "$ref": "#/$defs/RelatedResearchProject"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "headline": {
+                    "description": "The primary-type title of the research project",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "identifier": {
                     "$ref": "#/$defs/PropertyValue"
+                },
+                "isBasedOn": {
+                    "description": "Related RAiDs this project is derived from (relatedRaid.type.schema/200). See RAID-706.",
+                    "items": {
+                        "$ref": "#/$defs/RelatedResearchProject"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "isPartOf": {
+                    "description": "Related RAiDs of which this project is a part (relatedRaid.type.schema/202). See RAID-706.",
+                    "items": {
+                        "$ref": "#/$defs/RelatedResearchProject"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "isRelatedTo": {
+                    "description": "Related RAiDs with any other relationship type. Carries the raw relationshipType URI and its resolved relationshipTypeName label. See RAID-706/756.",
+                    "items": {
+                        "$ref": "#/$defs/RelatedResearchProject"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 },
                 "keywords": {
                     "description": "Keywords associated with the project",
@@ -299,7 +451,7 @@
                     ]
                 },
                 "name": {
-                    "description": "The title/name of the research project",
+                    "description": "The title/name of the research project (all titles joined by \" | \")",
                     "type": [
                         "string",
                         "null"
@@ -314,7 +466,7 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The RAiD identifier owner"
+                    "description": "The RAiD registration agency: the ROR-identified organisation that operates the registration service. Emitted as an Organization whose identifier is the agency ROR. Resolved under RAID-778: both live emitters use the registration agency (the static-site json-ld.ts as parentOrganization, the API RaidJsonLdConverter as publisher). The earlier \"owner\" description was incorrect and has been superseded."
                 }
             },
             "required": [

--- a/api-svc/datamodel/generated/v2/researchproject.json
+++ b/api-svc/datamodel/generated/v2/researchproject.json
@@ -10,7 +10,7 @@
         },
         "CreativeWork": {
             "additionalProperties": false,
-            "description": "A related research object (input/output) referenced by the project under the citation slot. See RAID-757.",
+            "description": "A related research object (input/output) referenced by the project under the citation slot.",
             "properties": {
                 "@id": {
                     "description": "The identifier of the related object (DOI, ARK, ISBN or URL)",
@@ -27,7 +27,7 @@
                     ]
                 },
                 "additionalType": {
-                    "description": "The related object's category id(s) (Input/Output/Internal). In the live output a single category is emitted as a scalar and multiple categories as a list; the schema models this as multivalued. See RAID-757.",
+                    "description": "The related object's category id(s) (Input/Output/Internal). In the live output a single category is emitted as a scalar and multiple categories as a list; the schema models this as multivalued.",
                     "items": {
                         "type": "string"
                     },
@@ -250,7 +250,7 @@
         },
         "RelatedResearchProject": {
             "additionalProperties": false,
-            "description": "A related RAiD referenced from isPartOf/hasPart/isBasedOn/isRelatedTo. Its identifier is the plain RAiD URI string, not a PropertyValue. See RAID-706.",
+            "description": "A related RAiD referenced from isPartOf/hasPart/isBasedOn/isRelatedTo. Its identifier is the plain RAiD URI string, not a PropertyValue.",
             "properties": {
                 "@id": {
                     "description": "The related RAiD identifier",
@@ -281,7 +281,7 @@
                     ]
                 },
                 "relationshipTypeName": {
-                    "description": "The resolved human-readable label for relationshipType, when available. Emitted only under isRelatedTo. See RAID-706/756.",
+                    "description": "The resolved human-readable label for relationshipType, when available. Emitted only under isRelatedTo.",
                     "type": [
                         "string",
                         "null"
@@ -320,7 +320,7 @@
                     ]
                 },
                 "citation": {
-                    "description": "Related objects (research inputs/outputs) emitted as a flat list of CreativeWork references. The category is preserved on additionalType rather than split across distinct properties. See RAID-757.",
+                    "description": "Related objects (research inputs/outputs) emitted as a flat list of CreativeWork references. The category is preserved on additionalType rather than split across distinct properties.",
                     "items": {
                         "$ref": "#/$defs/CreativeWork"
                     },
@@ -363,7 +363,7 @@
                     ]
                 },
                 "hasPart": {
-                    "description": "Related RAiDs that are part of this project (relatedRaid.type.schema/201). See RAID-706.",
+                    "description": "Related RAiDs that are part of this project (relatedRaid.type.schema/201).",
                     "items": {
                         "$ref": "#/$defs/RelatedResearchProject"
                     },
@@ -383,7 +383,7 @@
                     "$ref": "#/$defs/PropertyValue"
                 },
                 "isBasedOn": {
-                    "description": "Related RAiDs this project is derived from (relatedRaid.type.schema/200). See RAID-706.",
+                    "description": "Related RAiDs this project is derived from (relatedRaid.type.schema/200).",
                     "items": {
                         "$ref": "#/$defs/RelatedResearchProject"
                     },
@@ -393,7 +393,7 @@
                     ]
                 },
                 "isPartOf": {
-                    "description": "Related RAiDs of which this project is a part (relatedRaid.type.schema/202). See RAID-706.",
+                    "description": "Related RAiDs of which this project is a part (relatedRaid.type.schema/202).",
                     "items": {
                         "$ref": "#/$defs/RelatedResearchProject"
                     },
@@ -403,7 +403,7 @@
                     ]
                 },
                 "isRelatedTo": {
-                    "description": "Related RAiDs with any other relationship type. Carries the raw relationshipType URI and its resolved relationshipTypeName label. See RAID-706/756.",
+                    "description": "Related RAiDs with any other relationship type. Carries the raw relationshipType URI and its resolved relationshipTypeName label.",
                     "items": {
                         "$ref": "#/$defs/RelatedResearchProject"
                     },
@@ -466,7 +466,7 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The RAiD registration agency: the ROR-identified organisation that operates the registration service. Emitted as an Organization whose identifier is the agency ROR. Resolved under RAID-778: both live emitters use the registration agency (the static-site json-ld.ts as parentOrganization, the API RaidJsonLdConverter as publisher). The earlier \"owner\" description was incorrect and has been superseded."
+                    "description": "The RAiD registration agency: the ROR-identified organisation that operates the registration service. Emitted as an Organization whose identifier is the agency ROR. Both live emitters use the registration agency (the static-site json-ld.ts as parentOrganization, the API RaidJsonLdConverter as publisher). The earlier \"owner\" description was incorrect and has been superseded."
                 }
             },
             "required": [

--- a/api-svc/datamodel/src/v2/researchproject.yaml
+++ b/api-svc/datamodel/src/v2/researchproject.yaml
@@ -50,7 +50,11 @@ classes:
       name:
         slot_uri: schema:name
         range: string
-        description: The title/name of the research project
+        description: The title/name of the research project (all titles joined by " | ")
+      headline:
+        slot_uri: schema:headline
+        range: string
+        description: The primary-type title of the research project
       description:
         slot_uri: schema:description
         range: string
@@ -97,7 +101,60 @@ classes:
         slot_uri: schema:parentOrganization
         range: Organization
         inlined: true
-        description: The RAiD identifier owner
+        description: >-
+          The RAiD registration agency: the ROR-identified organisation that
+          operates the registration service. Emitted as an Organization whose
+          identifier is the agency ROR. Resolved under RAID-778: both live
+          emitters use the registration agency (the static-site json-ld.ts as
+          parentOrganization, the API RaidJsonLdConverter as publisher). The
+          earlier "owner" description was incorrect and has been superseded.
+      citation:
+        slot_uri: schema:citation
+        range: CreativeWork
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+        description: >-
+          Related objects (research inputs/outputs) emitted as a flat list of
+          CreativeWork references. The category is preserved on additionalType
+          rather than split across distinct properties. See RAID-757.
+      isPartOf:
+        slot_uri: schema:isPartOf
+        range: RelatedResearchProject
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+        description: >-
+          Related RAiDs of which this project is a part
+          (relatedRaid.type.schema/202). See RAID-706.
+      hasPart:
+        slot_uri: schema:hasPart
+        range: RelatedResearchProject
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+        description: >-
+          Related RAiDs that are part of this project
+          (relatedRaid.type.schema/201). See RAID-706.
+      isBasedOn:
+        slot_uri: schema:isBasedOn
+        range: RelatedResearchProject
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+        description: >-
+          Related RAiDs this project is derived from
+          (relatedRaid.type.schema/200). See RAID-706.
+      isRelatedTo:
+        slot_uri: schema:isRelatedTo
+        range: RelatedResearchProject
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+        description: >-
+          Related RAiDs with any other relationship type. Carries the raw
+          relationshipType URI and its resolved relationshipTypeName label.
+          See RAID-706/756.
   Organization:
     class_uri: schema:Organization
     attributes:
@@ -117,13 +174,15 @@ classes:
       name:
         slot_uri: schema:name
         range: string
-        required: true
-        description: Name of the organization
+        description: >-
+          Name of the organization. Optional: the live parentOrganization
+          emitter carries only the ROR identifier, not a name.
       identifier:
         slot_uri: schema:identifier
         range: PropertyValue
         required: true
-        description: Extended identifier information
+        inlined: true
+        description: Extended identifier information (the agency ROR as a PropertyValue)
   ResearchProjectRole:
     class_uri: schema:Role
     description: A role held by a person or organization in the project
@@ -259,6 +318,86 @@ classes:
         slot_uri: schema:propertyID
         range: string
         description: Property identifier
+  CreativeWork:
+    class_uri: schema:CreativeWork
+    description: >-
+      A related research object (input/output) referenced by the project under
+      the citation slot. See RAID-757.
+    attributes:
+      type:
+        range: string
+        description: The schema.org type
+        ifabsent: string(CreativeWork)
+        alias: "@type"
+        annotations:
+          json_property: "@type"
+      id:
+        identifier: true
+        range: uriorcurie
+        description: The identifier of the related object (DOI, ARK, ISBN or URL)
+        alias: "@id"
+        annotations:
+          json_property: "@id"
+      name:
+        slot_uri: schema:name
+        range: string
+        description: >-
+          The formatted citation text (APA string fetched from the identifier
+          at build time) when available; omitted otherwise.
+      identifier:
+        slot_uri: schema:identifier
+        range: PropertyValue
+        required: true
+        inlined: true
+        description: >-
+          Structured identifier carrying the scheme's propertyID and name.
+          DOI/ARK/ISBN are recognised; every other scheme falls back to a
+          generic URL identifier.
+      additionalType:
+        slot_uri: schema:additionalType
+        range: uriorcurie
+        multivalued: true
+        description: >-
+          The related object's category id(s) (Input/Output/Internal). In the
+          live output a single category is emitted as a scalar and multiple
+          categories as a list; the schema models this as multivalued. See
+          RAID-757.
+  RelatedResearchProject:
+    class_uri: schema:ResearchProject
+    description: >-
+      A related RAiD referenced from isPartOf/hasPart/isBasedOn/isRelatedTo. Its
+      identifier is the plain RAiD URI string, not a PropertyValue. See RAID-706.
+    attributes:
+      type:
+        range: string
+        description: The schema.org type
+        ifabsent: string(ResearchProject)
+        alias: "@type"
+        annotations:
+          json_property: "@type"
+      id:
+        identifier: true
+        range: uriorcurie
+        description: The related RAiD identifier
+        alias: "@id"
+        annotations:
+          json_property: "@id"
+      identifier:
+        slot_uri: schema:identifier
+        range: string
+        description: The related RAiD identifier as a plain URI string
+      relationshipType:
+        range: uriorcurie
+        description: >-
+          The raw relatedRaid.type vocabulary URI. Emitted only under
+          isRelatedTo; the other three properties encode the relationship in
+          the property name itself. Serialized as a bare key resolved under the
+          schema.org @vocab in the live output.
+      relationshipTypeName:
+        range: string
+        description: >-
+          The resolved human-readable label for relationshipType, when
+          available. Emitted only under isRelatedTo. See RAID-706/756.
 
 enums:
   RoleType:

--- a/api-svc/datamodel/src/v2/researchproject.yaml
+++ b/api-svc/datamodel/src/v2/researchproject.yaml
@@ -104,8 +104,8 @@ classes:
         description: >-
           The RAiD registration agency: the ROR-identified organisation that
           operates the registration service. Emitted as an Organization whose
-          identifier is the agency ROR. Resolved under RAID-778: both live
-          emitters use the registration agency (the static-site json-ld.ts as
+          identifier is the agency ROR. Both live emitters use the registration
+          agency (the static-site json-ld.ts as
           parentOrganization, the API RaidJsonLdConverter as publisher). The
           earlier "owner" description was incorrect and has been superseded.
       citation:
@@ -117,7 +117,7 @@ classes:
         description: >-
           Related objects (research inputs/outputs) emitted as a flat list of
           CreativeWork references. The category is preserved on additionalType
-          rather than split across distinct properties. See RAID-757.
+          rather than split across distinct properties.
       isPartOf:
         slot_uri: schema:isPartOf
         range: RelatedResearchProject
@@ -126,7 +126,7 @@ classes:
         inlined_as_list: true
         description: >-
           Related RAiDs of which this project is a part
-          (relatedRaid.type.schema/202). See RAID-706.
+          (relatedRaid.type.schema/202).
       hasPart:
         slot_uri: schema:hasPart
         range: RelatedResearchProject
@@ -135,7 +135,7 @@ classes:
         inlined_as_list: true
         description: >-
           Related RAiDs that are part of this project
-          (relatedRaid.type.schema/201). See RAID-706.
+          (relatedRaid.type.schema/201).
       isBasedOn:
         slot_uri: schema:isBasedOn
         range: RelatedResearchProject
@@ -144,7 +144,7 @@ classes:
         inlined_as_list: true
         description: >-
           Related RAiDs this project is derived from
-          (relatedRaid.type.schema/200). See RAID-706.
+          (relatedRaid.type.schema/200).
       isRelatedTo:
         slot_uri: schema:isRelatedTo
         range: RelatedResearchProject
@@ -154,7 +154,6 @@ classes:
         description: >-
           Related RAiDs with any other relationship type. Carries the raw
           relationshipType URI and its resolved relationshipTypeName label.
-          See RAID-706/756.
   Organization:
     class_uri: schema:Organization
     attributes:
@@ -322,7 +321,7 @@ classes:
     class_uri: schema:CreativeWork
     description: >-
       A related research object (input/output) referenced by the project under
-      the citation slot. See RAID-757.
+      the citation slot.
     attributes:
       type:
         range: string
@@ -360,13 +359,12 @@ classes:
         description: >-
           The related object's category id(s) (Input/Output/Internal). In the
           live output a single category is emitted as a scalar and multiple
-          categories as a list; the schema models this as multivalued. See
-          RAID-757.
+          categories as a list; the schema models this as multivalued.
   RelatedResearchProject:
     class_uri: schema:ResearchProject
     description: >-
       A related RAiD referenced from isPartOf/hasPart/isBasedOn/isRelatedTo. Its
-      identifier is the plain RAiD URI string, not a PropertyValue. See RAID-706.
+      identifier is the plain RAiD URI string, not a PropertyValue.
     attributes:
       type:
         range: string
@@ -397,7 +395,7 @@ classes:
         range: string
         description: >-
           The resolved human-readable label for relationshipType, when
-          available. Emitted only under isRelatedTo. See RAID-706/756.
+          available. Emitted only under isRelatedTo.
 
 enums:
   RoleType:

--- a/api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml
+++ b/api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml
@@ -1714,6 +1714,46 @@ components:
       - "https://datamodel.raid.org/core/alternativeIdentifier"
       title: "AlternativeIdentifierPropertyEnum"
       type: "string"
+    CreativeWork:
+      additionalProperties: false
+      description: "A related research object (input/output) referenced by the project\
+        \ under the citation slot. See RAID-757."
+      properties:
+        '@id':
+          description: "The identifier of the related object (DOI, ARK, ISBN or URL)"
+          type:
+          - "string"
+          - "null"
+        '@type':
+          description: "The schema.org type"
+          type:
+          - "string"
+          - "null"
+        additionalType:
+          description: "The related object's category id(s) (Input/Output/Internal).\
+            \ In the live output a single category is emitted as a scalar and multiple\
+            \ categories as a list; the schema models this as multivalued. See RAID-757."
+          items:
+            type: "string"
+          type:
+          - "array"
+          - "null"
+        identifier:
+          $ref: "#/components/schemas/PropertyValue"
+          description: "Structured identifier carrying the scheme's propertyID and\
+            \ name. DOI/ARK/ISBN are recognised; every other scheme falls back to\
+            \ a generic URL identifier."
+        name:
+          description: "The formatted citation text (APA string fetched from the identifier\
+            \ at build time) when available; omitted otherwise."
+          type:
+          - "string"
+          - "null"
+      required:
+      - "@id"
+      - "identifier"
+      title: "CreativeWork"
+      type: "object"
     DefinedTerm:
       additionalProperties: false
       description: "A term from a controlled vocabulary"
@@ -1780,12 +1820,14 @@ components:
           - "null"
         identifier:
           $ref: "#/components/schemas/PropertyValue"
-          description: "Extended identifier information"
+          description: "Extended identifier information (the agency ROR as a PropertyValue)"
         name:
-          description: "Name of the organization"
-          type: "string"
+          description: "Name of the organization. Optional: the live parentOrganization\
+            \ emitter carries only the ROR identifier, not a name."
+          type:
+          - "string"
+          - "null"
       required:
-      - "name"
       - "identifier"
       title: "Organization"
       type: "object"
@@ -1850,6 +1892,44 @@ components:
           - "null"
       title: "PropertyValue"
       type: "object"
+    RelatedResearchProject:
+      additionalProperties: false
+      description: "A related RAiD referenced from isPartOf/hasPart/isBasedOn/isRelatedTo.\
+        \ Its identifier is the plain RAiD URI string, not a PropertyValue. See RAID-706."
+      properties:
+        '@id':
+          description: "The related RAiD identifier"
+          type:
+          - "string"
+          - "null"
+        '@type':
+          description: "The schema.org type"
+          type:
+          - "string"
+          - "null"
+        identifier:
+          description: "The related RAiD identifier as a plain URI string"
+          type:
+          - "string"
+          - "null"
+        relationshipType:
+          description: "The raw relatedRaid.type vocabulary URI. Emitted only under\
+            \ isRelatedTo; the other three properties encode the relationship in the\
+            \ property name itself. Serialized as a bare key resolved under the schema.org\
+            \ @vocab in the live output."
+          type:
+          - "string"
+          - "null"
+        relationshipTypeName:
+          description: "The resolved human-readable label for relationshipType, when\
+            \ available. Emitted only under isRelatedTo. See RAID-706/756."
+          type:
+          - "string"
+          - "null"
+      required:
+      - "@id"
+      title: "RelatedResearchProject"
+      type: "object"
     ResearchProject:
       additionalProperties: false
       description: "A research project with contributors and organizational relationships"
@@ -1868,6 +1948,15 @@ components:
           description: "The schema.org type"
           type:
           - "string"
+          - "null"
+        citation:
+          description: "Related objects (research inputs/outputs) emitted as a flat\
+            \ list of CreativeWork references. The category is preserved on additionalType\
+            \ rather than split across distinct properties. See RAID-757."
+          items:
+            $ref: "#/components/schemas/CreativeWork"
+          type:
+          - "array"
           - "null"
         description:
           description: "Description of the research project"
@@ -1893,8 +1982,46 @@ components:
           type:
           - "array"
           - "null"
+        hasPart:
+          description: "Related RAiDs that are part of this project (relatedRaid.type.schema/201).\
+            \ See RAID-706."
+          items:
+            $ref: "#/components/schemas/RelatedResearchProject"
+          type:
+          - "array"
+          - "null"
+        headline:
+          description: "The primary-type title of the research project"
+          type:
+          - "string"
+          - "null"
         identifier:
           $ref: "#/components/schemas/PropertyValue"
+        isBasedOn:
+          description: "Related RAiDs this project is derived from (relatedRaid.type.schema/200).\
+            \ See RAID-706."
+          items:
+            $ref: "#/components/schemas/RelatedResearchProject"
+          type:
+          - "array"
+          - "null"
+        isPartOf:
+          description: "Related RAiDs of which this project is a part (relatedRaid.type.schema/202).\
+            \ See RAID-706."
+          items:
+            $ref: "#/components/schemas/RelatedResearchProject"
+          type:
+          - "array"
+          - "null"
+        isRelatedTo:
+          description: "Related RAiDs with any other relationship type. Carries the\
+            \ raw relationshipType URI and its resolved relationshipTypeName label.\
+            \ See RAID-706/756."
+          items:
+            $ref: "#/components/schemas/RelatedResearchProject"
+          type:
+          - "array"
+          - "null"
         keywords:
           description: "Keywords associated with the project"
           type:
@@ -1920,7 +2047,8 @@ components:
           - "array"
           - "null"
         name:
-          description: "The title/name of the research project"
+          description: "The title/name of the research project (all titles joined\
+            \ by \" | \")"
           type:
           - "string"
           - "null"
@@ -1928,7 +2056,12 @@ components:
           anyOf:
           - $ref: "#/components/schemas/Organization"
           - type: "null"
-          description: "The RAiD identifier owner"
+          description: "The RAiD registration agency: the ROR-identified organisation\
+            \ that operates the registration service. Emitted as an Organization whose\
+            \ identifier is the agency ROR. Resolved under RAID-778: both live emitters\
+            \ use the registration agency (the static-site json-ld.ts as parentOrganization,\
+            \ the API RaidJsonLdConverter as publisher). The earlier \"owner\" description\
+            \ was incorrect and has been superseded."
       required:
       - "@id"
       - "identifier"

--- a/api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml
+++ b/api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml
@@ -1717,7 +1717,7 @@ components:
     CreativeWork:
       additionalProperties: false
       description: "A related research object (input/output) referenced by the project\
-        \ under the citation slot. See RAID-757."
+        \ under the citation slot."
       properties:
         '@id':
           description: "The identifier of the related object (DOI, ARK, ISBN or URL)"
@@ -1732,7 +1732,7 @@ components:
         additionalType:
           description: "The related object's category id(s) (Input/Output/Internal).\
             \ In the live output a single category is emitted as a scalar and multiple\
-            \ categories as a list; the schema models this as multivalued. See RAID-757."
+            \ categories as a list; the schema models this as multivalued."
           items:
             type: "string"
           type:
@@ -1895,7 +1895,7 @@ components:
     RelatedResearchProject:
       additionalProperties: false
       description: "A related RAiD referenced from isPartOf/hasPart/isBasedOn/isRelatedTo.\
-        \ Its identifier is the plain RAiD URI string, not a PropertyValue. See RAID-706."
+        \ Its identifier is the plain RAiD URI string, not a PropertyValue."
       properties:
         '@id':
           description: "The related RAiD identifier"
@@ -1922,7 +1922,7 @@ components:
           - "null"
         relationshipTypeName:
           description: "The resolved human-readable label for relationshipType, when\
-            \ available. Emitted only under isRelatedTo. See RAID-706/756."
+            \ available. Emitted only under isRelatedTo."
           type:
           - "string"
           - "null"
@@ -1952,7 +1952,7 @@ components:
         citation:
           description: "Related objects (research inputs/outputs) emitted as a flat\
             \ list of CreativeWork references. The category is preserved on additionalType\
-            \ rather than split across distinct properties. See RAID-757."
+            \ rather than split across distinct properties."
           items:
             $ref: "#/components/schemas/CreativeWork"
           type:
@@ -1983,8 +1983,7 @@ components:
           - "array"
           - "null"
         hasPart:
-          description: "Related RAiDs that are part of this project (relatedRaid.type.schema/201).\
-            \ See RAID-706."
+          description: "Related RAiDs that are part of this project (relatedRaid.type.schema/201)."
           items:
             $ref: "#/components/schemas/RelatedResearchProject"
           type:
@@ -1998,16 +1997,14 @@ components:
         identifier:
           $ref: "#/components/schemas/PropertyValue"
         isBasedOn:
-          description: "Related RAiDs this project is derived from (relatedRaid.type.schema/200).\
-            \ See RAID-706."
+          description: "Related RAiDs this project is derived from (relatedRaid.type.schema/200)."
           items:
             $ref: "#/components/schemas/RelatedResearchProject"
           type:
           - "array"
           - "null"
         isPartOf:
-          description: "Related RAiDs of which this project is a part (relatedRaid.type.schema/202).\
-            \ See RAID-706."
+          description: "Related RAiDs of which this project is a part (relatedRaid.type.schema/202)."
           items:
             $ref: "#/components/schemas/RelatedResearchProject"
           type:
@@ -2015,8 +2012,7 @@ components:
           - "null"
         isRelatedTo:
           description: "Related RAiDs with any other relationship type. Carries the\
-            \ raw relationshipType URI and its resolved relationshipTypeName label.\
-            \ See RAID-706/756."
+            \ raw relationshipType URI and its resolved relationshipTypeName label."
           items:
             $ref: "#/components/schemas/RelatedResearchProject"
           type:
@@ -2058,10 +2054,10 @@ components:
           - type: "null"
           description: "The RAiD registration agency: the ROR-identified organisation\
             \ that operates the registration service. Emitted as an Organization whose\
-            \ identifier is the agency ROR. Resolved under RAID-778: both live emitters\
-            \ use the registration agency (the static-site json-ld.ts as parentOrganization,\
-            \ the API RaidJsonLdConverter as publisher). The earlier \"owner\" description\
-            \ was incorrect and has been superseded."
+            \ identifier is the agency ROR. Both live emitters use the registration\
+            \ agency (the static-site json-ld.ts as parentOrganization, the API RaidJsonLdConverter\
+            \ as publisher). The earlier \"owner\" description was incorrect and has\
+            \ been superseded."
       required:
       - "@id"
       - "identifier"

--- a/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
+++ b/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
@@ -1846,6 +1846,46 @@ components:
       - "https://datamodel.raid.org/core/alternativeIdentifier"
       title: "AlternativeIdentifierPropertyEnum"
       type: "string"
+    CreativeWork:
+      additionalProperties: false
+      description: "A related research object (input/output) referenced by the project\
+        \ under the citation slot. See RAID-757."
+      properties:
+        '@id':
+          description: "The identifier of the related object (DOI, ARK, ISBN or URL)"
+          type:
+          - "string"
+          - "null"
+        '@type':
+          description: "The schema.org type"
+          type:
+          - "string"
+          - "null"
+        additionalType:
+          description: "The related object's category id(s) (Input/Output/Internal).\
+            \ In the live output a single category is emitted as a scalar and multiple\
+            \ categories as a list; the schema models this as multivalued. See RAID-757."
+          items:
+            type: "string"
+          type:
+          - "array"
+          - "null"
+        identifier:
+          $ref: "#/components/schemas/PropertyValue"
+          description: "Structured identifier carrying the scheme's propertyID and\
+            \ name. DOI/ARK/ISBN are recognised; every other scheme falls back to\
+            \ a generic URL identifier."
+        name:
+          description: "The formatted citation text (APA string fetched from the identifier\
+            \ at build time) when available; omitted otherwise."
+          type:
+          - "string"
+          - "null"
+      required:
+      - "@id"
+      - "identifier"
+      title: "CreativeWork"
+      type: "object"
     DefinedTerm:
       additionalProperties: false
       description: "A term from a controlled vocabulary"
@@ -1912,12 +1952,14 @@ components:
           - "null"
         identifier:
           $ref: "#/components/schemas/PropertyValue"
-          description: "Extended identifier information"
+          description: "Extended identifier information (the agency ROR as a PropertyValue)"
         name:
-          description: "Name of the organization"
-          type: "string"
+          description: "Name of the organization. Optional: the live parentOrganization\
+            \ emitter carries only the ROR identifier, not a name."
+          type:
+          - "string"
+          - "null"
       required:
-      - "name"
       - "identifier"
       title: "Organization"
       type: "object"
@@ -1982,6 +2024,44 @@ components:
           - "null"
       title: "PropertyValue"
       type: "object"
+    RelatedResearchProject:
+      additionalProperties: false
+      description: "A related RAiD referenced from isPartOf/hasPart/isBasedOn/isRelatedTo.\
+        \ Its identifier is the plain RAiD URI string, not a PropertyValue. See RAID-706."
+      properties:
+        '@id':
+          description: "The related RAiD identifier"
+          type:
+          - "string"
+          - "null"
+        '@type':
+          description: "The schema.org type"
+          type:
+          - "string"
+          - "null"
+        identifier:
+          description: "The related RAiD identifier as a plain URI string"
+          type:
+          - "string"
+          - "null"
+        relationshipType:
+          description: "The raw relatedRaid.type vocabulary URI. Emitted only under\
+            \ isRelatedTo; the other three properties encode the relationship in the\
+            \ property name itself. Serialized as a bare key resolved under the schema.org\
+            \ @vocab in the live output."
+          type:
+          - "string"
+          - "null"
+        relationshipTypeName:
+          description: "The resolved human-readable label for relationshipType, when\
+            \ available. Emitted only under isRelatedTo. See RAID-706/756."
+          type:
+          - "string"
+          - "null"
+      required:
+      - "@id"
+      title: "RelatedResearchProject"
+      type: "object"
     ResearchProject:
       additionalProperties: false
       description: "A research project with contributors and organizational relationships"
@@ -2000,6 +2080,15 @@ components:
           description: "The schema.org type"
           type:
           - "string"
+          - "null"
+        citation:
+          description: "Related objects (research inputs/outputs) emitted as a flat\
+            \ list of CreativeWork references. The category is preserved on additionalType\
+            \ rather than split across distinct properties. See RAID-757."
+          items:
+            $ref: "#/components/schemas/CreativeWork"
+          type:
+          - "array"
           - "null"
         description:
           description: "Description of the research project"
@@ -2025,8 +2114,46 @@ components:
           type:
           - "array"
           - "null"
+        hasPart:
+          description: "Related RAiDs that are part of this project (relatedRaid.type.schema/201).\
+            \ See RAID-706."
+          items:
+            $ref: "#/components/schemas/RelatedResearchProject"
+          type:
+          - "array"
+          - "null"
+        headline:
+          description: "The primary-type title of the research project"
+          type:
+          - "string"
+          - "null"
         identifier:
           $ref: "#/components/schemas/PropertyValue"
+        isBasedOn:
+          description: "Related RAiDs this project is derived from (relatedRaid.type.schema/200).\
+            \ See RAID-706."
+          items:
+            $ref: "#/components/schemas/RelatedResearchProject"
+          type:
+          - "array"
+          - "null"
+        isPartOf:
+          description: "Related RAiDs of which this project is a part (relatedRaid.type.schema/202).\
+            \ See RAID-706."
+          items:
+            $ref: "#/components/schemas/RelatedResearchProject"
+          type:
+          - "array"
+          - "null"
+        isRelatedTo:
+          description: "Related RAiDs with any other relationship type. Carries the\
+            \ raw relationshipType URI and its resolved relationshipTypeName label.\
+            \ See RAID-706/756."
+          items:
+            $ref: "#/components/schemas/RelatedResearchProject"
+          type:
+          - "array"
+          - "null"
         keywords:
           description: "Keywords associated with the project"
           type:
@@ -2052,7 +2179,8 @@ components:
           - "array"
           - "null"
         name:
-          description: "The title/name of the research project"
+          description: "The title/name of the research project (all titles joined\
+            \ by \" | \")"
           type:
           - "string"
           - "null"
@@ -2060,7 +2188,12 @@ components:
           anyOf:
           - $ref: "#/components/schemas/Organization"
           - type: "null"
-          description: "The RAiD identifier owner"
+          description: "The RAiD registration agency: the ROR-identified organisation\
+            \ that operates the registration service. Emitted as an Organization whose\
+            \ identifier is the agency ROR. Resolved under RAID-778: both live emitters\
+            \ use the registration agency (the static-site json-ld.ts as parentOrganization,\
+            \ the API RaidJsonLdConverter as publisher). The earlier \"owner\" description\
+            \ was incorrect and has been superseded."
       required:
       - "@id"
       - "identifier"

--- a/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
+++ b/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
@@ -1849,7 +1849,7 @@ components:
     CreativeWork:
       additionalProperties: false
       description: "A related research object (input/output) referenced by the project\
-        \ under the citation slot. See RAID-757."
+        \ under the citation slot."
       properties:
         '@id':
           description: "The identifier of the related object (DOI, ARK, ISBN or URL)"
@@ -1864,7 +1864,7 @@ components:
         additionalType:
           description: "The related object's category id(s) (Input/Output/Internal).\
             \ In the live output a single category is emitted as a scalar and multiple\
-            \ categories as a list; the schema models this as multivalued. See RAID-757."
+            \ categories as a list; the schema models this as multivalued."
           items:
             type: "string"
           type:
@@ -2027,7 +2027,7 @@ components:
     RelatedResearchProject:
       additionalProperties: false
       description: "A related RAiD referenced from isPartOf/hasPart/isBasedOn/isRelatedTo.\
-        \ Its identifier is the plain RAiD URI string, not a PropertyValue. See RAID-706."
+        \ Its identifier is the plain RAiD URI string, not a PropertyValue."
       properties:
         '@id':
           description: "The related RAiD identifier"
@@ -2054,7 +2054,7 @@ components:
           - "null"
         relationshipTypeName:
           description: "The resolved human-readable label for relationshipType, when\
-            \ available. Emitted only under isRelatedTo. See RAID-706/756."
+            \ available. Emitted only under isRelatedTo."
           type:
           - "string"
           - "null"
@@ -2084,7 +2084,7 @@ components:
         citation:
           description: "Related objects (research inputs/outputs) emitted as a flat\
             \ list of CreativeWork references. The category is preserved on additionalType\
-            \ rather than split across distinct properties. See RAID-757."
+            \ rather than split across distinct properties."
           items:
             $ref: "#/components/schemas/CreativeWork"
           type:
@@ -2115,8 +2115,7 @@ components:
           - "array"
           - "null"
         hasPart:
-          description: "Related RAiDs that are part of this project (relatedRaid.type.schema/201).\
-            \ See RAID-706."
+          description: "Related RAiDs that are part of this project (relatedRaid.type.schema/201)."
           items:
             $ref: "#/components/schemas/RelatedResearchProject"
           type:
@@ -2130,16 +2129,14 @@ components:
         identifier:
           $ref: "#/components/schemas/PropertyValue"
         isBasedOn:
-          description: "Related RAiDs this project is derived from (relatedRaid.type.schema/200).\
-            \ See RAID-706."
+          description: "Related RAiDs this project is derived from (relatedRaid.type.schema/200)."
           items:
             $ref: "#/components/schemas/RelatedResearchProject"
           type:
           - "array"
           - "null"
         isPartOf:
-          description: "Related RAiDs of which this project is a part (relatedRaid.type.schema/202).\
-            \ See RAID-706."
+          description: "Related RAiDs of which this project is a part (relatedRaid.type.schema/202)."
           items:
             $ref: "#/components/schemas/RelatedResearchProject"
           type:
@@ -2147,8 +2144,7 @@ components:
           - "null"
         isRelatedTo:
           description: "Related RAiDs with any other relationship type. Carries the\
-            \ raw relationshipType URI and its resolved relationshipTypeName label.\
-            \ See RAID-706/756."
+            \ raw relationshipType URI and its resolved relationshipTypeName label."
           items:
             $ref: "#/components/schemas/RelatedResearchProject"
           type:
@@ -2190,10 +2186,10 @@ components:
           - type: "null"
           description: "The RAiD registration agency: the ROR-identified organisation\
             \ that operates the registration service. Emitted as an Organization whose\
-            \ identifier is the agency ROR. Resolved under RAID-778: both live emitters\
-            \ use the registration agency (the static-site json-ld.ts as parentOrganization,\
-            \ the API RaidJsonLdConverter as publisher). The earlier \"owner\" description\
-            \ was incorrect and has been superseded."
+            \ identifier is the agency ROR. Both live emitters use the registration\
+            \ agency (the static-site json-ld.ts as parentOrganization, the API RaidJsonLdConverter\
+            \ as publisher). The earlier \"owner\" description was incorrect and has\
+            \ been superseded."
       required:
       - "@id"
       - "identifier"

--- a/documentation/20260727-researchproject-linkml-schema-completion-raid-778.md
+++ b/documentation/20260727-researchproject-linkml-schema-completion-raid-778.md
@@ -1,0 +1,95 @@
+# Complete researchproject.yaml LinkML schema to match json-ld.ts
+
+**Ticket:** [RAID-778](https://ardc.atlassian.net/browse/RAID-778) — Complete researchproject.yaml LinkML schema to match RAID-756/757 json-ld.ts output
+**Type:** Story · **Parent epic:** [RAID-574](https://ardc.atlassian.net/browse/RAID-574)
+**Author:** Rob Leney
+**Date:** 2026-07-27
+**PR:** [au-research/raid-au#577](https://github.com/au-research/raid-au/pull/577)
+**Related:** [RAID-759](https://ardc.atlassian.net/browse/RAID-759) (investigation), [RAID-756](https://ardc.atlassian.net/browse/RAID-756), [RAID-757](https://ardc.atlassian.net/browse/RAID-757), [RAID-784](https://ardc.atlassian.net/browse/RAID-784) (follow-on: organisation names)
+
+---
+
+## 1. What changed and why
+
+Phase 1 of the RAID-759 consolidation recommendation: bring the canonical LinkML schema
+`api-svc/datamodel/src/v2/researchproject.yaml` up to what the RAID-756/757-corrected
+static-site `json-ld.ts` now emits. The static site is the only consumer-validated
+schema.org emitter (harvested by RDA / NESP, HELP-2753), so its output is treated as the
+reference specification the schema must describe.
+
+Changes to `researchproject.yaml`:
+
+- **`headline`** slot added (`schema:headline`) — the primary-type title. `name` remains the
+  pipe-joined list of all titles.
+- **`citation`** slot (`schema:citation`, multivalued) + new **`CreativeWork`** class —
+  related objects (research inputs/outputs) as a flat CreativeWork list with a PropertyValue
+  identifier (DOI/ARK/ISBN recognised, otherwise a generic URL), an optional formatted
+  citation `name`, and `additionalType` for the category (RAID-757).
+- **`isPartOf` / `hasPart` / `isBasedOn` / `isRelatedTo`** slots + new
+  **`RelatedResearchProject`** class — related RAiDs split by relationship type. Its
+  `identifier` is a plain URI string (not a PropertyValue); `isRelatedTo` additionally
+  carries `relationshipType` (raw vocab URI) and `relationshipTypeName` (resolved label)
+  (RAID-706/756).
+- **`parentOrganization`** semantics resolved to the **registration agency** (AC#2). Both
+  live emitters already use the registration agency (static site as `parentOrganization`,
+  the API `RaidJsonLdConverter` as `publisher`); only the schema *description* said "owner".
+  The description is corrected and the resolution documented in the slot.
+- **`Organization.name`** `required` flag dropped — the live `parentOrganization` emits only
+  the ROR identifier, no name.
+
+Regenerated `researchproject.json` (LinkML `gen-json-schema`) and reassembled the 3.1 OpenAPI
+specs, which merge that JSON. Four tracked files changed: the YAML source, the generated
+JSON, and the two assembled `raid-openapi-*3.1.yaml` specs.
+
+## 2. Decisions
+
+- **No bare `label` slots on Role/DefinedTerm.** The ticket's Phase 1 text listed "label slots
+  to Role/DefinedTerm", but the current `json-ld.ts` emits no `label` field; labels are carried
+  by `roleName` (Role), `name` (DefinedTerm) and `relationshipTypeName` (related RAiDs). Adding
+  bare `label` slots would introduce a discrepancy that AC#3 ("no structural discrepancies vs
+  current json-ld.ts") forbids, so they were deliberately omitted.
+- **`parentOrganization` = registration agency** (not owner) — see above. The RAID-778 ticket
+  said "two live emitters disagree"; in fact both live emitters use the registration agency, so
+  there was no real disagreement to reconcile beyond the stale schema description.
+- **`additionalType` modelled as `multivalued`.** The live output emits a scalar for one category
+  and a list for several; LinkML cannot cleanly express that scalar-or-list union, so multivalued
+  is the closest single representation (documented in the slot).
+
+## 3. AC#3 — by-hand validation against current `json-ld.ts`
+
+| json-ld.ts output | Schema slot/class | Match |
+|---|---|---|
+| `@context` / `@type` / `@id` | `context` / `type` / `id` | ✓ |
+| `name`, `headline` | `name`, `headline` | ✓ |
+| `identifier` (RAiD PropertyValue) | `identifier` → `PropertyValue` | ✓ |
+| `parentOrganization` `{@type,@id,identifier}` (no name) | `parentOrganization` → `Organization` (name optional) | ✓ |
+| `description?`, `foundingDate`, `dissolutionDate?` | same | ✓ |
+| `member[]`, `funder[]` (`Role` → Person/Org member) | `member`/`funder` → `ResearchProjectRole` → `Member` | ✓ |
+| `knowsAbout[]` (`DefinedTerm`) | `knowsAbout` → `DefinedTerm` | ✓ |
+| `citation?[]` (`CreativeWork`, PropertyValue id, name, additionalType) | `citation` → `CreativeWork` | ✓ |
+| `isPartOf/hasPart/isBasedOn/isRelatedTo?[]` (string identifier, relationshipType/Name) | 4 slots → `RelatedResearchProject` | ✓ |
+
+No structural discrepancies remain. The one representational nuance is `additionalType`
+(scalar-or-list, see §2).
+
+## 4. Verification
+
+- `./gradlew :api-svc:datamodel:generateJSONSchemaV2ResearchProject --rerun-tasks` — regenerated
+  `researchproject.json` (the task declares no `inputs`, so a forced rerun is needed after a source
+  edit).
+- `./gradlew build` — green. OpenAPI spec validation (`validateSpec = true`) accepts the merged
+  schema, and unit tests pass. The new `RelatedResearchProject.identifier` (string) vs
+  `CreativeWork.identifier` (PropertyValue) resolved to correct per-class definitions with no
+  global-slot conflict.
+
+Note on tests: the `datamodel` module has no unit-test harness, and the LinkML YAML is
+documentation/source-of-truth compiled manually to committed JSON (CI has no Docker/LinkML). Its
+automated gates are LinkML compilation and the OpenAPI spec validation in `./gradlew build`;
+structural correctness against the reference output is verified by hand per AC#3 (§3).
+
+## 5. Out of scope / follow-on
+
+Organisation names are not emitted by `json-ld.ts` today (organisations carry only a ROR id;
+names are a build-time ROR-API enrichment used only by the UI). Emitting them requires changes to
+`json-ld.ts` and `fetch-ror.js`, tracked separately under **[RAID-784](https://ardc.atlassian.net/browse/RAID-784)**.
+Once names are emitted, this schema should be updated to describe them.


### PR DESCRIPTION
## What & why

Follow-on from the RAID-759 investigation (Phase 1 under the LinkML epic RAID-574). Completes the canonical LinkML schema `api-svc/datamodel/src/v2/researchproject.yaml` so it exactly describes the RAID-756/757-corrected static-site `json-ld.ts` output, which is the only consumer-validated (RDA/HELP-2753) schema.org emitter and is therefore treated as the reference specification.

## Changes

- **`headline`** slot added (primary-type title).
- **`citation`** slot + new **`CreativeWork`** class — related objects (inputs/outputs) as a flat CreativeWork list with a PropertyValue identifier, formatted `name`, and `additionalType` category (RAID-757).
- **`isPartOf`/`hasPart`/`isBasedOn`/`isRelatedTo`** slots + new **`RelatedResearchProject`** class — related RAiDs, whose `identifier` is a plain URI string (not a PropertyValue); `isRelatedTo` carries `relationshipType` + resolved `relationshipTypeName` (RAID-706/756).
- **`parentOrganization`** resolved to the **registration agency** (AC#2). Both live emitters already use the registration agency (static site as `parentOrganization`, API `RaidJsonLdConverter` as `publisher`); only the schema *description* said "owner". Description corrected and the resolution documented.
- **`Organization.name`** `required` flag dropped — the live `parentOrganization` carries only the ROR identifier, no name.

## Deliberately out of scope

- **No bare `label` slots on Role/DefinedTerm** (listed in the ticket's Phase 1 text). The current `json-ld.ts` emits no `label` field; labels live in `roleName` (Role), `name` (DefinedTerm), and `relationshipTypeName` (related RAiDs). Adding bare `label` slots would introduce a discrepancy that AC#3 ("no structural discrepancies vs current json-ld.ts") forbids.

## Known representational nuance

- `additionalType` is modelled as `multivalued`. The live output emits a scalar for a single category and a list for multiple; LinkML cannot cleanly express that scalar-or-list union, so multivalued is the closest single representation (documented in the slot description).

## Verification

- `researchproject.json` regenerated via the LinkML generator; 3.1 OpenAPI specs reassembled.
- `./gradlew build` passes — OpenAPI spec validation (`validateSpec=true`) and unit tests green.
- Manual field-by-field validation against `json-ld.ts` (AC#3): no structural discrepancies remain.

Note: the LinkML `.yaml` has no dedicated unit-test harness (the `datamodel` module has no tests). Its automated gates are LinkML compilation and OpenAPI spec validation in the build; structural correctness against the reference output is verified by hand per AC#3.

## Tickets

- Story: [RAID-778](https://ardc.atlassian.net/browse/RAID-778)
- Parent epic: [RAID-574](https://ardc.atlassian.net/browse/RAID-574)
- Context: [RAID-759](https://ardc.atlassian.net/browse/RAID-759) (investigation), [RAID-756](https://ardc.atlassian.net/browse/RAID-756), [RAID-757](https://ardc.atlassian.net/browse/RAID-757)

🤖 Generated with [Claude Code](https://claude.com/claude-code)