### PR TITLE
RAID-775: treat blank date strings as absent when minting

### DIFF
--- a/api-svc/datamodel/generated/v2/raid-jsonschema.json
+++ b/api-svc/datamodel/generated/v2/raid-jsonschema.json
@@ -1295,7 +1295,6 @@
             "properties": {
                 "endDate": {
                     "description": "the date the project or activity title was changed or stopped being used",
-                    "pattern": "^\\s*\\S.*$",
                     "type": [
                         "string",
                         "null"

--- a/api-svc/datamodel/generated/v2/raid-strict-jsonschema.json
+++ b/api-svc/datamodel/generated/v2/raid-strict-jsonschema.json
@@ -1444,7 +1444,6 @@
       "properties": {
         "endDate": {
           "description": "the date the project or activity title was changed or stopped being used",
-          "pattern": "^\\s*\\S.*$",
           "type": [
             "string",
             "null"

--- a/api-svc/datamodel/src/v2/raid-core.yaml
+++ b/api-svc/datamodel/src/v2/raid-core.yaml
@@ -269,7 +269,6 @@ classes:
         description: the date the project or activity title was changed or stopped being used
         range: string
         required: false
-        pattern: "^\\s*\\S.*$"
         exact_mappings:
           - dcat:endDate
           - schema:endDate

--- a/api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml
+++ b/api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml
@@ -1660,7 +1660,6 @@ components:
         endDate:
           description: "the date the project or activity title was changed or stopped\
             \ being used"
-          pattern: "^\\s*\\S.*$"
           type:
           - "string"
           - "null"

--- a/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
+++ b/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
@@ -1785,7 +1785,6 @@ components:
         endDate:
           description: "the date the project or activity title was changed or stopped\
             \ being used"
-          pattern: "^\\s*\\S.*$"
           type:
           - "string"
           - "null"

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RaidIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RaidIntegrationTest.java
@@ -394,6 +394,53 @@ public class RaidIntegrationTest extends AbstractIntegrationTest {
         }
     }
 
+    @Test
+    @DisplayName("RAID-775: Mint a raid succeeds when date fields are submitted as an empty string end date")
+    void mintRaidWithEmptyStringEndDates() {
+        // RAID-775: the frontend clears an end date by sending "" rather than omitting the field
+        // or sending null. Before the fix, DateValidator (and the Title/ContributorPosition/
+        // OrganisationRole validators) only treated a null endDate as "not set" and passed any
+        // non-null value - including "" - straight into DateUtil.parseDate(), which threw
+        // InvalidDateException and surfaced as an unhandled 400. The fix treats a blank string the
+        // same as absent, so minting with "" end dates across the overall date, title, contributor
+        // position and organisation role must now succeed.
+        //
+        // NOTE: this test also caught a second, related defect: the openapi-generated Title
+        // model's getEndDate() carried a stray Bean Validation @Pattern(regexp = "^\\s*\\S.*$")
+        // constraint that Date/ContributorPosition/OrganisationRole's getEndDate() did not have.
+        // That constraint ran at controller @Valid binding, before TitleValidator ever executed,
+        // and rejected "" outright with a "notSet"/"field must be set" 400 on "title[0].endDate" -
+        // independently of the RAID-775 validator fix. Fixed by removing the stray `pattern`
+        // from Title.endDate in api-svc/datamodel/src/v2/raid-core.yaml and regenerating the
+        // model chain (generateStrictJsonSchemaV2, assembleOpenAPIV2*, openApiGenerate).
+        createRequest.getDate().setEndDate("");
+        createRequest.getTitle().get(0).setEndDate("");
+        createRequest.getContributor().get(0).getPosition().get(0).setEndDate("");
+        createRequest.getOrganisation().get(0).getRole().get(0).setEndDate("");
+
+        try {
+            final var mintedRaid = raidApi.mintRaid(createRequest).getBody();
+
+            assertThat(mintedRaid).isNotNull();
+            assertThat(mintedRaid.getIdentifier()).isNotNull();
+            assertThat(mintedRaid.getIdentifier().getId()).isNotBlank();
+
+            final var handle = new Handle(mintedRaid.getIdentifier().getId());
+            final var result = raidApi.findRaidByName(handle.getPrefix(), handle.getSuffix()).getBody();
+
+            assertThat(result).isNotNull();
+            assertThat(result.getDate().getStartDate()).isEqualTo(createRequest.getDate().getStartDate());
+            assertThat(result.getTitle().get(0).getStartDate())
+                    .isEqualTo(createRequest.getTitle().get(0).getStartDate());
+            assertThat(result.getContributor().get(0).getPosition().get(0).getStartDate())
+                    .isEqualTo(createRequest.getContributor().get(0).getPosition().get(0).getStartDate());
+            assertThat(result.getOrganisation().get(0).getRole().get(0).getStartDate())
+                    .isEqualTo(createRequest.getOrganisation().get(0).getRole().get(0).getStartDate());
+        } catch (final RaidApiValidationException e) {
+            failOnError(e);
+        }
+    }
+
     private RaidUpdateRequest mapReadToUpdate(RaidDto read) {
         return new RaidUpdateRequest()
                 .metadata(read.getMetadata())

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/validator/ContributorPositionValidator.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/validator/ContributorPositionValidator.java
@@ -28,7 +28,7 @@ public class ContributorPositionValidator {
             final ContributorPosition position, final int contributorIndex, final int positionIndex) {
         final var failures = new ArrayList<ValidationFailure>();
 
-        if (position.getStartDate() == null) {
+        if (isBlank(position.getStartDate())) {
             failures.add(
                     new ValidationFailure()
                             .fieldId("contributor[%d].position[%d].startDate".formatted(contributorIndex, positionIndex))

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/validator/ContributorTypeValidator.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/validator/ContributorTypeValidator.java
@@ -117,8 +117,8 @@ public class ContributorTypeValidator {
 
             sortedPositions.add(Map.of(
                     "index", i,
-                    "start", DateUtil.parseDate(position.getStartDate()),
-                    "end", position.getEndDate() == null ? LocalDate.now() : DateUtil.parseDate(position.getEndDate())
+                    "start", isBlank(position.getStartDate()) ? LocalDate.now() : DateUtil.parseDate(position.getStartDate()),
+                    "end", isBlank(position.getEndDate()) ? LocalDate.now() : DateUtil.parseDate(position.getEndDate())
             ));
         }
 

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/validator/ContributorValidator.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/validator/ContributorValidator.java
@@ -214,8 +214,8 @@ public class ContributorValidator {
 
             sortedPositions.add(Map.of(
                     "index", i,
-                    "start", DateUtil.parseDate(position.getStartDate()),
-                    "end", position.getEndDate() == null ? LocalDate.now() : DateUtil.parseDate(position.getEndDate())
+                    "start", isBlank(position.getStartDate()) ? LocalDate.now() : DateUtil.parseDate(position.getStartDate()),
+                    "end", isBlank(position.getEndDate()) ? LocalDate.now() : DateUtil.parseDate(position.getEndDate())
                     ));
         }
 

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/validator/DateValidator.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/validator/DateValidator.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import static au.org.raid.api.endpoint.message.ValidationMessage.END_DATE_BEFORE_START_DATE;
 import static au.org.raid.api.endpoint.message.ValidationMessage.INVALID_VALUE_TYPE;
+import static au.org.raid.api.util.StringUtil.isBlank;
 
 @Component
 public class DateValidator {
@@ -19,9 +20,9 @@ public class DateValidator {
         if (date == null) {
             failures.add(ValidationMessage.DATES_NOT_SET);
         } else {
-            if (date.getStartDate() == null) {
+            if (isBlank(date.getStartDate())) {
                 failures.add(ValidationMessage.DATES_START_DATE_NOT_SET);
-            } else if (date.getEndDate() != null && DateUtil.parseDate(date.getEndDate()).isBefore(DateUtil.parseDate(date.getStartDate()))) {
+            } else if (!isBlank(date.getEndDate()) && DateUtil.parseDate(date.getEndDate()).isBefore(DateUtil.parseDate(date.getStartDate()))) {
                 failures.add(new ValidationFailure()
                         .fieldId("date.endDate")
                         .errorType(INVALID_VALUE_TYPE)

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/validator/TitleValidator.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/validator/TitleValidator.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 import static au.org.raid.api.endpoint.message.ValidationMessage.*;
@@ -56,7 +56,7 @@ public class TitleValidator {
             if (isBlank(title.getText())) {
                 failures.add(titleNotSet(index));
             }
-            if (title.getStartDate() == null) {
+            if (isBlank(title.getStartDate())) {
                 failures.add(titleStartDateNotSet(index));
             }
             else if (!isBlank(title.getEndDate()) && DateUtil.parseDate(title.getEndDate()).isBefore(DateUtil.parseDate(title.getStartDate()))) {
@@ -85,25 +85,39 @@ public class TitleValidator {
 
         var primaryTitles = titles.stream()
                 .filter(title -> title.getType().getId() == TitleTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_TITLE_TYPE_SCHEMA_5)
-                .sorted((o1, o2) -> {
-                    if (o1.getStartDate().equals(o2.getStartDate())) {
-                        final var o1EndDate = o1.getEndDate() == null ? LocalDate.now() : DateUtil.parseDate(o1.getEndDate());
-                        final var o2EndDate = o2.getEndDate() == null ? LocalDate.now() : DateUtil.parseDate(o2.getEndDate());
+                .toList();
 
-                        return o1EndDate.compareTo(o2EndDate);
-                    }
-                    return DateUtil.parseDate(o1.getStartDate()).compareTo(DateUtil.parseDate(o2.getStartDate()));
-                })
-                .collect(Collectors.toCollection(ArrayList::new));
+        // resolve each title's start/end into concrete LocalDates up front (blank -> today) so the
+        // comparator and overlap check below never touch a raw, possibly-blank date String.
+        var resolvedTitles = new ArrayList<Map<String, Object>>();
+        for (final var title : primaryTitles) {
+            resolvedTitles.add(Map.of(
+                    "title", title,
+                    "start", isBlank(title.getStartDate()) ? today : DateUtil.parseDate(title.getStartDate()),
+                    "end", isBlank(title.getEndDate()) ? today : DateUtil.parseDate(title.getEndDate())
+            ));
+        }
 
-        for (int i = 1; i < primaryTitles.size(); i++) {
-            final var previous = primaryTitles.get(i - 1);
-            final var title = primaryTitles.get(i);
+        resolvedTitles.sort((o1, o2) -> {
+            final var o1Start = (LocalDate) o1.get("start");
+            final var o2Start = (LocalDate) o2.get("start");
+
+            if (o1Start.equals(o2Start)) {
+                return ((LocalDate) o1.get("end")).compareTo((LocalDate) o2.get("end"));
+            }
+            return o1Start.compareTo(o2Start);
+        });
+
+        for (int i = 1; i < resolvedTitles.size(); i++) {
+            final var previousEntry = resolvedTitles.get(i - 1);
+            final var titleEntry = resolvedTitles.get(i);
+            final var previous = (Title) previousEntry.get("title");
+            final var title = (Title) titleEntry.get("title");
             final var previousIndex = titles.indexOf(previous);
             final var index = titles.indexOf(title);
 
-            final var startDate = DateUtil.parseDate(title.getStartDate());
-            final var endDate = (previous.getEndDate() != null) ? DateUtil.parseDate(previous.getEndDate()) : today;
+            final var startDate = (LocalDate) titleEntry.get("start");
+            final var endDate = (LocalDate) previousEntry.get("end");
 
             if (title.equals(previous)) {
                 return List.of(new ValidationFailure()

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/ContributorPositionValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/ContributorPositionValidatorTest.java
@@ -71,6 +71,27 @@ class ContributorPositionValidatorTest {
     }
 
     @Test
+    @DisplayName("Validation passes with empty string end date")
+    void validationPassesWithEmptyStringEndDate() {
+        final var position = new ContributorPosition()
+                .id(ContributorPositionIdEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_307)
+                .schemaUri(ContributorPositionSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_305)
+                .startDate(LocalDate.now().minusYears(1).format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .endDate("");
+
+        when(contributorPositionSchemaRepository.findActiveByUri(ContributorPositionSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_305.getValue()))
+                .thenReturn(Optional.of(CONTRIBUTOR_POSITION_TYPE_SCHEMA_RECORD));
+
+        when(contributorPositionRepository
+                .findByUriAndSchemaId(ContributorPositionIdEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_307.getValue(), CONTRIBUTOR_POSITION_TYPE_SCHEMA_ID))
+                .thenReturn(Optional.of(CONTRIBUTOR_POSITION_TYPE_RECORD));
+
+        final var failures = validationService.validate(position, 2, 3);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
     @DisplayName("Validation fails if end date is before start date")
     void endDateBeforeStartDate() {
         final var position = new ContributorPosition()
@@ -209,6 +230,35 @@ class ContributorPositionValidatorTest {
                 .findByUriAndSchemaId(ContributorPositionIdEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_307.getValue(), CONTRIBUTOR_POSITION_TYPE_SCHEMA_ID))
                 .thenReturn(Optional.of(CONTRIBUTOR_POSITION_TYPE_RECORD));
 
+        final var failures = validationService.validate(position, 2, 3);
+
+        assertThat(failures, hasSize(1));
+        assertThat(failures, hasItem(
+                new ValidationFailure()
+                        .fieldId("contributor[2].position[3].startDate")
+                        .errorType("notSet")
+                        .message("field must be set")
+        ));
+    }
+
+    @Test
+    @DisplayName("Validation fails with empty string startDate")
+    void emptyStringStartDate() {
+        final var position = new ContributorPosition()
+                .schemaUri(ContributorPositionSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_305)
+                .id(ContributorPositionIdEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_307)
+                .startDate("")
+                .endDate(LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
+
+        when(contributorPositionSchemaRepository.findActiveByUri(ContributorPositionSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_305.getValue()))
+                .thenReturn(Optional.of(CONTRIBUTOR_POSITION_TYPE_SCHEMA_RECORD));
+
+        when(contributorPositionRepository
+                .findByUriAndSchemaId(ContributorPositionIdEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_307.getValue(), CONTRIBUTOR_POSITION_TYPE_SCHEMA_ID))
+                .thenReturn(Optional.of(CONTRIBUTOR_POSITION_TYPE_RECORD));
+
+        // key assertion: a blank startDate must produce the NOT_SET failure (not silently pass),
+        // and must not throw InvalidDateException from the endDate/startDate comparison
         final var failures = validationService.validate(position, 2, 3);
 
         assertThat(failures, hasSize(1));

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/ContributorTypeValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/ContributorTypeValidatorTest.java
@@ -596,6 +596,44 @@ class ContributorTypeValidatorTest {
     }
 
     @Test
+    @DisplayName("Validation does not throw when position start date is an empty string, and propagates NOT_SET from position validator")
+    void positionWithEmptyStringStartDate() {
+        final var role = new ContributorRole()
+                .schemaUri(ContributorRoleSchemaUriEnum.HTTPS_CREDIT_NISO_ORG_)
+                .id(ContributorRoleIdEnum.HTTPS_CREDIT_NISO_ORG_CONTRIBUTOR_ROLES_SUPERVISION_);
+
+        final var position = new ContributorPosition()
+                .schemaUri(ContributorPositionSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_305)
+                .id(ContributorPositionIdEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_307)
+                .startDate("");
+
+        final var contributor = new Contributor()
+                .id(VALID_ORCID)
+                .schemaUri(ContributorSchemaUriEnum.HTTPS_ORCID_ORG_)
+                .role(List.of(role))
+                .position(List.of(position));
+
+        // ContributorPositionValidator is mocked here, but in production it now returns a NOT_SET
+        // failure for a blank startDate (see ContributorPositionValidatorTest) - stub the mock to
+        // match that real behaviour so this test reflects what actually happens end-to-end.
+        final var startDateNotSetFailure = new ValidationFailure()
+                .fieldId("contributor[0].position[0].startDate")
+                .errorType(NOT_SET_TYPE)
+                .message(NOT_SET_MESSAGE);
+
+        when(contributorClient.exists(VALID_ORCID)).thenReturn(true);
+        when(roleValidator.validate(role, CONTRIBUTOR_INDEX, 0)).thenReturn(Collections.emptyList());
+        when(positionValidator.validate(position, CONTRIBUTOR_INDEX, 0)).thenReturn(List.of(startDateNotSetFailure));
+
+        final var failures = validator.validate(contributor, CONTRIBUTOR_INDEX);
+
+        // the key assertion for this test: the blank startDate must not throw InvalidDateException
+        // while ContributorTypeValidator's own position-sort logic resolves it internally
+        assertThat(failures, hasSize(1));
+        assertThat(failures, hasItem(startDateNotSetFailure));
+    }
+
+    @Test
     @DisplayName("Validation fails when position without end date overlaps with earlier position")
     void positionWithoutEndDateOverlaps() {
         final var role = new ContributorRole()

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/DateValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/DateValidatorTest.java
@@ -62,6 +62,18 @@ class DateValidatorTest {
     }
 
     @Test
+    @DisplayName("Validation passes with empty string end date")
+    void validEmptyStringEndDate() {
+        final var date = new Date()
+                .startDate("2021-03-01")
+                .endDate("");
+
+        final var failures = validator.validate(date);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
     @DisplayName("Validation fails if date null")
     void notSet() {
         final var failures = validator.validate(null);

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/OrganisationRoleValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/OrganisationRoleValidatorTest.java
@@ -69,6 +69,27 @@ class OrganisationRoleValidatorTest {
     }
 
     @Test
+    @DisplayName("Validation passes with empty string end date")
+    void validationPassesWithEmptyStringEndDate() {
+        final var role = new OrganisationRole()
+                .id(OrganizationRoleIdEnum.HTTPS_VOCABULARY_RAID_ORG_ORGANISATION_ROLE_SCHEMA_182)
+                .schemaUri(OrganizationRoleSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_ORGANISATION_ROLE_SCHEMA_359)
+                .startDate("2021")
+                .endDate("");
+
+        when(contributorRoleSchemaRepository.findActiveByUri(OrganizationRoleSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_ORGANISATION_ROLE_SCHEMA_359.getValue()))
+                .thenReturn(Optional.of(ORGANISATION_ROLE_SCHEMA_RECORD));
+
+        when(contributorRoleRepository
+                .findByUriAndSchemaId(OrganizationRoleIdEnum.HTTPS_VOCABULARY_RAID_ORG_ORGANISATION_ROLE_SCHEMA_182.getValue(), ORGANISATION_ROLE_SCHEMA_ID))
+                .thenReturn(Optional.of(ORGANISATION_ROLE_RECORD));
+
+        final var failures = validationService.validate(role, 2, 3);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
     @DisplayName("Validation fails if end date is before start date")
     void endDateBeforeStartDate() {
         final var role = new OrganisationRole()

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/TitleValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/TitleValidatorTest.java
@@ -20,6 +20,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
@@ -50,6 +51,31 @@ class TitleValidatorTest {
                 .text(TestConstants.TITLE)
                 .startDate(TestConstants.START_DATE.format(DateTimeFormatter.ISO_LOCAL_DATE))
                 .endDate(TestConstants.END_DATE.format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .language(language);
+
+        final var failures = validationService.validate(List.of(title));
+
+        assertThat(failures.size(), is(0));
+        verify(typeValidationService).validate(type, 0);
+        verify(languageValidator).validate(language, "title[0]");
+    }
+
+    @Test
+    @DisplayName("Validation passes with empty string end date")
+    void validationPassesWithEmptyStringEndDate() {
+        final var type = new TitleType()
+                .id(TitleTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_TITLE_TYPE_SCHEMA_5)
+                .schemaUri(TitleTypeSchemaURIEnum.HTTPS_VOCABULARY_RAID_ORG_TITLE_TYPE_SCHEMA_376);
+
+        final var language = new Language()
+                .id(TestConstants.LANGUAGE_ID)
+                .schemaUri(LanguageSchemaURIEnum.HTTPS_WWW_ISO_ORG_STANDARD_74575_HTML);
+
+        final var title = new Title()
+                .type(type)
+                .text(TestConstants.TITLE)
+                .startDate(TestConstants.START_DATE.format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .endDate("")
                 .language(language);
 
         final var failures = validationService.validate(List.of(title));
@@ -177,6 +203,78 @@ class TitleValidatorTest {
         )));
         verify(typeValidationService).validate(type, 0);
         verify(languageValidator).validate(language, "title[0]");
+    }
+
+    @Test
+    @DisplayName("Validation passes with multiple primary titles where the earlier one has a blank (ongoing) end date")
+    void multiplePrimaryTitlesWithBlankEndDate() {
+        final var type = new TitleType()
+                .id(TitleTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_TITLE_TYPE_SCHEMA_5)
+                .schemaUri(TitleTypeSchemaURIEnum.HTTPS_VOCABULARY_RAID_ORG_TITLE_TYPE_SCHEMA_376);
+
+        final var language = new Language()
+                .id(TestConstants.LANGUAGE_ID)
+                .schemaUri(LanguageSchemaURIEnum.HTTPS_WWW_ISO_ORG_STANDARD_74575_HTML);
+
+        final var title1 = new Title()
+                .type(type)
+                .text(TestConstants.TITLE)
+                .startDate(LocalDate.now().minusYears(3).format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .endDate(LocalDate.now().minusYears(2).format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .language(language);
+
+        // ongoing (blank endDate) title that starts exactly when title1 ends - must not throw
+        // and must not be treated as overlapping
+        final var title2 = new Title()
+                .type(type)
+                .text(TestConstants.TITLE)
+                .startDate(LocalDate.now().minusYears(2).format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .endDate("")
+                .language(language);
+
+        final var failures = validationService.validate(List.of(title1, title2));
+
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("Validation does not throw with multiple primary titles when one has a blank start date")
+    void multiplePrimaryTitlesWithBlankStartDate() {
+        final var type = new TitleType()
+                .id(TitleTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_TITLE_TYPE_SCHEMA_5)
+                .schemaUri(TitleTypeSchemaURIEnum.HTTPS_VOCABULARY_RAID_ORG_TITLE_TYPE_SCHEMA_376);
+
+        final var language = new Language()
+                .id(TestConstants.LANGUAGE_ID)
+                .schemaUri(LanguageSchemaURIEnum.HTTPS_WWW_ISO_ORG_STANDARD_74575_HTML);
+
+        // blank start/end - resolves to "today" for sorting/overlap purposes, and separately
+        // fails titleStartDateNotSet since a primary title's start date is still required
+        final var title1 = new Title()
+                .type(type)
+                .text(TestConstants.TITLE)
+                .startDate("")
+                .endDate("")
+                .language(language);
+
+        final var title2 = new Title()
+                .type(type)
+                .text(TestConstants.TITLE)
+                .startDate(LocalDate.now().minusYears(1).format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .language(language);
+
+        final var failures = validationService.validate(List.of(title1, title2));
+
+        // key assertion: resolving the blank start date must not throw InvalidDateException in
+        // validatePrimaryTitleDates; the only failure expected is the pre-existing
+        // titleStartDateNotSet check, not an overlap failure
+        assertThat(failures, hasSize(1));
+        assertThat(failures, hasItem(
+                new ValidationFailure()
+                        .fieldId("title[0].startDate")
+                        .errorType("notSet")
+                        .message("field must be set")
+        ));
     }
 
     @Test

--- a/documentation/20260724-raid-775-empty-string-end-date.md
+++ b/documentation/20260724-raid-775-empty-string-end-date.md
@@ -1,0 +1,32 @@
+# RAID-775: InvalidDateException when minting with a cleared end date
+
+- **JIRA:** [RAID-775](https://ardc.atlassian.net/browse/RAID-775) (Bug, standalone — no sub-tasks)
+- **PR:** [au-research/raid-au#582](https://github.com/au-research/raid-au/pull/582)
+- **Date:** 2026-07-24
+
+## Problem
+
+Minting a RAiD failed with a `400 InvalidDateException` (`" is an invalid date or has an unsupported format."`, note the leading blank) when a user set a start date and then cleared the end date. The frontend clears an end date by submitting an empty string `""` rather than omitting the field or sending `null`. End dates are optional in the metadata schema, so this should mint successfully (consistent with the intent of RAID-595 and RAID-708).
+
+## Root cause
+
+Two independent defects, at different layers:
+
+1. **Validator date guards (Java).** `DateUtil.parseDate("")` throws because an empty string matches none of its date regexes. Several validators guarded `parseDate` calls with `== null` (or no guard) instead of the blank-safe `StringUtil.isBlank` used elsewhere, so `""` was passed straight into `parseDate`. Affected: `DateValidator` (overall date — the path in the reported reproduction), `TitleValidator`, `ContributorPositionValidator`, `ContributorTypeValidator`, `ContributorValidator`.
+
+2. **Stray `@Pattern` on `Title.endDate` (datamodel).** The generated `Title` model uniquely carried `@Pattern(regexp = "^\\s*\\S.*$")` on `endDate` (an accidental copy from `Title.startDate`/`text`); `Date`, `ContributorPosition` and `OrganisationRole` did not. This constraint runs at the controller `@Valid` boundary, before `TitleValidator`, and rejected `""` outright. This was surfaced by the integration test and is a separate, pre-existing issue from defect 1.
+
+## What changed
+
+- Replaced `== null` / unguarded date checks with `StringUtil.isBlank` across the five validators, so a blank date string (null, empty, or whitespace) is treated as absent. A blank *required* start date now correctly raises the existing NOT_SET failure rather than being silently accepted or throwing.
+- Refactored `TitleValidator.validatePrimaryTitleDates` to resolve dates into `LocalDate` before sorting, removing an unrelated NPE risk on a raw nullable `startDate`.
+- Removed the stray `pattern` from `Title.endDate` in the LinkML datamodel (`api-svc/datamodel/src/v2/raid-core.yaml`) and regenerated the JSON schemas (`raid-jsonschema.json`, `raid-strict-jsonschema.json`) and OpenAPI specs (`raid-openapi-3.1.yaml`, `raid-openapi-strict-3.1.yaml`). `Title.startDate` retains `@NotNull @Pattern`. Removing a pattern is a relaxation, so the API contract change is backward-compatible.
+
+## Testing
+
+- Unit tests added for empty-string dates across all affected validators; full `raid-api` unit suite passes.
+- Integration test `RaidIntegrationTest.mintRaidWithEmptyStringEndDates` mints a RAiD with cleared (`""`) end dates on the overall date, title, contributor position and organisation role, and asserts success (Acceptance Criteria Scenario 1). Verified passing against the local Docker + Keycloak stack.
+
+## Follow-up noted (not in scope)
+
+`datamodel/build.gradle`'s `generateStrictJsonSchemaV2` (`AddStaticEnums`) can silently rewrite `raid-strict-jsonschema.json` to empty when re-triggered by a plain `./gradlew build`, because it depends on the sparql-cache to inject enum values. Worth its own ticket.


### PR DESCRIPTION
## Summary

Fixes [RAID-775](https://ardc.atlassian.net/browse/RAID-775): minting a RAiD failed with a `400 InvalidDateException` when the frontend cleared an end date by sending an empty string `""` instead of omitting the field.

Two independent defects were behind this:

### 1. Validator date guards (Java)
`DateValidator`, `TitleValidator`, `ContributorPositionValidator`, `ContributorTypeValidator` and `ContributorValidator` guarded `DateUtil.parseDate` with `== null` (or no guard), so an empty string was passed straight into `parseDate` and threw `InvalidDateException`. They now use `StringUtil.isBlank`, so a blank date string (null, empty, or whitespace) is treated as absent — consistent with the validators that already did this (`OrganisationRoleValidator`).

- `ContributorPositionValidator`: blank `startDate` now correctly raises the NOT_SET failure (previously `""` was silently accepted).
- `TitleValidator.validatePrimaryTitleDates` was refactored to resolve dates into `LocalDate` before sorting, removing an unrelated NPE risk on a raw nullable `startDate`.

### 2. Stray `@Pattern` on `Title.endDate` (datamodel)
The generated `Title` model uniquely carried `@Pattern(regexp = "^\\s*\\S.*$")` on `endDate`, while `Date`/`ContributorPosition`/`OrganisationRole` did not. That constraint runs at the controller `@Valid` boundary — before `TitleValidator` — and rejected `""` outright. Removed the stray `pattern` from `Title.endDate` in the LinkML datamodel (`api-svc/datamodel/src/v2/raid-core.yaml`) and regenerated the JSON schemas and OpenAPI specs. `Title.startDate` retains its `@NotNull @Pattern`.

## Testing

- Unit tests added for empty-string dates across all affected validators; full `raid-api` unit suite green.
- Integration test `RaidIntegrationTest.mintRaidWithEmptyStringEndDates` mints a RAiD with cleared (`""`) end dates on the overall date, title, contributor position and organisation role, and confirms it succeeds (mirrors the ticket's Acceptance Criteria Scenario 1). Verified passing against the local Docker + Keycloak stack.

## Notes for reviewers

- The generated Java models under `idl-raid-v2/src/main/generated/` are gitignored (built from the OpenAPI spec); the committed generated artifacts here are the two JSON schemas and two OpenAPI specs, each a clean one-line removal of the `Title.endDate` pattern.
- Removing a validation pattern is a relaxation, so it is backward-compatible for the API contract.
- Separately noted: `datamodel/build.gradle`'s `generateStrictJsonSchemaV2` (`AddStaticEnums`) can silently rewrite `raid-strict-jsonschema.json` to empty when re-triggered by a plain `./gradlew build` (it depends on the sparql-cache). Worth a follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)