### PR TITLE
RAID-737: seed sandbox contributor schema in stage

### DIFF
--- a/api-svc/db/src/main/resources/db/env/stage/V42.1__add_sandbox_contributor_schema.sql
+++ b/api-svc/db/src/main/resources/db/env/stage/V42.1__add_sandbox_contributor_schema.sql
@@ -1,0 +1,12 @@
+-- RAID-737: register the ORCID sandbox contributor schema in the stage environment.
+-- Stage now points at the ORCID sandbox (raid.contributor-validation.orcid.schema-uri
+-- = https://sandbox.orcid.org/), matching the agency UI, so ContributorService needs a
+-- matching contributor_schema row to persist sandbox contributors. Production stays
+-- orcid.org-only and omits this row.
+-- Guarded so a re-seeded/dump-restored database cannot end up with duplicate rows
+-- (ContributorSchemaRepository.findByUri uses fetchOptional, which fails on >1 row).
+insert into contributor_schema (uri, status)
+select 'https://sandbox.orcid.org/', 'active'::schema_status
+where not exists (
+    select 1 from contributor_schema where uri = 'https://sandbox.orcid.org/'
+);


### PR DESCRIPTION
## Summary

Stage environment is being switched to use the ORCID sandbox for contributor validation, matching the agency UI configuration which already sends sandbox credentials for all non-production environments. This migration adds the required `https://sandbox.orcid.org/` schema entry to stage's database.

## Details

The `ContributorService.create()` method looks up the schema URI in the contributor_schema table. Without a sandbox entry, minting a sandbox contributor 500s with `ContributorSchemaNotFoundException`. This migration (V42.1) adds the sandbox schema row to stage's DB, mirroring the existing migrations in `db/env/{dev,test,demo}` and guarded with `where-not-exists` to prevent duplicate key errors.

The backend contributor-validation config for stage is updated separately in [raido-v2-aws-private](https://github.com/au-research/raido-v2-aws-private).

Stage must be rebuilt and redeployed on a RAID-737-capable image for this change to take effect.

**Relates to:** [RAID-737](https://ardc.atlassian.net/browse/RAID-737)

🤖 Generated with [Claude Code](https://claude.com/claude-code)