### PR TITLE
RAID-802: fix mint 500 — scope validator timeouts to a dedicated RestTemplate

### DIFF
--- a/api-svc/raid-api/src/main/java/au/org/raid/api/Api.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/Api.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
@@ -28,20 +29,17 @@ public class Api {
         return Clock.systemUTC();
     }
 
+    /**
+     * Shared, general-purpose RestTemplate used by outbound clients such as
+     * DataCite, the legacy RAiD service and Keycloak logout. Its timeouts are
+     * intentionally left unbounded here — those calls (e.g. a DataCite mint) can
+     * legitimately run longer than a URI-existence check. URI validators use the
+     * separately bounded {@link #uriValidatorRestTemplate} instead. See RAID-802.
+     */
     @Bean
-    public RestTemplate restTemplate(
-            @Value("${raid.rest-template.connect-timeout:5s}") final Duration connectTimeout,
-            @Value("${raid.rest-template.read-timeout:10s}") final Duration readTimeout) {
-
-        // Bound connect/read timeouts so a slow or unreachable external resolver
-        // (timeout, DNS failure, connection refused) surfaces as a clean validation
-        // failure instead of hanging the request. This is the shared RestTemplate,
-        // so the bound also applies to other outbound clients. See RAID-802.
-        final var requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(connectTimeout);
-        requestFactory.setReadTimeout(readTimeout);
-
-        RestTemplate restTemplate = new RestTemplate(requestFactory);
+    @Primary
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
 
         // Add JAXB message converter for XML
         Jaxb2RootElementHttpMessageConverter jaxbConverter =
@@ -54,6 +52,26 @@ public class Api {
 
         restTemplate.setMessageConverters(converters);
         return restTemplate;
+    }
+
+    /**
+     * Dedicated RestTemplate for external URI validators (DOI, ROR, GeoNames,
+     * OpenStreetMap). Connect/read timeouts are bounded so a slow or unreachable
+     * resolver surfaces as a clean validation failure instead of hanging the
+     * request, without affecting the shared RestTemplate used for minting and
+     * other outbound calls. Configurable via {@code raid.uri-validation.*}.
+     * See RAID-802.
+     */
+    @Bean
+    public RestTemplate uriValidatorRestTemplate(
+            @Value("${raid.uri-validation.connect-timeout:5s}") final Duration connectTimeout,
+            @Value("${raid.uri-validation.read-timeout:10s}") final Duration readTimeout) {
+
+        final var requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(connectTimeout);
+        requestFactory.setReadTimeout(readTimeout);
+
+        return new RestTemplate(requestFactory);
     }
 
     public static void main(String[] args) {

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/bean/ExternalPidService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/bean/ExternalPidService.java
@@ -11,6 +11,7 @@ import au.org.raid.api.util.Log;
 import au.org.raid.api.validator.GeoNamesUriValidator;
 import au.org.raid.api.validator.OpenStreetMapUriValidator;
 import au.org.raid.idl.raidv2.model.ValidationFailure;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
@@ -47,7 +48,7 @@ public class ExternalPidService {
     @Primary
     public RorService rorService(
             StubProperties stubProperties,
-            RestTemplate restTemplate
+            @Qualifier("uriValidatorRestTemplate") RestTemplate restTemplate
     ) {
         if (stubProperties.getRor().isEnabled()) {
             log.with("rorInMemoryStubDelay", stubProperties.getRor().getDelay()).
@@ -63,7 +64,7 @@ public class ExternalPidService {
     @Primary
     public DoiService doiService(
             StubProperties stubProperties,
-            RestTemplate restTemplate
+            @Qualifier("uriValidatorRestTemplate") RestTemplate restTemplate
     ) {
         if (stubProperties.getDoi().isEnabled()) {
             log.warn("using the in-memory DOI service");
@@ -77,7 +78,7 @@ public class ExternalPidService {
     @Primary
     public GeoNamesUriValidator geoNamesUriValidator(
             final StubProperties stubProperties,
-            final RestTemplate restTemplate,
+            @Qualifier("uriValidatorRestTemplate") final RestTemplate restTemplate,
             @Value("${raid.validation.geonames.username}") final String username
     ) {
         if (stubProperties.getGeoNames().isEnabled()) {
@@ -92,7 +93,7 @@ public class ExternalPidService {
     @Primary
     public OpenStreetMapUriValidator openStreetMapUriValidator(
             final StubProperties stubProperties,
-            final RestTemplate restTemplate
+            @Qualifier("uriValidatorRestTemplate") final RestTemplate restTemplate
     ) {
         if (stubProperties.getOpenStreetMap().isEnabled()) {
             log.warn("using the in-memory OpenStreetMap validator");

--- a/api-svc/raid-api/src/main/resources/application.yaml
+++ b/api-svc/raid-api/src/main/resources/application.yaml
@@ -67,9 +67,10 @@ raid:
   validation:
     geonames:
       username: geonames
-  rest-template:
-    # Bounded connect/read timeouts on the shared RestTemplate so a slow or
-    # unreachable external resolver fails gracefully rather than hanging (RAID-802).
+  uri-validation:
+    # Bounded connect/read timeouts for the URI validators' RestTemplate so a slow
+    # or unreachable external resolver fails gracefully rather than hanging. Scoped
+    # to validators only; the shared RestTemplate (minting etc.) is unaffected (RAID-802).
     connect-timeout: 5s
     read-timeout: 10s
   history:

--- a/documentation/20260804-raid-802-uri-validator-hardening.md
+++ b/documentation/20260804-raid-802-uri-validator-hardening.md
@@ -23,12 +23,20 @@ validation result:
 
 ### Changes
 
-- **`Api.java`** — the shared `RestTemplate` now uses a
-  `SimpleClientHttpRequestFactory` with bounded connect (5s) and read (10s)
-  timeouts, configurable via `raid.rest-template.connect-timeout` and
-  `raid.rest-template.read-timeout`. Defaults are baked into the `@Value`
-  bindings so a missing property cannot break bean construction. The existing
-  JAXB-converter-first ordering (relied on by the ISNI XML client) is preserved.
+- **`Api.java`** — introduces a **dedicated** `uriValidatorRestTemplate` bean
+  backed by a `SimpleClientHttpRequestFactory` with bounded connect (5s) and
+  read (10s) timeouts, configurable via `raid.uri-validation.connect-timeout` /
+  `raid.uri-validation.read-timeout` (defaults baked into the `@Value` bindings
+  so a missing property cannot break bean construction). The shared, general
+  `restTemplate` bean is left **unbounded** (as before) and marked `@Primary` so
+  all existing by-type injections keep resolving to it; its JAXB-converter-first
+  ordering (relied on by the ISNI XML client) is unchanged.
+- **`ExternalPidService.java`** — the four external URI validators built here
+  (`RorService`, `DoiService`, `GeoNamesUriValidator`,
+  `OpenStreetMapUriValidator`) now inject the bounded template via
+  `@Qualifier("uriValidatorRestTemplate")`. Everything else (DataCite, legacy
+  RAiD, Keycloak logout, ISNI/ROR/ORCID clients) continues to use the unbounded
+  shared bean.
 - **`AbstractUriValidator.java`** — a broad `catch (RestClientException e)` was
   added after the existing `HttpClientErrorException` block. It covers
   `ResourceAccessException` (timeout / DNS / connection refused),
@@ -37,38 +45,54 @@ validation result:
   (`"uri could not be validated - server error"`) validation failure. The
   404 -> `URI_DOES_NOT_EXIST` special-case is unchanged. Duplicated failure
   construction was pulled into a small `serverError(fieldId)` helper.
-- **`application.yaml`** — documents the new `raid.rest-template.*` timeout block.
+- **`application.yaml`** — documents the new `raid.uri-validation.*` timeout block.
 - **`AbstractUriValidatorTest.java`** — new unit tests for the timeout,
   connection-refused, 5xx and generic `RestClientException` paths, each
   asserting a clean `SERVER_ERROR` failure (no exception thrown).
 
 ## Coverage
 
-All five external-resolution validators — `DoiService`, `OrcidService`,
-`RorService`, `OpenStreetMapUriValidator`, `GeoNamesUriValidator` — extend
-`AbstractUriValidator` and share the single `RestTemplate` bean, so both fixes
-apply to them automatically. The ARK/Handle/RRID validators from the RAID-699
-follow-up do not exist yet (only a spike doc,
+The four external-resolution validators built in `ExternalPidService`
+(`RorService`, `DoiService`, `OpenStreetMapUriValidator`,
+`GeoNamesUriValidator`) extend `AbstractUriValidator` and now use the bounded
+template, so both fixes apply to them. `OrcidService` also extends
+`AbstractUriValidator` but is **not currently wired** into the Spring context
+(no `@Bean`/`@Component`/constructor call — only a dead import and the
+`OrcidServiceStub` subclass), so ORCID URL validation does not run through it;
+it will pick up the bounded template if/when it is wired. The ARK/Handle/RRID
+validators from the RAID-699 follow-up do not exist yet (only a spike doc,
 `20260710-raid-699-identifier-validator-spike.md`); they will inherit this
 hardening when built.
 
-## Design note / known consideration
+## Design note: why a dedicated template (not the shared one)
 
-The timeout is applied to the **shared** `RestTemplate` bean, as the ticket
-specifies. That bean is also injected into `DataciteService`,
-`LegacyRaidService`, `RaidUpgradeService`, `KeycloakLogoutHandler` and the
-ROR/ORCID/ISNI clients, so the 5s/10s bound now applies process-wide where those
-callers previously relied on OS-level (effectively unbounded) timeouts. This is
-intentional within the ticket scope. The read timeout is per-inactivity
-(`SO_TIMEOUT`), not total request time, so a slow-but-streaming response is not
-tripped. If any of those integrations (notably a DataCite mint/deposit) needs a
-longer bound, a follow-up could either raise `raid.rest-template.read-timeout`
-or move the validators onto a dedicated, tighter-bounded `RestTemplate`.
+The ticket originally called for bounding the **shared** `RestTemplate`. A first
+pass did exactly that, and the branch pipeline
+([Branch-Build-Deploy `f84d8d25`](https://ap-southeast-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/Branch-Build-Deploy/executions/f84d8d25-5f7a-49e2-a5e0-e500fd616653/visualization?region=ap-southeast-2))
+went red: every `POST /raid/` mint returned an empty-body HTTP 500. Root cause —
+the shared bean is also used by `DataciteService.mint()`, which only catches
+`HttpClientErrorException` (4xx). DataCite's test endpoint routinely takes longer
+than the new 10s read bound, so a `ResourceAccessException` propagated uncaught
+as a raw 500 on every mint. The read timeout is per-inactivity (`SO_TIMEOUT`),
+not total request time, but DataCite test stalls exceeded even that.
+
+Rather than bound the shared bean and add `ResourceAccessException` handling to
+every non-validator caller, the timeout was scoped to a dedicated
+`uriValidatorRestTemplate` used only by the URI validators — which is precisely
+what RAID-802's "graceful external-resolver failure" is about. DataCite minting
+and other outbound calls keep their prior (unbounded) behaviour, so there is no
+blast radius outside URI validation.
 
 ## Testing
 
 - `./gradlew :api-svc:raid-api:test` — full unit suite green, including the four
   new failure-mode tests.
+- Local `dockerComposeUp bootRun` — the application context initialised all
+  singleton beans (both `RestTemplate` beans plus the four qualified validators)
+  successfully; the run only stopped at the final web-server bind because port
+  8080 was already in use locally, confirming the DI wiring resolves.
+- The branch pipeline re-run after this fix is the end-to-end gate (mint 500s
+  resolved, `intTest` + `e2e` green).
 
 ## Acceptance criteria
 


### PR DESCRIPTION
## Why this PR exists

PR #591 was merged **before** the follow-up fix landed. It merged commit `d1ac37a9`, which includes `c8ede1f6` ("harden URI validator and bound RestTemplate timeouts"). That commit bounded the **shared** `RestTemplate`, which broke DataCite minting: `DataciteService.mint()` only catches `HttpClientErrorException` (4xx), so a read timeout on the slow DataCite test endpoint propagated as an **empty-body HTTP 500 on every `POST /raid/`**. Branch pipeline `f84d8d25` failed with 85 intTest failures + 3 e2e failures as a result.

**`main` currently has this regression.** This PR carries the single fix commit that was never merged.

## The fix (`4471b31a`)

- **`Api.java`** — adds a dedicated `uriValidatorRestTemplate` bean with bounded connect (5s) / read (10s) timeouts (`raid.uri-validation.*`). The shared `restTemplate` bean is reverted to **unbounded** and marked `@Primary`.
- **`ExternalPidService.java`** — the four external URI validators (`RorService`, `DoiService`, `GeoNamesUriValidator`, `OpenStreetMapUriValidator`) inject the bounded template via `@Qualifier("uriValidatorRestTemplate")`. DataCite, legacy RAiD, Keycloak logout and the ISNI/ROR/ORCID clients keep the shared unbounded bean.
- **`application.yaml`** — `raid.uri-validation.*` timeout block.
- Completion doc updated.

`AbstractUriValidator`'s broad `catch (RestClientException e)` (added in `c8ede1f6`, already in main) is retained and unaffected.

## Verification

- Branch pipeline **`fa300262` Succeeded** on this exact commit (`4471b31a`): Build ✅, Deploy ✅, **E2e-Test ✅** (mint flow works), **Api-Integration-Test ✅** (180/181 first run; the one failure was an unrelated transient live-ISNI timeout that passed on a failed-action retry).
- Local: full unit suite green; `intTest` 181/181 (0 failures) against a local API from this branch.

## Note

Merging this restores correct minting on `main` (and therefore the test env, which deploys from main). Recommend merging promptly.

Separate follow-up (epic RAID-789): ISNI validator hardening — ISNI is unstubbed in the test env and `IsniClient` has no error handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)