### PR TITLE
RAID-794: add resolved ROR org name to schema.org output

### DIFF
--- a/documentation/20260729-raid-794-ror-org-name-schema-org.md
+++ b/documentation/20260729-raid-794-ror-org-name-schema-org.md
@@ -1,0 +1,64 @@
+# RAID-794: Include resolved organisation name (from ROR) in schema.org output
+
+- **JIRA**: [RAID-794](https://ardc.atlassian.net/browse/RAID-794) (Story)
+- **Related**: [RAID-756](https://ardc.atlassian.net/browse/RAID-756) (vocabulary label resolution), HELP-2753 (RDA request that prompted this)
+- **PR**: https://github.com/au-research/raid-au/pull/587
+- **Date**: 2026-07-29
+
+## What changed and why
+
+The static site's schema.org / JSON-LD `Organization` nodes emitted the ROR URI
+and a `PropertyValue` identifier but not the organisation's resolved name (for
+example `https://ror.org/03sd43014` without "QCIF Ltd."). Downstream consumers
+such as RDA's NESP Domain Data Portal therefore had to call the ROR API per
+record to obtain the name (raised via HELP-2753).
+
+The static site already resolves and caches ROR names at build time
+(`scripts/fetch-ror.js` writes them to `.ror-cache.json` and onto
+`organisation[].rorDetails`). The JSON-LD builder simply wasn't consuming them.
+This change consumes the existing build-time data instead of adding any
+render-time ROR calls, consistent with how RAID-756 handled vocabulary-backed
+label resolution (build-time, no runtime fetch). This approach was confirmed
+with Rob per acceptance criterion 3.
+
+### Changes
+
+- `raid-agency-app-static/src/utils/json-ld.ts`
+  - `buildOrganisationRole` emits `name` from `organisation.rorDetails?.name` on
+    member and funder `Organization` nodes.
+  - `parentOrganization` emits the registration agency's resolved ROR name.
+  - Both use a conditional spread, so a node still emits with just the ROR
+    identifier when the name is unavailable (graceful degradation).
+  - The three org-role helpers now take `OrganisationDetails`; the registration
+    agency is read as `RegistrationAgencyDetails`.
+- `raid-agency-app-static/scripts/fetch-ror.js`
+  - Build-time enrichment now also resolves the registration agency's ROR name
+    (previously only `organisation[]` was enriched), reusing the same ROR cache.
+- `raid-agency-app-static/src/model/raid/RegistrationAgencyDetails.ts` (new)
+  - `*Details` model type mirroring `OrganisationDetails`, exported from
+    `model/raid/index.ts`.
+- `raid-agency-app-static/src/utils/json-ld.test.ts`
+  - Five new tests covering name present on member/funder/parentOrganization and
+    name omitted when `rorDetails` is absent or the name is an empty string.
+
+## Acceptance criteria
+
+1. Organization node includes `name` alongside the ROR PropertyValue — done.
+2. Graceful degradation when the name is unavailable — done.
+3. Approach reuses build-time resolution, consistent with RAID-756, confirmed
+   with Rob — done.
+
+## Testing
+
+- 43 json-ld unit tests pass (5 new).
+- `tsc --noEmit` clean for the changed files.
+- `scripts/fetch-ror.js` enrichment smoke-tested with a mocked ROR response:
+  both `organisation` and `registrationAgency` receive `rorDetails.name`, and
+  non-ROR ids are skipped without error.
+
+## Follow-up (out of scope)
+
+`OrganisationDetails.rorDetails` is declared as `{rorId, name, country, types}`
+but `getSimplifiedRorInfo` actually returns `{rorId, name, type, rorUrl}`. This
+change only reads `.name`, so it is unaffected, but the inaccurate type is worth
+a follow-up ticket now that `json-ld.ts` consumes `rorDetails`.

--- a/raid-agency-app-static/scripts/fetch-ror.js
+++ b/raid-agency-app-static/scripts/fetch-ror.js
@@ -150,6 +150,18 @@ export async function addRorDetailsToRaidData(raidData, makeRequestWithRetry, co
         }
       });
     }
+
+    // Also resolve the registration agency's ROR name so the schema.org
+    // parentOrganization node can include it (RAID-794).
+    const registrationAgencyId = raid.identifier?.registrationAgency?.id;
+    if (registrationAgencyId && registrationAgencyId.includes('ror.org')) {
+      allRorIds.push({
+        rorId: registrationAgencyId,
+        raidIndex,
+        field: 'registrationAgency'
+      });
+      stats.totalRorIds++;
+    }
   });
   
   console.log(`Found ${stats.totalRorIds} ROR IDs to process`);
@@ -175,12 +187,16 @@ export async function addRorDetailsToRaidData(raidData, makeRequestWithRetry, co
 
     const results = await processBatchRorDetails(batch, makeRequestWithRetry, config, stats);
     // Apply results to RAID data
-    results.forEach(({ rorDetails, raidIndex, orgIndex, field, subIndex }) => {
+    results.forEach(({ rorDetails, raidIndex, orgIndex, field }) => {
       if (rorDetails) {
         const simplifiedInfo = getSimplifiedRorInfo(rorDetails);
-        
+
         // Add to appropriate field
-        raidData[raidIndex].organisation[orgIndex].rorDetails = simplifiedInfo;
+        if (field === 'registrationAgency') {
+          raidData[raidIndex].identifier.registrationAgency.rorDetails = simplifiedInfo;
+        } else {
+          raidData[raidIndex].organisation[orgIndex].rorDetails = simplifiedInfo;
+        }
       }
     });
 

--- a/raid-agency-app-static/src/model/raid/RegistrationAgencyDetails.ts
+++ b/raid-agency-app-static/src/model/raid/RegistrationAgencyDetails.ts
@@ -1,0 +1,15 @@
+import type { RegistrationAgency } from "@/generated/raid";
+
+/**
+ * RegistrationAgency enriched at build time by scripts/fetch-ror.js with the
+ * organisation details resolved from ROR. The shape of `rorDetails` mirrors the
+ * output of getSimplifiedRorInfo in that script.
+ */
+export interface RegistrationAgencyDetails extends RegistrationAgency {
+    rorDetails?: {
+        rorId: string;
+        name: string;
+        type: string;
+        rorUrl: string;
+    };
+}

--- a/raid-agency-app-static/src/model/raid/index.ts
+++ b/raid-agency-app-static/src/model/raid/index.ts
@@ -2,3 +2,4 @@ export * from "./Citation";
 export * from "./RelatedObjectWithCitation";
 export * from "./ContributorDetails";
 export * from "./OrganisationDetails";
+export * from "./RegistrationAgencyDetails";

--- a/raid-agency-app-static/src/utils/json-ld.test.ts
+++ b/raid-agency-app-static/src/utils/json-ld.test.ts
@@ -119,6 +119,28 @@ describe("buildResearchProjectJsonLd", () => {
     });
   });
 
+  it("includes the resolved ROR name on parentOrganization when available (RAID-794)", () => {
+    const raid = minimalRaid();
+    // rorDetails is attached to the registration agency at build time by
+    // scripts/fetch-ror.js and is not part of the generated type.
+    (raid.identifier!.registrationAgency as never as { rorDetails: { name: string } }).rorDetails = {
+      name: "Australian Research Data Commons",
+    };
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.parentOrganization).toEqual({
+      "@type": "Organization",
+      "@id": "https://ror.org/038sjwq14",
+      name: "Australian Research Data Commons",
+      identifier: {
+        "@type": "PropertyValue",
+        propertyID: "https://registry.identifiers.org/registry/ror",
+        name: "ROR",
+        value: "https://ror.org/038sjwq14",
+      },
+    });
+  });
+
   it("extracts primary description", () => {
     const raid = minimalRaid();
     raid.description = [
@@ -293,6 +315,82 @@ describe("buildResearchProjectJsonLd", () => {
     });
   });
 
+  it("includes the resolved ROR name on the member Organization when available (RAID-794)", () => {
+    const raid = minimalRaid();
+    raid.organisation = [
+      {
+        id: "https://ror.org/03sd43014",
+        schemaUri: "https://ror.org",
+        rorDetails: { name: "QCIF Ltd." },
+        role: [
+          {
+            schemaUri: "https://vocabulary.raid.org",
+            id: "https://vocabulary.raid.org/organisation.role.schema/185",
+            startDate: "2025-01-01",
+          },
+        ],
+        // rorDetails is attached at build time by scripts/fetch-ror.js and is
+        // not part of the generated Organisation type.
+      } as never,
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.member[0].member).toEqual({
+      "@type": "Organization",
+      "@id": "https://ror.org/03sd43014",
+      name: "QCIF Ltd.",
+      identifier: {
+        "@type": "PropertyValue",
+        propertyID: "https://registry.identifiers.org/registry/ror",
+        name: "ROR",
+        value: "https://ror.org/03sd43014",
+      },
+    });
+  });
+
+  it("omits the member Organization name when ROR resolution is unavailable (RAID-794 graceful degradation)", () => {
+    const raid = minimalRaid();
+    raid.organisation = [
+      {
+        id: "https://ror.org/03sd43014",
+        schemaUri: "https://ror.org",
+        role: [
+          {
+            schemaUri: "https://vocabulary.raid.org",
+            id: "https://vocabulary.raid.org/organisation.role.schema/185",
+            startDate: "2025-01-01",
+          },
+        ],
+      },
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.member[0].member).not.toHaveProperty("name");
+    expect(result.member[0].member["@id"]).toBe("https://ror.org/03sd43014");
+    expect(result.member[0].member.identifier.value).toBe("https://ror.org/03sd43014");
+  });
+
+  it("omits the member Organization name when the resolved name is an empty string (RAID-794)", () => {
+    const raid = minimalRaid();
+    raid.organisation = [
+      {
+        id: "https://ror.org/03sd43014",
+        schemaUri: "https://ror.org",
+        rorDetails: { name: "" },
+        role: [
+          {
+            schemaUri: "https://vocabulary.raid.org",
+            id: "https://vocabulary.raid.org/organisation.role.schema/185",
+            startDate: "2025-01-01",
+          },
+        ],
+      } as never,
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.member[0].member).not.toHaveProperty("name");
+  });
+
   it("maps funder organisations to funder roles", () => {
     const raid = minimalRaid();
     raid.organisation = [
@@ -316,6 +414,27 @@ describe("buildResearchProjectJsonLd", () => {
     const funderRole = result.funder[0];
     expect(funderRole["@id"]).toBe(FUNDER_ORGANISATION_ROLE);
     expect(funderRole.member["@type"]).toBe("Organization");
+  });
+
+  it("includes the resolved ROR name on funder Organizations too (RAID-794)", () => {
+    const raid = minimalRaid();
+    raid.organisation = [
+      {
+        id: "https://ror.org/04yx6dh41",
+        schemaUri: "https://ror.org",
+        rorDetails: { name: "Australian Research Council" },
+        role: [
+          {
+            schemaUri: "https://vocabulary.raid.org",
+            id: FUNDER_ORGANISATION_ROLE,
+            startDate: "2025-01-01",
+          },
+        ],
+      } as never,
+    ];
+
+    const result = buildResearchProjectJsonLd(raid);
+    expect(result.funder[0].member.name).toBe("Australian Research Council");
   });
 
   it("splits organisation with both funder and non-funder roles", () => {

--- a/raid-agency-app-static/src/utils/json-ld.ts
+++ b/raid-agency-app-static/src/utils/json-ld.ts
@@ -1,5 +1,5 @@
-import type { Contributor, Organisation, RaidDto, RelatedRaid } from "@/generated/raid";
-import type { RelatedObjectWithCitation } from "@/model/raid";
+import type { Contributor, RaidDto, RelatedRaid } from "@/generated/raid";
+import type { OrganisationDetails, RegistrationAgencyDetails, RelatedObjectWithCitation } from "@/model/raid";
 import generalMapping from "@/mapping/data/general-mapping.json";
 import subjectMapping from "@/mapping/data/subject-mapping.json";
 import { kebabToTitle } from "@/utils";
@@ -66,6 +66,7 @@ interface Role {
   member: {
     "@type": "Person" | "Organization";
     "@id": string;
+    name?: string;
     identifier: PropertyValue;
   };
 }
@@ -103,6 +104,7 @@ interface ResearchProjectJsonLd {
   parentOrganization: {
     "@type": "Organization";
     "@id": string;
+    name?: string;
     identifier: PropertyValue;
   };
   description?: string;
@@ -149,7 +151,13 @@ function buildContributorRoles(contributor: Contributor): Role[] {
   return [...positionRoles, ...creditRoles];
 }
 
-function buildOrganisationRole(organisation: Organisation, orgRole: { id: string; startDate: string; endDate?: string }): Role {
+function buildOrganisationRole(organisation: OrganisationDetails, orgRole: { id: string; startDate: string; endDate?: string }): Role {
+  // The organisation's resolved ROR name is fetched and cached at build time by
+  // scripts/fetch-ror.js and stored on organisation.rorDetails. Emit it as the
+  // schema.org Organization `name` so consumers don't have to call the ROR API
+  // themselves (RAID-794). Omitted when resolution was unavailable so the node
+  // still emits with just the ROR identifier.
+  const resolvedName = organisation.rorDetails?.name;
   return {
     "@type": "Role",
     "@id": orgRole.id,
@@ -159,6 +167,7 @@ function buildOrganisationRole(organisation: Organisation, orgRole: { id: string
     member: {
       "@type": "Organization",
       "@id": organisation.id,
+      ...(resolvedName && { name: resolvedName }),
       identifier: {
         "@type": "PropertyValue",
         propertyID: "https://registry.identifiers.org/registry/ror",
@@ -169,13 +178,13 @@ function buildOrganisationRole(organisation: Organisation, orgRole: { id: string
   };
 }
 
-function buildOrganisationRoles(organisation: Organisation): Role[] {
+function buildOrganisationRoles(organisation: OrganisationDetails): Role[] {
   return organisation.role
     .filter((r) => r.id !== FUNDER_ORGANISATION_ROLE)
     .map((r) => buildOrganisationRole(organisation, r));
 }
 
-function buildFunderRoles(organisation: Organisation): Role[] {
+function buildFunderRoles(organisation: OrganisationDetails): Role[] {
   return organisation.role
     .filter((r) => r.id === FUNDER_ORGANISATION_ROLE)
     .map((r) => buildOrganisationRole(organisation, r));
@@ -279,7 +288,13 @@ function buildRelatedObjectCitations(relatedObjects: RelatedObjectWithCitation[]
 }
 
 export function buildResearchProjectJsonLd(raid: Partial<RaidDto>): ResearchProjectJsonLd {
-  const registrationAgencyId = raid.identifier?.registrationAgency?.id ?? "";
+  // registrationAgency is enriched with its resolved ROR name at build time by
+  // scripts/fetch-ror.js (RAID-794); the generated type doesn't declare it.
+  const registrationAgency = raid.identifier?.registrationAgency as
+    | RegistrationAgencyDetails
+    | undefined;
+  const registrationAgencyId = registrationAgency?.id ?? "";
+  const registrationAgencyName = registrationAgency?.rorDetails?.name;
 
   const description = raid.description
     ?.filter((d) => d.type.id === PRIMARY_DESCRIPTION_TYPE)
@@ -334,6 +349,7 @@ export function buildResearchProjectJsonLd(raid: Partial<RaidDto>): ResearchProj
     parentOrganization: {
       "@type": "Organization",
       "@id": registrationAgencyId,
+      ...(registrationAgencyName && { name: registrationAgencyName }),
       identifier: {
         "@type": "PropertyValue",
         propertyID: "https://registry.identifiers.org/registry/ror",


### PR DESCRIPTION
## Summary

Follow-up to RAID-756. schema.org / JSON-LD `Organization` nodes previously emitted the ROR URI and a `PropertyValue` identifier but not the organisation's **resolved name**, so downstream consumers (e.g. RDA's NESP Domain Data Portal, HELP-2753) had to call the ROR API per record.

The static site already resolves and caches ROR names at build time (`scripts/fetch-ror.js` → `.ror-cache.json`, stored on `organisation[].rorDetails`). This change consumes that existing build-time data rather than adding any render-time ROR calls, consistent with RAID-756's build-time label-resolution approach.

## Changes

- **`src/utils/json-ld.ts`** — `buildOrganisationRole` now emits `name` from `organisation.rorDetails?.name` on member and funder `Organization` nodes. `parentOrganization` emits the registration agency's resolved ROR name. Both use a conditional spread so the node still emits with just the ROR identifier when the name is absent (graceful degradation).
- **`scripts/fetch-ror.js`** — extended build-time enrichment to also resolve the registration agency's ROR name (previously only `organisation[]` was enriched), reusing the same ROR cache.
- **`src/model/raid/RegistrationAgencyDetails.ts`** (new) — `*Details` model type mirroring the existing `OrganisationDetails` pattern, so `json-ld.ts` reads the build-time-enriched shape without an inline cast.
- **`src/utils/json-ld.test.ts`** — added 5 tests: name present on member org, funder org, and parentOrganization; name omitted when `rorDetails` absent and when the name is an empty string.

## Acceptance criteria

- [x] AC1 — Organization node includes `name` with the resolved name alongside the existing ROR PropertyValue
- [x] AC2 — graceful degradation: node still emits with the ROR identifier when the name is unavailable
- [x] AC3 — approach reuses build-time resolution, consistent with RAID-756 (confirmed with Rob)

## Testing

- All 43 json-ld unit tests pass (5 new).
- `tsc --noEmit` clean for changed files.
- Build-time enrichment smoke-tested with a mocked ROR response: both `organisation` and `registrationAgency` receive `rorDetails.name`; non-ROR ids are skipped without error.

## Follow-up (out of scope)

`OrganisationDetails.rorDetails` is declared as `{rorId, name, country, types}` but `getSimplifiedRorInfo` actually returns `{rorId, name, type, rorUrl}`. Not touched here (this change only reads `.name`), but worth a follow-up ticket now that `json-ld.ts` consumes `rorDetails`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)