### PR TITLE
RAID-737: accept sandbox ORCID contributor schemaUri in non-prod

### DIFF
--- a/api-svc/datamodel/examples/ContributorSchemaUriEnum-allowed-values.yaml
+++ b/api-svc/datamodel/examples/ContributorSchemaUriEnum-allowed-values.yaml
@@ -1,2 +1,3 @@
 https://isni.org/|ISNI contributor ID schema
 https://orcid.org/|ORCID contributor ID schema
+https://sandbox.orcid.org/|ORCID SANDBOX contributor ID schema

--- a/api-svc/datamodel/generated/v2/raid-strict-jsonschema.json
+++ b/api-svc/datamodel/generated/v2/raid-strict-jsonschema.json
@@ -345,7 +345,8 @@
       "type": "string",
       "enum": [
         "https://isni.org/",
-        "https://orcid.org/"
+        "https://orcid.org/",
+        "https://sandbox.orcid.org/"
       ]
     },
     "ContributorStatusEnum": {

--- a/api-svc/datamodel/sparql-cache/ContributorSchemaUriEnum.json
+++ b/api-svc/datamodel/sparql-cache/ContributorSchemaUriEnum.json
@@ -20,6 +20,16 @@
       {
         "uri" : {
           "type" : "uri",
+          "value" : "https://sandbox.orcid.org/"
+        },
+        "prefLabel" : {
+          "type" : "literal",
+          "value" : "ORCID SANDBOX contributor ID schema"
+        }
+      },
+      {
+        "uri" : {
+          "type" : "uri",
           "value" : "https://isni.org/"
         },
         "prefLabel" : {

--- a/api-svc/datamodel/src/v2/core-enums.yaml
+++ b/api-svc/datamodel/src/v2/core-enums.yaml
@@ -116,7 +116,7 @@ enums:
 
   ContributorSchemaUriEnum:
     reachable_from:
-      source_ontology: https://demo.vocabs.ardc.edu.au/repository/api/sparql/raid_raid-controlled-lists-v2_1-7-1
+      source_ontology: https://vocabs.ardc.edu.au/repository/api/sparql/raid_research-activity-identifier-raid-controlled-lists_raid-cl-v1-7-1
       source_nodes:
         - https://vocabulary.raid.org/contributor.id.schemaUri/scheme
       relationship_types:

--- a/api-svc/db/src/main/resources/db/env/demo/V42.1__add_sandbox_contributor_schema.sql
+++ b/api-svc/db/src/main/resources/db/env/demo/V42.1__add_sandbox_contributor_schema.sql
@@ -1,0 +1,12 @@
+-- RAID-737: register the ORCID sandbox contributor schema in non-production environments.
+-- Non-production accepts sandbox ORCID contributors
+-- (raid.contributor-validation.orcid.schema-uri = https://sandbox.orcid.org/), and
+-- ContributorService requires a matching contributor_schema row to persist them.
+-- Production and stage intentionally omit this row (they accept only https://orcid.org/).
+-- Guarded so a re-seeded/dump-restored database cannot end up with duplicate rows
+-- (ContributorSchemaRepository.findByUri uses fetchOptional, which fails on >1 row).
+insert into contributor_schema (uri, status)
+select 'https://sandbox.orcid.org/', 'active'::schema_status
+where not exists (
+    select 1 from contributor_schema where uri = 'https://sandbox.orcid.org/'
+);

--- a/api-svc/db/src/main/resources/db/env/dev/V42.1__add_sandbox_contributor_schema.sql
+++ b/api-svc/db/src/main/resources/db/env/dev/V42.1__add_sandbox_contributor_schema.sql
@@ -1,0 +1,12 @@
+-- RAID-737: register the ORCID sandbox contributor schema in non-production environments.
+-- Non-production accepts sandbox ORCID contributors
+-- (raid.contributor-validation.orcid.schema-uri = https://sandbox.orcid.org/), and
+-- ContributorService requires a matching contributor_schema row to persist them.
+-- Production and stage intentionally omit this row (they accept only https://orcid.org/).
+-- Guarded so a re-seeded/dump-restored database cannot end up with duplicate rows
+-- (ContributorSchemaRepository.findByUri uses fetchOptional, which fails on >1 row).
+insert into contributor_schema (uri, status)
+select 'https://sandbox.orcid.org/', 'active'::schema_status
+where not exists (
+    select 1 from contributor_schema where uri = 'https://sandbox.orcid.org/'
+);

--- a/api-svc/db/src/main/resources/db/env/test/V42.1__add_sandbox_contributor_schema.sql
+++ b/api-svc/db/src/main/resources/db/env/test/V42.1__add_sandbox_contributor_schema.sql
@@ -1,0 +1,12 @@
+-- RAID-737: register the ORCID sandbox contributor schema in non-production environments.
+-- Non-production accepts sandbox ORCID contributors
+-- (raid.contributor-validation.orcid.schema-uri = https://sandbox.orcid.org/), and
+-- ContributorService requires a matching contributor_schema row to persist them.
+-- Production and stage intentionally omit this row (they accept only https://orcid.org/).
+-- Guarded so a re-seeded/dump-restored database cannot end up with duplicate rows
+-- (ContributorSchemaRepository.findByUri uses fetchOptional, which fails on >1 row).
+insert into contributor_schema (uri, status)
+select 'https://sandbox.orcid.org/', 'active'::schema_status
+where not exists (
+    select 1 from contributor_schema where uri = 'https://sandbox.orcid.org/'
+);

--- a/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
+++ b/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
@@ -939,6 +939,7 @@ components:
       enum:
       - "https://isni.org/"
       - "https://orcid.org/"
+      - "https://sandbox.orcid.org/"
     ContributorStatusEnum:
       description: ""
       enum:

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/factory/datacite/DataciteCreatorFactory.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/factory/datacite/DataciteCreatorFactory.java
@@ -17,12 +17,15 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class DataciteCreatorFactory {
     private static final String ORCID_SCHEMA_URI = "https://orcid.org/";
+    private static final String SANDBOX_ORCID_SCHEMA_URI = "https://sandbox.orcid.org/";
     private static final String ISNI_SCHEMA_URI = "https://isni.org/";
     private final OrcidClient orcidClient;
     private final IsniClient isniClient;
 
+    // Sandbox ORCID (used in non-production environments) is still the ORCID scheme for DataCite.
     private static final Map<String, String> NAME_IDENTIFIER_SCHEMA_MAP = Map.of(
             ORCID_SCHEMA_URI, "ORCID",
+            SANDBOX_ORCID_SCHEMA_URI, "ORCID",
             ISNI_SCHEMA_URI, "ISNI"
     );
 
@@ -30,12 +33,13 @@ public class DataciteCreatorFactory {
         final var creator = new DataciteCreator();
         String name;
 
-        if (contributor.getSchemaUri().getValue().equals(ORCID_SCHEMA_URI)) {
+        final var schemaUri = contributor.getSchemaUri().getValue();
+        if (schemaUri.equals(ORCID_SCHEMA_URI) || schemaUri.equals(SANDBOX_ORCID_SCHEMA_URI)) {
             name = orcidClient.getName(contributor.getId());
-        } else if (contributor.getSchemaUri().getValue().equals(ISNI_SCHEMA_URI)) {
+        } else if (schemaUri.equals(ISNI_SCHEMA_URI)) {
             name = isniClient.getName(contributor.getId());
         } else {
-            throw new RuntimeException("Unsupported contributor schema %s".formatted(contributor.getSchemaUri().getValue()));
+            throw new RuntimeException("Unsupported contributor schema %s".formatted(schemaUri));
         }
 
         creator.setName(name);

--- a/api-svc/raid-api/src/main/resources/application-dev.yaml
+++ b/api-svc/raid-api/src/main/resources/application-dev.yaml
@@ -23,6 +23,7 @@ raid:
   contributor-validation:
     orcid:
       url-prefix: https://sandbox.orcid.org/
+      schema-uri: https://sandbox.orcid.org/
 spring:
   security:
     oauth2:

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/factory/datacite/DataciteCreatorFactoryTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/factory/datacite/DataciteCreatorFactoryTest.java
@@ -49,6 +49,28 @@ public class DataciteCreatorFactoryTest {
     }
 
     @Test
+    @DisplayName("RAID-737: Create with contributor - sandbox ORCID maps to ORCID scheme")
+    void createWithContributorSandboxORCID() {
+        final var id = "https://sandbox.orcid.org/0009-0002-5128-5184";
+        final var name = "_name";
+
+        final var contributor = new Contributor()
+                .id(id)
+                .status("AUTHENTICATED")
+                .schemaUri(ContributorSchemaUriEnum.HTTPS_SANDBOX_ORCID_ORG_);
+
+        when(orcidClient.getName(id)).thenReturn(name);
+
+        final var result = dataciteCreatorFactory.create(contributor);
+
+        assertThat(result.getName(), is(name));
+        assertThat(result.getNameType(), is("Personal"));
+        assertThat(result.getNameIdentifiers().get(0).getNameIdentifier(), is(id));
+        assertThat(result.getNameIdentifiers().get(0).getSchemeUri(), is("https://sandbox.orcid.org/"));
+        assertThat(result.getNameIdentifiers().get(0).getNameIdentifierScheme(), is("ORCID"));
+    }
+
+    @Test
     @DisplayName("Create with contributor - ISNI")
     void createWithContributorISNI() {
         final var id = "_id";

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/ContributorTypeValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/ContributorTypeValidatorTest.java
@@ -33,6 +33,9 @@ import static org.mockito.Mockito.*;
 class ContributorTypeValidatorTest {
     private static final String URL_PREFIX = "https://orcid.org/";
     private static final String SCHEMA_URI_PATTERN = "https://orcid.org/";
+    private static final String SANDBOX_URL_PREFIX = "https://sandbox.orcid.org/";
+    private static final String SANDBOX_SCHEMA_URI = "https://sandbox.orcid.org/";
+    private static final String SANDBOX_ORCID = "https://sandbox.orcid.org/0000-0000-0000-0001";
     private static final int CONTRIBUTOR_INDEX = 0;
 
     @Mock
@@ -259,6 +262,59 @@ class ContributorTypeValidatorTest {
                         .fieldId("contributor[0].schemaUri")
                         .errorType(NOT_SET_TYPE)
                         .message(NOT_SET_MESSAGE)
+        ));
+    }
+
+    @Test
+    @DisplayName("RAID-737: production config rejects a sandbox ORCID schemaUri")
+    void productionRejectsSandboxSchemaUri() {
+        // setUp() configures production properties (schemaUri pattern https://orcid.org/)
+        final var contributor = validContributor(VALID_ORCID, ContributorSchemaUriEnum.HTTPS_SANDBOX_ORCID_ORG_);
+
+        final var failures = validator.validate(contributor, CONTRIBUTOR_INDEX);
+
+        assertThat(failures, hasItem(
+                new ValidationFailure()
+                        .fieldId("contributor[0].schemaUri")
+                        .errorType(INVALID_VALUE_TYPE)
+                        .message(INVALID_VALUE_MESSAGE + " - should be %s".formatted(SCHEMA_URI_PATTERN))
+        ));
+    }
+
+    @Test
+    @DisplayName("RAID-737: production config accepts a production ORCID schemaUri")
+    void productionAcceptsProductionSchemaUri() {
+        final var contributor = validContributor(VALID_ORCID, ContributorSchemaUriEnum.HTTPS_ORCID_ORG_);
+
+        final var failures = validator.validate(contributor, CONTRIBUTOR_INDEX);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("RAID-737: non-production config accepts a sandbox ORCID schemaUri")
+    void nonProductionAcceptsSandboxSchemaUri() {
+        final var sandboxValidator = validatorWith(SANDBOX_URL_PREFIX, SANDBOX_SCHEMA_URI);
+        final var contributor = validContributor(SANDBOX_ORCID, ContributorSchemaUriEnum.HTTPS_SANDBOX_ORCID_ORG_);
+
+        final var failures = sandboxValidator.validate(contributor, CONTRIBUTOR_INDEX);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("RAID-737: non-production config rejects a production ORCID schemaUri")
+    void nonProductionRejectsProductionSchemaUri() {
+        final var sandboxValidator = validatorWith(SANDBOX_URL_PREFIX, SANDBOX_SCHEMA_URI);
+        final var contributor = validContributor(SANDBOX_ORCID, ContributorSchemaUriEnum.HTTPS_ORCID_ORG_);
+
+        final var failures = sandboxValidator.validate(contributor, CONTRIBUTOR_INDEX);
+
+        assertThat(failures, hasItem(
+                new ValidationFailure()
+                        .fieldId("contributor[0].schemaUri")
+                        .errorType(INVALID_VALUE_TYPE)
+                        .message(INVALID_VALUE_MESSAGE + " - should be %s".formatted(SANDBOX_SCHEMA_URI))
         ));
     }
 
@@ -670,5 +726,38 @@ class ContributorTypeValidatorTest {
                         .errorType(INVALID_VALUE_TYPE)
                         .message("Contributors can only hold one position at any given time. This position conflicts with contributor[0].position[0]")
         ));
+    }
+
+    private ContributorTypeValidator validatorWith(final String urlPrefix, final String schemaUri) {
+        return new ContributorTypeValidator(
+                ContributorTypeValidationProperties.builder()
+                        .urlPrefix(urlPrefix)
+                        .schemaUri(schemaUri)
+                        .build(),
+                contributorClient,
+                roleValidator,
+                positionValidator
+        );
+    }
+
+    private Contributor validContributor(final String id, final ContributorSchemaUriEnum schemaUri) {
+        final var role = new ContributorRole()
+                .schemaUri(ContributorRoleSchemaUriEnum.HTTPS_CREDIT_NISO_ORG_)
+                .id(ContributorRoleIdEnum.HTTPS_CREDIT_NISO_ORG_CONTRIBUTOR_ROLES_SUPERVISION_);
+
+        final var position = new ContributorPosition()
+                .schemaUri(ContributorPositionSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_305)
+                .id(ContributorPositionIdEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_307)
+                .startDate(LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
+
+        when(contributorClient.exists(id)).thenReturn(true);
+        when(roleValidator.validate(role, CONTRIBUTOR_INDEX, 0)).thenReturn(Collections.emptyList());
+        when(positionValidator.validate(position, CONTRIBUTOR_INDEX, 0)).thenReturn(Collections.emptyList());
+
+        return new Contributor()
+                .id(id)
+                .schemaUri(schemaUri)
+                .role(List.of(role))
+                .position(List.of(position));
     }
 }

--- a/api-svc/testFixtures/src/testFixtures/java/au/org/raid/fixtures/TestConstants.java
+++ b/api-svc/testFixtures/src/testFixtures/java/au/org/raid/fixtures/TestConstants.java
@@ -49,7 +49,9 @@ public class TestConstants {
     public static final String DESCRIPTION_TYPE_SCHEMA_URI =
             "https://vocabulary.raid.org/description.type.schema/320";
 
-    public static final String ORCID_SCHEMA_URI = "https://orcid.org/";
+    // Integration tests run under the dev profile, which enforces the sandbox ORCID schema (RAID-737).
+    // Paired with the sandbox REAL_TEST_ORCID id above.
+    public static final String ORCID_SCHEMA_URI = "https://sandbox.orcid.org/";
     public static final String ISNI_SCHEMA_URI = "https://isni.org/";
 
     public static final String CONTRIBUTOR_POSITION_SCHEMA_URI =

--- a/documentation/20260730-raid-737-sandbox-orcid-schemauri.md
+++ b/documentation/20260730-raid-737-sandbox-orcid-schemauri.md
@@ -91,26 +91,34 @@ override `url-prefix`).
   keep this change scoped.
 - `datamodel/generated/v2/referencedata.sql` is generated but not tracked — do not commit it.
 
-## Known limitation / deploy dependency (agency UI)
+### raid-agency-app (frontend — part of PR #588)
 
-This change is **backend only** (deliberate scope, per RAID-737 decision). The agency UI
-(`raid-agency-app`) hardcodes the contributor schemaUri and is **not** part of this change:
+The agency UI previously hardcoded the contributor `schemaUri` to `https://orcid.org/` (Zod schema +
+data generator), which would fail non-prod validation once the backend enforces sandbox-only. Made it
+environment-aware, mirroring the existing `containers/orcid-lookup/ORCID.tsx` pattern:
 
-- `entities/contributor/validation-schema/contributor-validation-schema.ts` — `schemaUri: z.literal("https://orcid.org/")`
-- `entities/contributor/data-generator/contributor-data-generator.ts` — `schemaUri: "https://orcid.org/"`
+- New `src/utils/contributor-utils/contributor-schema-uri.ts` — `getContributorSchemaUri()` returns
+  `https://orcid.org/` in prod, `https://sandbox.orcid.org/` otherwise. Called **lazily** only — never at
+  module load, because `getRuntimeConfig()` throws before the runtime config is loaded.
+- `entities/contributor/validation-schema/contributor-validation-schema.ts` — `schemaUri` is now a
+  `z.string().refine(...)` that accepts only the env-appropriate value (refinement runs at parse time).
+- `entities/contributor/data-generator/contributor-data-generator.ts` — uses the helper.
+- Added a helper unit test; `npm run build` + `npm test` pass (one pre-existing unrelated ServicePoint test
+  failure, confirmed at baseline).
 
-The ORCID **id** regex already accepts `sandbox.orcid.org`, but the schemaUri is pinned to
-`https://orcid.org/` in every environment.
+## Deploy coordination (three changes must land together)
 
-**Deploy risk:** once the CDK PR (#33) deploys, non-prod backends accept only
-`https://sandbox.orcid.org/`. The agency UI still sends `https://orcid.org/`, so **adding or
-editing contributors via the test/demo UI will fail validation** after deploy. API-only clients
-(the pilot testers) are fixed; the UI regresses until the frontend is made environment-aware
-(pattern already exists at `containers/orcid-lookup/ORCID.tsx:42`,
-`getRuntimeConfig().environment === 'prod' ? 'https://orcid.org/' : 'https://sandbox.orcid.org/'`).
+Because the rule is strict (non-prod accepts **only** sandbox), the branch pipeline proved these three must
+deploy together or the pipeline can't be green — under the strict rule, intTest (fixture → sandbox) and E2E
+(agency UI → its schemaUri) require the API and UI to agree:
 
-Coordinate the rollout accordingly, or land the frontend change before deploying to environments
-where the agency UI is used to create contributors.
+1. CDK #33 — deployed env config sets non-prod `schema-uri` to sandbox (branch API then requires sandbox).
+2. This PR's frontend change — UI sends sandbox in non-prod.
+3. This PR's fixture change — intTest sends sandbox.
+
+Deploying any subset causes a mismatch (e.g. #33 without the frontend → UI 400s; the frontend without #33 →
+E2E 400s). Merge/deploy #588 and #33 together; the branch pipeline stays red until #33 reaches the branch
+environment. Prod is unaffected (it keeps `https://orcid.org/` throughout).
 
 ## Verification
 

--- a/documentation/20260730-raid-737-sandbox-orcid-schemauri.md
+++ b/documentation/20260730-raid-737-sandbox-orcid-schemauri.md
@@ -1,0 +1,78 @@
+# RAID-737: Accept sandbox ORCID contributor schemaUri in non-production
+
+**Date:** 2026-07-30
+**JIRA:** [RAID-737](https://ardc.atlassian.net/browse/RAID-737) — ORCID sandbox schemaUri incorrectly rejected in non-production environments
+**PRs:**
+- raid-au: https://github.com/au-research/raid-au/pull/588
+- raido-v2-aws-private (deployed env config): https://github.com/au-research/raido-v2-aws-private/pull/33
+
+## Problem
+
+US pilot testers were instructed to use sandbox ORCiDs, but submitting a contributor with
+`schemaUri: https://sandbox.orcid.org/` was rejected during validation in the demo environment.
+
+Two independent causes:
+
+1. **Enum did not contain the value.** Contributor `schemaUri` is a codegen-locked enum
+   (`ContributorSchemaUriEnum`) materialised from the ARDC controlled-lists SPARQL vocabulary.
+   It only contained `https://orcid.org/` and `https://isni.org/`, so a sandbox value failed at
+   JSON deserialization (`fromValue` throws) before any validator ran.
+2. **Validation was not environment-scoped.** The deployed non-prod environments override the
+   contributor ORCID id `url-prefix` to sandbox but never override `schema-uri`, so schemaUri was
+   still validated against the production default `https://orcid.org/`.
+
+## Required behaviour (from the ticket)
+
+- Production: accept only `https://orcid.org/`.
+- Non-production (test, demo, sandbox): accept only `https://sandbox.orcid.org/`.
+
+This keeps production free of sandbox-issued identifiers and vice versa.
+
+## Vocabulary prerequisite
+
+The value had to come from the vocabulary (the enum is generated, not hand-maintained). The ARDC
+controlled-lists team published **RAiD-CL v1.7.1**, adding the "ORCID SANDBOX contributor ID schema"
+concept (`https://sandbox.orcid.org/`). An earlier draft (v1.7.0) had modelling defects that made the
+build's SPARQL query skip the value; these were reported and fixed before this change (see RAID-737
+comments). Verified the v1.7.1 endpoint returns all three values with the correct trailing slash.
+
+## Changes
+
+### raid-au (PR #588)
+
+- **`datamodel/src/v2/core-enums.yaml`** — repointed `ContributorSchemaUriEnum.reachable_from.source_ontology`
+  to the v1.7.1 production endpoint
+  (`https://vocabs.ardc.edu.au/repository/api/sparql/raid_research-activity-identifier-raid-controlled-lists_raid-cl-v1-7-1`).
+- **Regenerated** (`./gradlew :api-svc:datamodel:generateStrictJsonSchemaV2 :api-svc:datamodel:generateReferenceDataV2`,
+  then `assembleOpenAPIV2InternalSpecs` + `openApiGenerate`), producing a single semantic addition of
+  `https://sandbox.orcid.org/` to: `raid-strict-jsonschema.json`, `raid-openapi-strict-3.1.yaml`,
+  `ContributorSchemaUriEnum-allowed-values.yaml`, and `sparql-cache/ContributorSchemaUriEnum.json`.
+  The git-ignored generated Java enum now includes `HTTPS_SANDBOX_ORCID_ORG_`.
+- **`raid-api/.../application-dev.yaml`** — added `raid.contributor-validation.orcid.schema-uri: https://sandbox.orcid.org/`
+  so local dev accepts sandbox schemaUri. No Java production code changed: `ContributorTypeValidator`
+  already validates `schemaUri` against this config value, so the environment scoping is config-driven.
+- **`ContributorTypeValidatorTest`** — four new unit tests: prod config rejects sandbox / accepts orcid;
+  non-prod config accepts sandbox / rejects orcid.
+
+### raido-v2-aws-private (companion PR)
+
+Added `raid.contributor-validation.orcid.schema-uri: https://sandbox.orcid.org/` wherever the CDK already
+overrides `url-prefix` to sandbox: **test**, **demo**, **branch deployments**, and the **agency non-prod**
+environment. **Stage and prod are intentionally unchanged** — they keep production ORCID (they do not
+override `url-prefix`).
+
+## Notes / gotchas
+
+- The `AddStaticEnums` task (`generateStrictJsonSchemaV2`) emits **minified** JSON, whereas the committed
+  `raid-strict-jsonschema.json` is pretty-printed (2-space). After regen, re-serialise with 2-space indent
+  (`ensure_ascii=False`, trailing newline) so the diff is only the semantic enum change.
+- `generateReferenceDataV2` regenerates **all** enum example files; it surfaced an unrelated stale entry in
+  `RelatedObjectSchemaUriEnum-allowed-values.yaml` (a dropped `https://archive.org/`) which was reverted to
+  keep this change scoped.
+- `datamodel/generated/v2/referencedata.sql` is generated but not tracked — do not commit it.
+
+## Verification
+
+- Regenerated Java enum contains all three values including `https://sandbox.orcid.org/`.
+- No exhaustive `switch` on `ContributorSchemaUriEnum` exists, so adding a value needs no mapping changes.
+- `ContributorTypeValidatorTest` and `ContributorValidatorTest` pass; no other enum values drifted.

--- a/documentation/20260730-raid-737-sandbox-orcid-schemauri.md
+++ b/documentation/20260730-raid-737-sandbox-orcid-schemauri.md
@@ -49,10 +49,30 @@ comments). Verified the v1.7.1 endpoint returns all three values with the correc
   `ContributorSchemaUriEnum-allowed-values.yaml`, and `sparql-cache/ContributorSchemaUriEnum.json`.
   The git-ignored generated Java enum now includes `HTTPS_SANDBOX_ORCID_ORG_`.
 - **`raid-api/.../application-dev.yaml`** — added `raid.contributor-validation.orcid.schema-uri: https://sandbox.orcid.org/`
-  so local dev accepts sandbox schemaUri. No Java production code changed: `ContributorTypeValidator`
-  already validates `schemaUri` against this config value, so the environment scoping is config-driven.
-- **`ContributorTypeValidatorTest`** — four new unit tests: prod config rejects sandbox / accepts orcid;
-  non-prod config accepts sandbox / rejects orcid.
+  so local dev accepts sandbox schemaUri. The *validation* scoping is config-driven: `ContributorTypeValidator`
+  already validates `schemaUri` against this config value, so no validator code change was needed.
+- **`factory/datacite/DataciteCreatorFactory.java`** (production Java) — the DataCite mint path maps each
+  contributor to a `DataciteCreator` and previously threw `RuntimeException` for any schemaUri other than
+  `https://orcid.org/` / `https://isni.org/`. Without this fix, minting a raid with a (now-required) sandbox
+  contributor in an environment that mints real DOIs (e.g. demo) would 500. It now treats
+  `https://sandbox.orcid.org/` as the ORCID scheme (resolves the name via `orcidClient`,
+  `nameIdentifierScheme: "ORCID"`). This gap was found by running the integration tests, not by the
+  enum-usage grep — the check is a string comparison against a hardcoded literal, not a `switch`.
+- **Flyway migration** `db/env/{dev,test,demo}/V42.1__add_sandbox_contributor_schema.sql` (production data) —
+  `ContributorService.create()` looks the schemaUri up in the `contributor_schema` table and 500s
+  (`ContributorSchemaNotFoundException`) if there is no matching row. The table is a registry of known
+  schemes (seeded orcid.org in V27, isni.org in V29). This seeds `https://sandbox.orcid.org/` (status
+  `active`) **only in the non-prod environment locations** — prod and stage deliberately omit it, consistent
+  with them accepting only production ORCID. The insert is guarded with `where not exists` because
+  `findByUri` uses `fetchOptional`, which throws on duplicate rows (defends against dump-restored test DBs).
+  No JOOQ regen needed (data-only; the `status` column already exists). Also found by the integration tests.
+- **`testFixtures/.../fixtures/TestConstants.java`** — `ORCID_SCHEMA_URI` changed to `https://sandbox.orcid.org/`.
+  Integration tests run under the dev profile (which now enforces sandbox), and the fixture id
+  (`REAL_TEST_ORCID`) was already sandbox; the schemaUri constant is referenced by ~20 intTest call sites so
+  the single change cascades. The separate unit-test `TestConstants` keeps production values.
+- **Tests** — four new `ContributorTypeValidatorTest` cases (prod rejects sandbox / accepts orcid; non-prod
+  accepts sandbox / rejects orcid) and one new `DataciteCreatorFactoryTest` case (sandbox ORCID maps to the
+  ORCID scheme).
 
 ### raido-v2-aws-private (companion PR)
 
@@ -95,5 +115,12 @@ where the agency UI is used to create contributors.
 ## Verification
 
 - Regenerated Java enum contains all three values including `https://sandbox.orcid.org/`.
-- No exhaustive `switch` on `ContributorSchemaUriEnum` exists, so adding a value needs no mapping changes.
-- `ContributorTypeValidatorTest` and `ContributorValidatorTest` pass; no other enum values drifted.
+- Enum-usage audit: no exhaustive `switch` on `ContributorSchemaUriEnum`, but `DataciteCreatorFactory`
+  compared `schemaUri.getValue()` against a hardcoded `"https://orcid.org/"` string (fixed here). The only
+  other hardcoded `orcid.org` literal, `SchemaValues.ORCID_SCHEMA_URI`, is defined but unused.
+- Integration tests run under the dev profile; the full contributor intTest surface was run and confirmed
+  green after the fixture + DataCite fixes (previously 41 failures, all traced to the mismatched fixture
+  schemaUri). intTest uses local (`http://raid.local/`) handles so it does not exercise the DataCite mint
+  path — the `DataciteCreatorFactoryTest` unit test covers the sandbox mapping directly.
+- Unit tests pass (`ContributorTypeValidatorTest`, `ContributorValidatorTest`, `DataciteCreatorFactoryTest`);
+  no other enum values drifted.

--- a/documentation/20260730-raid-737-sandbox-orcid-schemauri.md
+++ b/documentation/20260730-raid-737-sandbox-orcid-schemauri.md
@@ -71,6 +71,27 @@ override `url-prefix`).
   keep this change scoped.
 - `datamodel/generated/v2/referencedata.sql` is generated but not tracked — do not commit it.
 
+## Known limitation / deploy dependency (agency UI)
+
+This change is **backend only** (deliberate scope, per RAID-737 decision). The agency UI
+(`raid-agency-app`) hardcodes the contributor schemaUri and is **not** part of this change:
+
+- `entities/contributor/validation-schema/contributor-validation-schema.ts` — `schemaUri: z.literal("https://orcid.org/")`
+- `entities/contributor/data-generator/contributor-data-generator.ts` — `schemaUri: "https://orcid.org/"`
+
+The ORCID **id** regex already accepts `sandbox.orcid.org`, but the schemaUri is pinned to
+`https://orcid.org/` in every environment.
+
+**Deploy risk:** once the CDK PR (#33) deploys, non-prod backends accept only
+`https://sandbox.orcid.org/`. The agency UI still sends `https://orcid.org/`, so **adding or
+editing contributors via the test/demo UI will fail validation** after deploy. API-only clients
+(the pilot testers) are fixed; the UI regresses until the frontend is made environment-aware
+(pattern already exists at `containers/orcid-lookup/ORCID.tsx:42`,
+`getRuntimeConfig().environment === 'prod' ? 'https://orcid.org/' : 'https://sandbox.orcid.org/'`).
+
+Coordinate the rollout accordingly, or land the frontend change before deploying to environments
+where the agency UI is used to create contributors.
+
 ## Verification
 
 - Regenerated Java enum contains all three values including `https://sandbox.orcid.org/`.

--- a/raid-agency-app/src/entities/contributor/data-generator/contributor-data-generator.ts
+++ b/raid-agency-app/src/entities/contributor/data-generator/contributor-data-generator.ts
@@ -1,6 +1,7 @@
 import { contributorPositionDataGenerator } from "@/entities/contributor-position/data-generator/contributor-position-data-generator";
 import { contributorRoleDataGenerator } from "@/entities/contributor-role/data-generator/contributor-role-data-generator";
 import { Contributor } from "@/generated/raid";
+import { getContributorSchemaUri } from "@/utils/contributor-utils/contributor-schema-uri";
 
 type ContributorExtended = Contributor &
   (
@@ -15,7 +16,7 @@ export const contributorDataGenerator = (
   const baseData: Omit<Contributor, "id" | "uuid"> = {
     leader: true,
     contact: true,
-    schemaUri: "https://orcid.org/",
+    schemaUri: getContributorSchemaUri(),
     position: [contributorPositionDataGenerator(startDate, endDate)],
     role: [contributorRoleDataGenerator(), contributorRoleDataGenerator()],
   };

--- a/raid-agency-app/src/entities/contributor/validation-schema/contributor-validation-schema.ts
+++ b/raid-agency-app/src/entities/contributor/validation-schema/contributor-validation-schema.ts
@@ -13,6 +13,7 @@
  */
 import { contributorPositionValidationSchema } from "@/entities/contributor-position/validation-schema/contributor-position-validation-schema";
 import { contributorRoleValidationSchema } from "@/entities/contributor-role/validation-schema/contributor-role-validation-schema";
+import { getContributorSchemaUri } from "@/utils/contributor-utils/contributor-schema-uri";
 import { z } from "zod";
 
 // The ORCID regex pattern used in multiple places
@@ -28,7 +29,10 @@ const baseContributorSchema = z.object({
   leader: z.boolean(),
   position: contributorPositionValidationSchema,
   role: contributorRoleValidationSchema,
-  schemaUri: z.literal("https://orcid.org/"),
+  schemaUri: z.string().refine((v) => v === getContributorSchemaUri(), {
+    message:
+      "Invalid contributor schemaUri for this environment, expected the environment-appropriate ORCID URL",
+  }),
   status: z.string().optional(),
   uuid: z.string().optional(),
 });

--- a/raid-agency-app/src/utils/contributor-utils/contributor-schema-uri.test.ts
+++ b/raid-agency-app/src/utils/contributor-utils/contributor-schema-uri.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RuntimeConfig } from "@/config/RuntimeConfig";
+
+vi.mock("@/config", () => ({
+  getRuntimeConfig: vi.fn(),
+}));
+
+import { getRuntimeConfig } from "@/config";
+import { getContributorSchemaUri } from "./contributor-schema-uri";
+
+describe("getContributorSchemaUri", () => {
+  beforeEach(() => {
+    vi.mocked(getRuntimeConfig).mockReset();
+  });
+
+  it("returns the live ORCID URL in prod", () => {
+    vi.mocked(getRuntimeConfig).mockReturnValue({
+      environment: "prod",
+    } as RuntimeConfig);
+
+    expect(getContributorSchemaUri()).toBe("https://orcid.org/");
+  });
+
+  it("returns the sandbox ORCID URL in non-prod environments", () => {
+    for (const environment of ["test", "demo", "local"]) {
+      vi.mocked(getRuntimeConfig).mockReturnValue({
+        environment,
+      } as RuntimeConfig);
+
+      expect(getContributorSchemaUri()).toBe("https://sandbox.orcid.org/");
+    }
+  });
+});

--- a/raid-agency-app/src/utils/contributor-utils/contributor-schema-uri.ts
+++ b/raid-agency-app/src/utils/contributor-utils/contributor-schema-uri.ts
@@ -1,0 +1,17 @@
+import { getRuntimeConfig } from "@/config";
+
+/**
+ * Returns the environment-appropriate ORCID schemaUri for contributors.
+ *
+ * Production uses the live ORCID registry; every other environment uses the
+ * ORCID sandbox. The backend enforces a sandbox-only schemaUri outside prod,
+ * so the agency UI must send the matching value.
+ *
+ * IMPORTANT: this calls getRuntimeConfig(), which throws if the runtime config
+ * has not been loaded yet. Only call it lazily (at render, validation or
+ * generation time), never at module-load time.
+ */
+export const getContributorSchemaUri = (): string =>
+  getRuntimeConfig().environment === "prod"
+    ? "https://orcid.org/"
+    : "https://sandbox.orcid.org/";


### PR DESCRIPTION
## Summary

- Repoint ContributorSchemaUriEnum LinkML source_ontology to RAiD-CL v1.7.1, which adds https://sandbox.orcid.org/ to the vocabulary; regenerate the strict JSON schema, OpenAPI spec, allowed-values and sparql-cache so the enum accepts the sandbox schemaUri.
- Add orcid.schema-uri override to application-dev.yaml so local dev accepts sandbox schemaUri (env-scoped validation is config-driven via raid.contributor-validation.orcid.schema-uri).
- Add ContributorTypeValidator unit tests covering env-scoped schemaUri acceptance (prod rejects sandbox / accepts orcid; non-prod accepts sandbox / rejects orcid).
- Deployed non-prod env config (test/demo/branch) is handled in a companion raido-v2-aws-private PR.

Closes [RAID-737](https://ardc.atlassian.net/browse/RAID-737)

🤖 Generated with [Claude Code](https://claude.com/claude-code)