### PR TITLE
RAID-782: validate static-site JSON-LD against LinkML schema in CI

### DIFF
--- a/api-svc/datamodel/generated/v2/researchproject.json
+++ b/api-svc/datamodel/generated/v2/researchproject.json
@@ -119,6 +119,13 @@
                         }
                     ],
                     "description": "Structured identifier with type information"
+                },
+                "name": {
+                    "description": "The resolved organisation name for organization members, carried so harvesters do not have to resolve the ROR themselves (RAID-794). Optional: person members and organizations whose ROR could not be resolved emit only the identifier.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "required": [

--- a/api-svc/datamodel/src/v2/researchproject.yaml
+++ b/api-svc/datamodel/src/v2/researchproject.yaml
@@ -243,6 +243,14 @@ classes:
         range: PropertyValue
         inlined: true
         description: Structured identifier with type information
+      name:
+        slot_uri: schema:name
+        range: string
+        description: >-
+          The resolved organisation name for organization members, carried so
+          harvesters do not have to resolve the ROR themselves (RAID-794).
+          Optional: person members and organizations whose ROR could not be
+          resolved emit only the identifier.
   Place:
     class_uri: schema:Place
     description: Geographic location

--- a/api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml
+++ b/api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml
@@ -1795,6 +1795,14 @@ components:
           - $ref: "#/components/schemas/PropertyValue"
           - type: "null"
           description: "Structured identifier with type information"
+        name:
+          description: "The resolved organisation name for organization members, carried\
+            \ so harvesters do not have to resolve the ROR themselves (RAID-794).\
+            \ Optional: person members and organizations whose ROR could not be resolved\
+            \ emit only the identifier."
+          type:
+          - "string"
+          - "null"
       required:
       - "@type"
       - "@id"

--- a/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
+++ b/api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml
@@ -1928,6 +1928,14 @@ components:
           - $ref: "#/components/schemas/PropertyValue"
           - type: "null"
           description: "Structured identifier with type information"
+        name:
+          description: "The resolved organisation name for organization members, carried\
+            \ so harvesters do not have to resolve the ROR themselves (RAID-794).\
+            \ Optional: person members and organizations whose ROR could not be resolved\
+            \ emit only the identifier."
+          type:
+          - "string"
+          - "null"
       required:
       - "@type"
       - "@id"

--- a/doc/adr/2026-08-06_validate-static-jsonld-against-linkml-schema.md
+++ b/doc/adr/2026-08-06_validate-static-jsonld-against-linkml-schema.md
@@ -1,0 +1,87 @@
+### Validate the static-site JSON-LD output against the LinkML-derived schema in CI (validation-only, not generated types)
+
+* Status: final
+* Who: proposed by Claude, decided by RL
+* When: 2026-08-06
+* Related: RAID-782 (parent RAID-574), follow-on from RAID-759 Phase 3a, depends on RAID-778 (LinkML schema) and RAID-779 (generated artefacts)
+
+# Context
+
+The static site's landing-page JSON-LD is produced by a hand-maintained builder,
+`raid-agency-app-static/src/utils/json-ld.ts`, whose output is embedded as
+`<script type="application/ld+json">` on each raid page and harvested by RDA for
+the NESP Domain Data Portal (HELP-2753). The canonical definition of RAiD's
+schema.org `ResearchProject` shape lives in the LinkML schema
+`api-svc/datamodel/src/v2/researchproject.yaml`, compiled by `gen-json-schema`
+to the committed `api-svc/datamodel/generated/v2/researchproject.json`.
+
+Nothing linked the two. `json-ld.ts` could drift from the canonical schema
+silently, with no consumer-visible signal until a harvester broke. RAID-759's
+Phase 3a asked us to close that gap. It framed the relationship as: `json-ld.ts`
+is the only consumer-validated emitter, so it is the *reference output*, and the
+LinkML schema is the *authoritative definition that must describe it*.
+
+RAID-782 required a documented choice between two mechanisms (AC#2):
+
+1. **Generate TypeScript types** (and ideally the `@context`) from the LinkML
+   schema so `json-ld.ts` stops being hand-maintained and drift becomes a compile
+   error.
+2. **Validation-only** — add a CI check that validates `json-ld.ts` output against
+   the LinkML-derived JSON Schema.
+
+# Decision
+
+Adopt **validation-only**. A Vitest suite
+(`raid-agency-app-static/src/utils/json-ld.schema.test.ts`) runs
+`buildResearchProjectJsonLd()` over representative fixtures and validates the
+output against `researchproject.json` with `ajv` (draft 2019-09) against the
+`#/$defs/ResearchProject` subschema (`additionalProperties: false`). It runs in
+the static site's existing `npm test` step
+(`.github/workflows/raid-agency-app-static.yml`), so any PR that makes the
+emitter diverge from the canonical schema fails CI.
+
+The schema is read at runtime from the datamodel module via a relative path,
+keeping it out of the TypeScript type graph and `astro check`; CI checks out the
+whole monorepo so the path resolves there.
+
+# Alternatives considered
+
+* **Generate TypeScript types from LinkML.** Rejected for now. The static site
+  has no codegen toolchain (its deps are Astro/Vitest/Tailwind only), and the
+  LinkML generators require Docker, which the static-site CI job does not have.
+  Wiring a LinkML-to-TypeScript generator into the site's build is a large,
+  standalone piece of infrastructure disproportionate to a low-priority ticket,
+  and it would still not validate the *values* the emitter produces — only its
+  static shape. Validation-only gives the drift guarantee the ticket asks for at
+  a fraction of the cost, and RAID-759 explicitly names it as an acceptable
+  minimum. Generated types remain a future option if `json-ld.ts` grows.
+
+* **Validate loosely (allow additional properties).** Rejected. It would not
+  catch the divergences that matter (renamed or stray fields), undercutting the
+  point of the check. We validate against the strict `ResearchProject` subschema
+  and the suite includes a negative-control test proving `additionalProperties:
+  false` is actually enforced.
+
+# Consequences
+
+* Two pre-existing emitter/schema drifts, invisible until the check existed, were
+  found and fixed as part of this work:
+  * **`CreativeWork.additionalType`** — the schema models it as multivalued
+    (array), but `json-ld.ts` emitted a bare scalar for a single category.
+    Resolved in the emitter: `additionalType` is now always emitted as an array
+    (omitted when there is no category). Harvester-safe — JSON-LD expansion
+    treats a single-element array and a scalar identically.
+  * **`Member.name`** — RAID-794 added the resolved ROR organisation name onto
+    organization member/funder nodes, but those validate against the `Member`
+    class, which had no `name` and `additionalProperties: false`. Resolved in the
+    schema: an optional `name` was added to the `Member` class in
+    `researchproject.yaml`, and `researchproject.json` plus the two committed
+    OpenAPI specs were regenerated.
+* The check couples the static-site test to the committed `researchproject.json`.
+  Because the datamodel is regenerated only locally (Docker/LinkML) and CI relies
+  on the committed JSON, any future schema change must commit the regenerated
+  `researchproject.json` or the check validates against a stale schema. This is
+  already the datamodel's operating model.
+* This addresses the "or at minimum" half of RAID-759 Phase 3a. Generating types
+  and/or the `@context` for the emitter remains available as later work if the
+  hand-maintained builder becomes harder to keep correct by hand.

--- a/documentation/20260806-raid-782-json-ld-schema-validation.md
+++ b/documentation/20260806-raid-782-json-ld-schema-validation.md
@@ -17,7 +17,7 @@ RAID-574.
 - Follow-on from: [RAID-759](https://ardc.atlassian.net/browse/RAID-759) (investigation, Phase 3a)
 - Depends on: [RAID-778](https://ardc.atlassian.net/browse/RAID-778) (LinkML schema), [RAID-779](https://ardc.atlassian.net/browse/RAID-779) (generated artefacts)
 - Related: [RAID-757](https://ardc.atlassian.net/browse/RAID-757) (citation), [RAID-794](https://ardc.atlassian.net/browse/RAID-794) (resolved ROR org name)
-- PR: _to be added_
+- PR: https://github.com/au-research/raid-au/pull/600
 - ADR: `doc/adr/2026-08-06_validate-static-jsonld-against-linkml-schema.md`
 
 ## What changed and why

--- a/documentation/20260806-raid-782-json-ld-schema-validation.md
+++ b/documentation/20260806-raid-782-json-ld-schema-validation.md
@@ -1,0 +1,104 @@
+# RAID-782: Validate static-site json-ld.ts output against the LinkML-derived schema in CI
+
+## Summary
+
+Added a CI validation check that fails the build if the static site's
+hand-maintained JSON-LD builder (`raid-agency-app-static/src/utils/json-ld.ts`)
+drifts from the canonical LinkML schema (`researchproject.yaml` ->
+`researchproject.json`). Chose validation-only over generated TypeScript types
+(recorded in an ADR). Fixed two pre-existing emitter/schema drifts that the new
+check surfaced. Follow-on from the RAID-759 investigation (Phase 3a) under epic
+RAID-574.
+
+## Links
+
+- Story: [RAID-782](https://ardc.atlassian.net/browse/RAID-782)
+- Epic: [RAID-574](https://ardc.atlassian.net/browse/RAID-574)
+- Follow-on from: [RAID-759](https://ardc.atlassian.net/browse/RAID-759) (investigation, Phase 3a)
+- Depends on: [RAID-778](https://ardc.atlassian.net/browse/RAID-778) (LinkML schema), [RAID-779](https://ardc.atlassian.net/browse/RAID-779) (generated artefacts)
+- Related: [RAID-757](https://ardc.atlassian.net/browse/RAID-757) (citation), [RAID-794](https://ardc.atlassian.net/browse/RAID-794) (resolved ROR org name)
+- PR: _to be added_
+- ADR: `doc/adr/2026-08-06_validate-static-jsonld-against-linkml-schema.md`
+
+## What changed and why
+
+### AC1 — CI fails when json-ld.ts output diverges from the canonical schema
+
+New test `raid-agency-app-static/src/utils/json-ld.schema.test.ts`:
+
+- Reads the committed `api-svc/datamodel/generated/v2/researchproject.json` at
+  runtime (relative path across the monorepo; kept out of the TS type graph and
+  `astro check`, which already excludes `*.test.ts`).
+- Compiles the strict `#/$defs/ResearchProject` subschema
+  (`additionalProperties: false`) with `ajv` (draft 2019-09) + `ajv-formats` (for
+  the `date` format), and validates `buildResearchProjectJsonLd()` output.
+- Fixtures: a minimal RAiD, a **maximal** RAiD exercising every emitted field (so
+  every schema class is covered — CreativeWork, RelatedResearchProject, Member
+  with a resolved name, DefinedTerm, PropertyValue, Organization), plus targeted
+  cases for the two drifts below.
+- A **negative-control** test confirms the suite validates against the strict
+  subschema (not the permissive schema root), so a real divergence is genuinely
+  rejected.
+
+Runs in the existing `npm test` step of
+`.github/workflows/raid-agency-app-static.yml` — no workflow change needed.
+`ajv` and `ajv-formats` added as devDependencies.
+
+Manually verified the guard bites by temporarily injecting a stray field into
+the emitter output (4 schema tests failed), then reverting.
+
+### AC2 — documented choice: validation-only vs generated types
+
+Recorded in `doc/adr/2026-08-06_validate-static-jsonld-against-linkml-schema.md`.
+Chose validation-only: the static site has no codegen toolchain and the LinkML
+generators need Docker (absent from the static-site CI job), whereas validation
+reuses the existing Vitest/`npm test` step and gives the drift guarantee the
+ticket asks for. RAID-759 names validation-only as an acceptable minimum.
+
+### Two drifts found and fixed
+
+The check was inert until the emitter and schema agreed. Two pre-existing
+divergences were surfaced and resolved:
+
+1. **`CreativeWork.additionalType`** (emitter fix). The schema models it as
+   multivalued (array); `json-ld.ts` emitted a bare scalar for a single category.
+   `buildRelatedObjectCitations` now always emits `additionalType` as an array
+   (omitted when there is no category). Harvester-safe: JSON-LD expansion treats a
+   single-element array and a scalar identically. Two assertions in
+   `json-ld.test.ts` updated accordingly.
+
+2. **`Member.name`** (schema fix). RAID-794 added the resolved ROR organisation
+   name onto organization member/funder nodes, but those validate against the
+   `Member` class, which had no `name` and `additionalProperties: false`. Added an
+   optional `name` to the `Member` class in `researchproject.yaml`.
+
+### Regenerated derived artefacts
+
+After the `Member.name` schema change, regenerated locally (Docker/LinkML,
+`--rerun-tasks`) and committed:
+
+- `api-svc/datamodel/generated/v2/researchproject.json`
+- `api-svc/idl-raid-v2/src/raid-openapi-3.1.yaml`
+- `api-svc/idl-raid-v2/src/raid-openapi-strict-3.1.yaml`
+
+Each diff is limited to the `Member.name` addition. CI has no Docker/LinkML, so
+the committed JSON is authoritative; regenerated Java models (gitignored) are
+unused dead code. Verified `:api-svc:idl-raid-v2:openApiGenerate` +
+`compileJava` still succeed.
+
+## Ticketing note
+
+The `Member.name` schema gap was strictly a coordination miss between the RAID-778
+schema completion and the later RAID-794 emitter change — exactly the class of
+drift this CI check now prevents. It was fixed here under RAID-782 (referencing
+RAID-794) rather than reopening a separate ticket, because the validation check is
+meaningless until the schema and emitter agree.
+
+## Verification
+
+- `raid-agency-app-static`: `npm test` -> 49 tests pass (existing suite + new
+  schema suite); `npx astro check` -> 0 errors; `npx astro build` completes.
+- `./gradlew :api-svc:idl-raid-v2:compileJava` -> BUILD SUCCESSFUL (specs valid,
+  Java generation compiles).
+- Negative check: stray field injected into emitter output -> schema tests fail
+  as expected; reverted.

--- a/raid-agency-app-static/package-lock.json
+++ b/raid-agency-app-static/package-lock.json
@@ -1950,7 +1950,7 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://raid-org-380617297661.d.codeartifact.us-east-1.amazonaws.com/npm/prod/ajv/-/ajv-8.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
@@ -1966,7 +1966,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://raid-org-380617297661.d.codeartifact.us-east-1.amazonaws.com/npm/prod/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "dev": true,
       "license": "MIT",
@@ -3123,7 +3123,7 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://raid-org-380617297661.d.codeartifact.us-east-1.amazonaws.com/npm/prod/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
@@ -3482,7 +3482,7 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://raid-org-380617297661.d.codeartifact.us-east-1.amazonaws.com/npm/prod/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
@@ -5264,7 +5264,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://raid-org-380617297661.d.codeartifact.us-east-1.amazonaws.com/npm/prod/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {

--- a/raid-agency-app-static/package-lock.json
+++ b/raid-agency-app-static/package-lock.json
@@ -24,6 +24,8 @@
       "devDependencies": {
         "@types/node": "^22.13.10",
         "@types/trusted-types": "^2.0.7",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "vitest": "^4.1.10"
       }
     },
@@ -506,22 +508,6 @@
       "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
       "license": "MIT"
     },
-    "node_modules/@astrojs/check/node_modules/@astrojs/language-server/node_modules/volar-service-yaml/node_modules/yaml-language-server/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@astrojs/check/node_modules/@astrojs/language-server/node_modules/volar-service-yaml/node_modules/yaml-language-server/node_modules/ajv-draft-04": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
@@ -534,27 +520,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@astrojs/check/node_modules/@astrojs/language-server/node_modules/volar-service-yaml/node_modules/yaml-language-server/node_modules/ajv/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/@astrojs/check/node_modules/@astrojs/language-server/node_modules/volar-service-yaml/node_modules/yaml-language-server/node_modules/ajv/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/@astrojs/check/node_modules/@astrojs/language-server/node_modules/volar-service-yaml/node_modules/yaml-language-server/node_modules/ajv/node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@astrojs/check/node_modules/@astrojs/language-server/node_modules/volar-service-yaml/node_modules/yaml-language-server/node_modules/prettier": {
@@ -1553,9 +1518,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1571,9 +1533,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1591,9 +1550,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1609,9 +1565,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1993,6 +1946,40 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://raid-org-380617297661.d.codeartifact.us-east-1.amazonaws.com/npm/prod/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://raid-org-380617297661.d.codeartifact.us-east-1.amazonaws.com/npm/prod/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -3134,6 +3121,12 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://raid-org-380617297661.d.codeartifact.us-east-1.amazonaws.com/npm/prod/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
@@ -3486,6 +3479,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://raid-org-380617297661.d.codeartifact.us-east-1.amazonaws.com/npm/prod/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
@@ -5258,6 +5257,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://raid-org-380617297661.d.codeartifact.us-east-1.amazonaws.com/npm/prod/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/raid-agency-app-static/package.json
+++ b/raid-agency-app-static/package.json
@@ -30,6 +30,8 @@
   "devDependencies": {
     "@types/node": "^22.13.10",
     "@types/trusted-types": "^2.0.7",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "vitest": "^4.1.10"
   },
   "overrides": {

--- a/raid-agency-app-static/src/utils/json-ld.schema.test.ts
+++ b/raid-agency-app-static/src/utils/json-ld.schema.test.ts
@@ -1,0 +1,344 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Ajv2019, { type ValidateFunction } from "ajv/dist/2019";
+import addFormats from "ajv-formats";
+import { describe, expect, it } from "vitest";
+import { buildResearchProjectJsonLd } from "./json-ld";
+import type { RaidDto } from "@/generated/raid";
+
+// RAID-782: the static site's JSON-LD output (json-ld.ts) is hand-maintained,
+// while the canonical shape of RAiD's schema.org ResearchProject lives in the
+// LinkML schema (api-svc/datamodel/src/v2/researchproject.yaml), compiled to the
+// JSON Schema below. This suite validates buildResearchProjectJsonLd() output
+// against that schema so CI fails if the emitter drifts from the canonical
+// definition (see RAID-759 Phase 3a; the decision rationale is recorded in
+// doc/adr).
+//
+// The schema is read at runtime rather than statically imported so it stays out
+// of the TypeScript type graph and `astro check`, and so the cross-module path to
+// the datamodel module is resolved by Node at test time. CI checks out the whole
+// monorepo, so this relative path resolves there too.
+const SCHEMA_PATH = fileURLToPath(
+  new URL(
+    "../../../api-svc/datamodel/generated/v2/researchproject.json",
+    import.meta.url,
+  ),
+);
+const RESEARCH_PROJECT_REF =
+  "https://example.org/raid-schema-org#/$defs/ResearchProject";
+
+const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf-8"));
+
+// strict:false — the LinkML output carries metaschema keywords (version:null,
+// title, metamodel_version, additionalProperties:true at the root) that ajv's
+// strict mode would reject. addFormats enables the `date` format assertion.
+const ajv = new Ajv2019({ strict: false, allErrors: true });
+addFormats(ajv);
+ajv.addSchema(schema);
+
+function researchProjectValidator(): ValidateFunction {
+  const validate = ajv.getSchema(RESEARCH_PROJECT_REF);
+  if (!validate) {
+    throw new Error(
+      `Could not resolve ${RESEARCH_PROJECT_REF}; the LinkML-generated schema may have changed shape (regenerate researchproject.json).`,
+    );
+  }
+  return validate;
+}
+
+function expectValid(jsonLd: unknown): void {
+  const validate = researchProjectValidator();
+  const valid = validate(jsonLd);
+  if (!valid) {
+    // Surface the ajv errors so a divergence is diagnosable straight from CI output.
+    // eslint-disable-next-line no-console
+    console.error(JSON.stringify(validate.errors, null, 2));
+  }
+  expect(valid).toBe(true);
+}
+
+const PRIMARY_TITLE_TYPE = "https://vocabulary.raid.org/title.type.schema/5";
+const PRIMARY_DESCRIPTION_TYPE =
+  "https://vocabulary.raid.org/description.type.schema/318";
+const FUNDER_ORGANISATION_ROLE =
+  "https://vocabulary.raid.org/organisation.role.schema/186";
+
+function minimalRaid(): Partial<RaidDto> {
+  return {
+    identifier: {
+      id: "https://raid.org/10.26259/0d7f1865",
+      schemaUri: "https://raid.org",
+      registrationAgency: {
+        id: "https://ror.org/038sjwq14",
+        schemaUri: "https://ror.org",
+      },
+      owner: {
+        id: "https://ror.org/038sjwq14",
+        schemaUri: "https://ror.org",
+        servicePoint: 1,
+      },
+      raidAgencyUrl: "",
+      license: "",
+      version: 1,
+    },
+    date: {
+      startDate: "2025-05-26",
+    },
+  };
+}
+
+// A fixture that exercises every field buildResearchProjectJsonLd() can emit, so
+// the validation covers every schema class (CreativeWork, RelatedResearchProject,
+// Member with a resolved name, DefinedTerm, PropertyValue, Organization) and every
+// property, not just the happy-path core.
+function maximalRaid(): Partial<RaidDto> {
+  const raid = minimalRaid();
+
+  // Registration agency enriched with a resolved ROR name (RAID-794).
+  raid.identifier = {
+    ...raid.identifier!,
+    registrationAgency: {
+      id: "https://ror.org/038sjwq14",
+      schemaUri: "https://ror.org",
+      rorDetails: { name: "Australian Research Data Commons" },
+    } as never,
+  };
+
+  raid.date = { startDate: "2024-01-01", endDate: "2025-12-31" };
+
+  raid.title = [
+    {
+      text: "Primary project title",
+      type: { id: PRIMARY_TITLE_TYPE, schemaUri: "" },
+      startDate: "2024-01-01",
+      language: {
+        id: "eng",
+        schemaUri: "https://www.iso.org/standard/74575.html",
+      },
+    },
+    {
+      text: "Alternative title",
+      type: {
+        id: "https://vocabulary.raid.org/title.type.schema/4",
+        schemaUri: "",
+      },
+      startDate: "2024-01-01",
+    },
+  ];
+
+  raid.description = [
+    {
+      text: "The primary description of the project.",
+      type: { id: PRIMARY_DESCRIPTION_TYPE, schemaUri: "" },
+      language: {
+        id: "eng",
+        schemaUri: "https://www.iso.org/standard/74575.html",
+      },
+    },
+  ];
+
+  raid.contributor = [
+    {
+      id: "https://orcid.org/0000-0002-4582-7728",
+      schemaUri: "https://orcid.org",
+      position: [
+        {
+          schemaUri: "https://vocabulary.raid.org",
+          id: "https://vocabulary.raid.org/contributor.position.schema/307",
+          startDate: "2024-01-01",
+          endDate: "2025-12-31",
+        },
+      ],
+      role: [
+        {
+          schemaUri: "https://credit.niso.org",
+          id: "https://credit.niso.org/contributor-roles/data-curation/",
+        },
+      ],
+    },
+  ];
+
+  raid.organisation = [
+    // Non-funder organisation -> member role, with a resolved ROR name (Member.name).
+    {
+      id: "https://ror.org/03sd43014",
+      schemaUri: "https://ror.org",
+      rorDetails: { name: "QCIF Ltd." },
+      role: [
+        {
+          schemaUri: "https://vocabulary.raid.org",
+          id: "https://vocabulary.raid.org/organisation.role.schema/185",
+          startDate: "2024-01-01",
+        },
+      ],
+    } as never,
+    // Funder organisation -> funder role.
+    {
+      id: "https://ror.org/04yx6dh41",
+      schemaUri: "https://ror.org",
+      rorDetails: { name: "Australian Research Council" },
+      role: [
+        {
+          schemaUri: "https://vocabulary.raid.org",
+          id: FUNDER_ORGANISATION_ROLE,
+          startDate: "2024-01-01",
+          endDate: "2025-12-31",
+        },
+      ],
+    } as never,
+  ];
+
+  raid.subject = [
+    {
+      id: "https://linked.data.gov.au/def/anzsrc-for/2020/420399",
+      schemaUri: "https://vocabs.ardc.edu.au/viewById/316",
+    },
+  ];
+
+  // Related objects -> citation CreativeWork nodes: one with a single category
+  // (additionalType as a one-element array) and formatted citation text, one with
+  // multiple categories.
+  raid.relatedObject = [
+    {
+      id: "https://doi.org/10.1007/s00442-014-2977-8",
+      schemaUri: "https://doi.org/",
+      type: {
+        id: "https://vocabulary.raid.org/relatedObject.type.schema/250",
+        schemaUri: "",
+      },
+      category: [
+        {
+          id: "https://vocabulary.raid.org/relatedObject.category.id/190",
+          schemaUri: "",
+        },
+      ],
+      citation: {
+        text: "Smith, J. (2014). A study of things. Oecologia, 176(2), 1-10.",
+      },
+    },
+    {
+      id: "https://doi.org/10.4227/05/598bd8a2e9e76",
+      schemaUri: "https://doi.org/",
+      type: {
+        id: "https://vocabulary.raid.org/relatedObject.type.schema/269",
+        schemaUri: "",
+      },
+      category: [
+        {
+          id: "https://vocabulary.raid.org/relatedObject.category.id/190",
+          schemaUri: "",
+        },
+        {
+          id: "https://vocabulary.raid.org/relatedObject.category.id/192",
+          schemaUri: "",
+        },
+      ],
+    },
+  ] as unknown as RaidDto["relatedObject"];
+
+  // Related RAiDs covering all four schema.org relationship properties.
+  raid.relatedRaid = [
+    {
+      id: "https://raid.org/10.71821/a945d761",
+      type: {
+        id: "https://vocabulary.raid.org/relatedRaid.type.schema/202",
+        schemaUri: "https://vocabulary.raid.org/relatedRaid.type.schema",
+      },
+    },
+    {
+      id: "https://raid.org/10.71821/23fcbc6f",
+      type: {
+        id: "https://vocabulary.raid.org/relatedRaid.type.schema/201",
+        schemaUri: "https://vocabulary.raid.org/relatedRaid.type.schema",
+      },
+    },
+    {
+      id: "https://raid.org/10.26259/abcd1234",
+      type: {
+        id: "https://vocabulary.raid.org/relatedRaid.type.schema/200",
+        schemaUri: "https://vocabulary.raid.org/relatedRaid.type.schema",
+      },
+    },
+    {
+      id: "https://raid.org/10.26259/efgh5678",
+      type: {
+        id: "https://vocabulary.raid.org/relatedRaid.type.schema/204",
+        schemaUri: "https://vocabulary.raid.org/relatedRaid.type.schema",
+      },
+    },
+  ];
+
+  return raid;
+}
+
+describe("buildResearchProjectJsonLd conforms to the LinkML researchproject schema", () => {
+  it("resolves the ResearchProject subschema from the generated JSON Schema", () => {
+    expect(researchProjectValidator()).toBeTypeOf("function");
+  });
+
+  it("validates the minimal RAiD output", () => {
+    expectValid(buildResearchProjectJsonLd(minimalRaid()));
+  });
+
+  it("validates the maximal RAiD output covering every emitted field", () => {
+    expectValid(buildResearchProjectJsonLd(maximalRaid()));
+  });
+
+  it("validates an organisation member carrying a resolved ROR name (RAID-794 -> Member.name)", () => {
+    const raid = minimalRaid();
+    raid.organisation = [
+      {
+        id: "https://ror.org/03sd43014",
+        schemaUri: "https://ror.org",
+        rorDetails: { name: "QCIF Ltd." },
+        role: [
+          {
+            schemaUri: "https://vocabulary.raid.org",
+            id: "https://vocabulary.raid.org/organisation.role.schema/185",
+            startDate: "2024-01-01",
+          },
+        ],
+      } as never,
+    ];
+    expectValid(buildResearchProjectJsonLd(raid));
+  });
+
+  it("validates a single-category related object (additionalType emitted as an array)", () => {
+    const raid = minimalRaid();
+    raid.relatedObject = [
+      {
+        id: "https://doi.org/10.1007/single-category",
+        schemaUri: "https://doi.org/",
+        type: {
+          id: "https://vocabulary.raid.org/relatedObject.type.schema/250",
+          schemaUri: "",
+        },
+        category: [
+          {
+            id: "https://vocabulary.raid.org/relatedObject.category.id/190",
+            schemaUri: "",
+          },
+        ],
+      },
+    ];
+    const output = buildResearchProjectJsonLd(raid);
+    expect(output.citation?.[0].additionalType).toEqual([
+      "https://vocabulary.raid.org/relatedObject.category.id/190",
+    ]);
+    expectValid(output);
+  });
+
+  // Negative control: proves the suite validates against the strict ResearchProject
+  // subschema (additionalProperties:false) rather than the permissive schema root,
+  // so a genuine divergence really would be rejected.
+  it("rejects output carrying an unexpected top-level property", () => {
+    const output = buildResearchProjectJsonLd(minimalRaid()) as Record<
+      string,
+      unknown
+    >;
+    const validate = researchProjectValidator();
+    expect(validate({ ...output, unexpectedProperty: "should not validate" })).toBe(
+      false,
+    );
+  });
+});

--- a/raid-agency-app-static/src/utils/json-ld.test.ts
+++ b/raid-agency-app-static/src/utils/json-ld.test.ts
@@ -551,7 +551,7 @@ describe("buildResearchProjectJsonLd", () => {
           name: "DOI",
           value: "https://doi.org/10.1007/s00442-014-2977-8",
         },
-        additionalType: "https://vocabulary.raid.org/relatedObject.category.id/190",
+        additionalType: ["https://vocabulary.raid.org/relatedObject.category.id/190"],
       },
     ]);
   });
@@ -623,12 +623,12 @@ describe("buildResearchProjectJsonLd", () => {
       "https://doi.org/10.1007/s00442-014-2977-8",
       "https://doi.org/10.4227/05/598bd8a2e9e76",
     ]);
-    expect(result.citation?.[0].additionalType).toBe(
-      "https://vocabulary.raid.org/relatedObject.category.id/190"
-    );
-    expect(result.citation?.[1].additionalType).toBe(
-      "https://vocabulary.raid.org/relatedObject.category.id/191"
-    );
+    expect(result.citation?.[0].additionalType).toEqual([
+      "https://vocabulary.raid.org/relatedObject.category.id/190",
+    ]);
+    expect(result.citation?.[1].additionalType).toEqual([
+      "https://vocabulary.raid.org/relatedObject.category.id/191",
+    ]);
   });
 
   it("falls back to a URL identifier for a schemaUri outside the DOI/ARK/ISBN set", () => {

--- a/raid-agency-app-static/src/utils/json-ld.ts
+++ b/raid-agency-app-static/src/utils/json-ld.ts
@@ -91,7 +91,7 @@ interface CreativeWorkReference {
   "@id": string;
   name?: string;
   identifier: PropertyValue;
-  additionalType?: string | string[];
+  additionalType?: string[];
 }
 
 interface ResearchProjectJsonLd {
@@ -238,7 +238,11 @@ function buildRelatedRaidProperties(relatedRaids: RelatedRaid[]): Pick<ResearchP
 // already uses CreativeWork properties (isPartOf/hasPart/isBasedOn) on the
 // project loosely, consistent with how harvesters consume the output. The
 // category (Input/Output/Internal) is preserved on `additionalType` rather
-// than split across distinct schema.org properties (see RAID-757).
+// than split across distinct schema.org properties (see RAID-757). It is always
+// emitted as an array (omitted when there is no category) so the output matches
+// the multivalued `additionalType` in the LinkML CreativeWork schema; harvesters
+// treat a single-element array and a scalar identically after JSON-LD expansion
+// (RAID-782).
 //
 // The formatted citation text (APA string fetched from DOI.org by the
 // fetch-raids build step, and shown on the landing page) is carried on `name`
@@ -275,9 +279,7 @@ function buildRelatedObjectCitations(relatedObjects: RelatedObjectWithCitation[]
       citation.name = citationText;
     }
 
-    if (categoryIds.length === 1) {
-      citation.additionalType = categoryIds[0];
-    } else if (categoryIds.length > 1) {
+    if (categoryIds.length > 0) {
       citation.additionalType = categoryIds;
     }
 


### PR DESCRIPTION
## Summary

Closes RAID-782 (epic RAID-574, follow-on from the RAID-759 investigation, Phase 3a).

Adds a CI check that fails the build if the static site's hand-maintained JSON-LD builder (`raid-agency-app-static/src/utils/json-ld.ts`) drifts from the canonical LinkML-derived schema (`researchproject.yaml` → `researchproject.json`).

- **AC1** — new Vitest suite `json-ld.schema.test.ts` validates `buildResearchProjectJsonLd()` output against the strict `#/$defs/ResearchProject` subschema (`additionalProperties: false`) with `ajv` (draft 2019-09). Runs in the existing `npm test` step of `raid-agency-app-static.yml`; no workflow change needed. Includes a maximal fixture covering every emitted field/class and a negative-control test proving strict validation is enforced.
- **AC2** — choice of **validation-only** over generated TypeScript types documented in `doc/adr/2026-08-06_validate-static-jsonld-against-linkml-schema.md`.

## Drifts found and fixed

The check surfaced two pre-existing emitter/schema divergences:

1. **`CreativeWork.additionalType`** (emitter) — was a bare scalar for a single category; now always emitted as an array to match the multivalued schema. Harvester-safe (JSON-LD expansion normalises both). Assertions in `json-ld.test.ts` updated.
2. **`Member.name`** (schema) — RAID-794 emits a resolved ROR org name on member nodes, but the `Member` class had no `name` and `additionalProperties: false`. Added optional `name`; regenerated `researchproject.json` and the two committed OpenAPI specs (diffs limited to this addition; regenerated Java models are unused dead code).

## Verification

- `raid-agency-app-static`: `npm test` → 49 tests pass; `astro check` → 0 errors; `astro build` completes.
- `./gradlew :api-svc:idl-raid-v2:compileJava` → BUILD SUCCESSFUL.
- Guard confirmed to bite: a stray field injected into the emitter output fails the schema tests (reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)