### PR TITLE
RAID-787: add RRID (SciCrunch) validator for relatedObject

### DIFF
--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RelatedObjectIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RelatedObjectIntegrationTest.java
@@ -31,6 +31,11 @@ public class RelatedObjectIntegrationTest extends AbstractIntegrationTest {
     private static final String NONEXISTENT_TEST_HANDLE = "https://hdl.handle.net/0.0/not-found";
     private static final String SERVER_ERROR_TEST_HANDLE = "https://hdl.handle.net/0.0/server-error";
 
+    /* confirmed sentinel values understood by the in-memory RRID stub, see
+       au.org.raid.api.service.stub.InMemoryStubTestData */
+    private static final String NONEXISTENT_TEST_RRID = "https://scicrunch.org/resolver/RRID:AB_0000000";
+    private static final String SERVER_ERROR_TEST_RRID = "https://scicrunch.org/resolver/RRID:AB_5000000";
+
     private RelatedObject webArchiveRelatedObject(String id) {
         return new RelatedObject()
                 .id(id)
@@ -143,6 +148,18 @@ public class RelatedObjectIntegrationTest extends AbstractIntegrationTest {
         }
     }
 
+    private RelatedObject rridRelatedObject(String id) {
+        return new RelatedObject()
+                .id(id)
+                .schemaUri(RelatedObjectSchemaUriEnum.fromValue(RRID_SCHEMA_URI))
+                .type(new RelatedObjectType()
+                        .id(RelatedObjectTypeIdEnum.fromValue(BOOK_CHAPTER_RELATED_OBJECT_TYPE))
+                        .schemaUri(RelatedObjectTypeSchemaUriEnum.fromValue(RELATED_OBJECT_TYPE_SCHEMA_URI)))
+                .category(List.of(new RelatedObjectCategory()
+                        .id(RelatedObjectCategoryIdEnum.fromValue(INPUT_RELATED_OBJECT_CATEGORY_ID))
+                        .schemaUri(RelatedObjectCategorySchemaUriEnum.fromValue(RELATED_OBJECT_CATEGORY_SCHEMA_URI))));
+    }
+
     @Test
     @DisplayName("Minting a RAiD with a valid Handle related object succeeds")
     void validHandleRelatedObject() {
@@ -231,4 +248,67 @@ public class RelatedObjectIntegrationTest extends AbstractIntegrationTest {
     // DataciteRelatedIdentifierFactoryTest, which directly asserts
     // relatedIdentifierType = RelatedIdentifierType.HANDLE.getName() for a Handle-scoped
     // RelatedObject. Rather than fabricate a brittle intTest, Scenario 4 is left to that unit test.
+
+    @Test
+    @DisplayName("Minting a RAiD with a valid RRID related object succeeds")
+    void validRridRelatedObject() {
+        createRequest.setRelatedObject(List.of(rridRelatedObject(VALID_RRID)));
+
+        try {
+            final var result = raidApi.mintRaid(createRequest);
+            final var raid = result.getBody();
+            assertThat(raid).isNotNull();
+            assertThat(raid.getRelatedObject()).hasSize(1);
+            assertThat(raid.getRelatedObject().get(0).getId()).isEqualTo(VALID_RRID);
+            assertThat(raid.getRelatedObject().get(0).getSchemaUri()).isEqualTo(RelatedObjectSchemaUriEnum.fromValue(RRID_SCHEMA_URI));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with an RRID related object that the resolver reports as non-existent fails validation")
+    void nonExistentRrid() {
+        createRequest.setRelatedObject(List.of(rridRelatedObject(NONEXISTENT_TEST_RRID)));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown with non-existent RRID");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures).contains(new ValidationFailure()
+                    .fieldId("relatedObject[0].id")
+                    .errorType("invalidValue")
+                    .message("uri not found"));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with an RRID related object fails validation when the resolver reports a server error")
+    void rridServerError() {
+        createRequest.setRelatedObject(List.of(rridRelatedObject(SERVER_ERROR_TEST_RRID)));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown when RRID resolver returns a server error");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures).contains(new ValidationFailure()
+                    .fieldId("relatedObject[0].id")
+                    .errorType("invalidValue")
+                    .message("uri could not be validated - server error"));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    // As with Handle (see Scenario 4 note above), the RRID DataCite mapping (relatedIdentifierType =
+    // "RRID") is not asserted at the intTest level for the same reasons - this package has no harness
+    // for inspecting the outbound DataCite request body. It is covered by the unit test
+    // DataciteRelatedIdentifierFactoryTest, which asserts relatedIdentifierType is "RRID" for a
+    // scicrunch-scoped RelatedObject.
 }

--- a/api-svc/raid-api/src/intTest/resources/application.yaml
+++ b/api-svc/raid-api/src/intTest/resources/application.yaml
@@ -17,6 +17,9 @@ raid:
     handle:
       enabled: true
       delay: 150
+    rrid:
+      enabled: true
+      delay: 150
     open-street-map:
       enabled: true
       delay: 150

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/bean/ExternalPidService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/bean/ExternalPidService.java
@@ -6,6 +6,7 @@ import au.org.raid.api.config.properties.StubProperties;
 import au.org.raid.api.service.doi.DoiService;
 import au.org.raid.api.service.handle.HandleService;
 import au.org.raid.api.service.orcid.OrcidService;
+import au.org.raid.api.service.rrid.RridService;
 import au.org.raid.api.service.stub.*;
 import au.org.raid.api.util.Log;
 import au.org.raid.api.validator.GeoNamesUriValidator;
@@ -70,6 +71,20 @@ public class ExternalPidService {
         }
 
         return new HandleService(restTemplate);
+    }
+
+    @Bean
+    @Primary
+    public RridService rridService(
+            StubProperties stubProperties,
+            @Qualifier("uriValidatorRestTemplate") RestTemplate restTemplate
+    ) {
+        if (stubProperties.getRrid().isEnabled()) {
+            log.warn("using the in-memory RRID service");
+            return new RridServiceStub(stubProperties.getRrid().getDelay());
+        }
+
+        return new RridService(restTemplate);
     }
 
     @Bean

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/properties/StubProperties.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/properties/StubProperties.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class StubProperties {
     private Doi doi;
     private Handle handle;
+    private Rrid rrid;
     private Orcid orcid;
     private GeoNames geoNames;
     private Apids apids;
@@ -24,6 +25,12 @@ public class StubProperties {
 
     @Data
     public static class Handle {
+        private boolean enabled;
+        private Long delay;
+    }
+
+    @Data
+    public static class Rrid {
         private boolean enabled;
         private Long delay;
     }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/factory/datacite/DataciteRelatedIdentifierFactory.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/factory/datacite/DataciteRelatedIdentifierFactory.java
@@ -23,7 +23,7 @@ public class DataciteRelatedIdentifierFactory {
             RelatedObjectSchemaUriEnum.HTTPS_ARKS_ORG_, RelatedIdentifierType.ARK.getName(),
             RelatedObjectSchemaUriEnum.HTTPS_DOI_ORG_, RelatedIdentifierType.DOI.getName(),
             RelatedObjectSchemaUriEnum.HTTPS_WWW_ISBN_INTERNATIONAL_ORG_, RelatedIdentifierType.ISBN.getName(),
-            RelatedObjectSchemaUriEnum.HTTPS_SCICRUNCH_ORG_RESOLVER_, RelatedIdentifierType.URL.getName(),
+            RelatedObjectSchemaUriEnum.HTTPS_SCICRUNCH_ORG_RESOLVER_, RelatedIdentifierType.RRID.getName(),
             RelatedObjectSchemaUriEnum.HTTPS_WEB_ARCHIVE_ORG_, RelatedIdentifierType.URL.getName(),
             RelatedObjectSchemaUriEnum.HTTPS_HDL_HANDLE_NET_, RelatedIdentifierType.HANDLE.getName()
     );

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/rrid/RridService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/rrid/RridService.java
@@ -1,0 +1,29 @@
+package au.org.raid.api.service.rrid;
+
+import au.org.raid.api.validator.AbstractUriValidator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.client.RestTemplate;
+
+@Getter
+@RequiredArgsConstructor
+public class RridService extends AbstractUriValidator {
+    // Source prefix (e.g. AB, SCR, CVCL, IMSR) then '_' then the id, which may itself contain a
+    // colon (e.g. RRID:IMSR_JAX:000664). Restricted to the observed RRID charset rather than \S+
+    // so that stored ids can't carry braces/quotes/query-fragments into the resolver URL, DataCite
+    // metadata, or the static site.
+    public final String regex = "^https://scicrunch\\.org/resolver/RRID:[A-Za-z0-9]+_[A-Za-z0-9:._-]+$";
+    private final RestTemplate restTemplate;
+
+    /**
+     * The bare scicrunch.org/resolver/ URL is served behind a Cloudflare interactive challenge
+     * (HTTP 403 to every non-browser client), so a server-side HEAD of the stored URL can never
+     * confirm existence. The ".json" resolver variant is not challenged and returns a clean
+     * HTTP 200 for a known RRID and HTTP 404 for an unknown one, so we existence-check that
+     * instead. The stored id and the DataCite relatedIdentifier value remain the bare URL.
+     */
+    @Override
+    protected String resolverUri(final String uri) {
+        return uri + ".json";
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/InMemoryStubTestData.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/InMemoryStubTestData.java
@@ -23,6 +23,9 @@ public class InMemoryStubTestData {
     public static String NONEXISTENT_TEST_HANDLE = "https://hdl.handle.net/0.0/not-found";
     public static String SERVER_ERROR_TEST_HANDLE = "https://hdl.handle.net/0.0/server-error";
 
+    public static String NONEXISTENT_TEST_RRID = "https://scicrunch.org/resolver/RRID:AB_0000000";
+    public static String SERVER_ERROR_TEST_RRID = "https://scicrunch.org/resolver/RRID:AB_5000000";
+
     public static String NONEXISTENT_TEST_GEONAMES_URI = "https://www.geonames.org/0/not-found.html";
     public static String SERVER_ERROR_TEST_GEONAMES_URI = "https://www.geonames.org/0/server-error.html";
 

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/RridServiceStub.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/RridServiceStub.java
@@ -1,0 +1,67 @@
+package au.org.raid.api.service.stub;
+
+import au.org.raid.api.service.rrid.RridService;
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static au.org.raid.api.endpoint.message.ValidationMessage.*;
+import static au.org.raid.api.service.stub.InMemoryStubTestData.NONEXISTENT_TEST_RRID;
+import static au.org.raid.api.service.stub.InMemoryStubTestData.SERVER_ERROR_TEST_RRID;
+import static au.org.raid.api.util.ObjectUtil.areEqual;
+
+@Slf4j
+public class RridServiceStub extends RridService {
+    private final Long delayMilliseconds;
+    public RridServiceStub(final Long delayMilliseconds) {
+        super(null);
+        this.delayMilliseconds = delayMilliseconds;
+    }
+
+    @Override
+    @SneakyThrows
+    public List<ValidationFailure> validate(String uri, String fieldId) {
+        final var failures = new ArrayList<ValidationFailure>();
+        final var regex = getRegex();
+
+        if (!uri.matches(regex)) {
+            failures.add(
+                    new ValidationFailure()
+                            .fieldId(fieldId)
+                            .errorType(INVALID_VALUE_TYPE)
+                            .message(INVALID_VALUE_MESSAGE + " - should match %s".formatted(regex))
+            );
+        } else {
+            log.debug("delay {}", delayMilliseconds);
+            log.debug("simulate RRID validation check");
+
+            final var start = Instant.now();
+            Thread.sleep(delayMilliseconds);
+            final var end = Instant.now();
+            Duration duration = Duration.between(start, end);
+            log.info("request to {} took {}.{} seconds", uri, duration.getSeconds(), duration.getNano());
+
+            if (areEqual(uri, NONEXISTENT_TEST_RRID)) {
+                failures.add(new ValidationFailure()
+                        .fieldId(fieldId)
+                        .errorType(INVALID_VALUE_TYPE)
+                        .message(URI_DOES_NOT_EXIST)
+                );
+            } else if (areEqual(uri, SERVER_ERROR_TEST_RRID)) {
+                failures.add(new ValidationFailure()
+                        .fieldId(fieldId)
+                        .errorType(INVALID_VALUE_TYPE)
+                        .message(SERVER_ERROR)
+                );
+            }
+        }
+
+
+        return failures;
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/validator/AbstractUriValidator.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/validator/AbstractUriValidator.java
@@ -21,6 +21,17 @@ public abstract class AbstractUriValidator implements UriValidator {
 
     protected abstract RestTemplate getRestTemplate();
 
+    /**
+     * The URL to HEAD-check for existence, derived from the (already regex-validated) stored uri.
+     * Defaults to the stored uri itself. Subclasses override this when the canonical stored form
+     * is not directly resolvable server-side (e.g. RRID: the bare scicrunch.org/resolver/ URL sits
+     * behind a Cloudflare challenge that returns 403 to all non-browser clients, so we check the
+     * ".json" resolver variant instead, which returns a clean 200/404).
+     */
+    protected String resolverUri(final String uri) {
+        return uri;
+    }
+
     public List<ValidationFailure> validate(final String uri, final String fieldId) {
         final var failures = new ArrayList<ValidationFailure>();
 
@@ -35,13 +46,14 @@ public abstract class AbstractUriValidator implements UriValidator {
             );
 
         } else {
-            final var requestEntity = RequestEntity.head(uri).build();
+            final var resolverUri = resolverUri(uri);
+            final var requestEntity = RequestEntity.head(resolverUri).build();
             try {
                 final var start = Instant.now();
                 getRestTemplate().exchange(requestEntity, Void.class);
                 final var end = Instant.now();
                 Duration duration = Duration.between(start, end);
-                log.info("request to {} took {}.{} seconds", uri, duration.getSeconds(), duration.getNano());
+                log.info("request to {} took {}.{} seconds", resolverUri, duration.getSeconds(), duration.getNano());
             } catch (HttpClientErrorException e) {
 
                 if (e.getStatusCode().equals(HttpStatusCode.valueOf(404))) {

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/validator/RelatedObjectValidator.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/validator/RelatedObjectValidator.java
@@ -3,6 +3,7 @@ package au.org.raid.api.validator;
 import au.org.raid.api.repository.RelatedObjectTypeRepository;
 import au.org.raid.api.service.doi.DoiService;
 import au.org.raid.api.service.handle.HandleService;
+import au.org.raid.api.service.rrid.RridService;
 import au.org.raid.idl.raidv2.model.RelatedObject;
 import au.org.raid.idl.raidv2.model.ValidationFailure;
 import org.springframework.stereotype.Service;
@@ -38,6 +39,7 @@ public class RelatedObjectValidator {
     private static final String DOI_SCHEMA_URI = "https://doi.org/";
     private static final String WEB_ARCHIVE_SCHEMA_URI = "https://web.archive.org/";
     private static final String HANDLE_SCHEMA_URI = "https://hdl.handle.net/";
+    private static final String RRID_SCHEMA_URI = "https://scicrunch.org/resolver/";
     private static final Pattern WEB_ARCHIVE_URL_PATTERN =
             Pattern.compile("https://web\\.archive\\.org/web/\\d{14}/https?://.+");
 
@@ -45,7 +47,7 @@ public class RelatedObjectValidator {
     private final RelatedObjectCategoryValidator categoryValidationService;
     private final Map<String, BiFunction<String, String, List<ValidationFailure>>> relatedObjectSchemaUriValidatorMap;
 
-    public RelatedObjectValidator(final RelatedObjectTypeRepository relatedObjectTypeRepository, final DoiService doiService, final HandleService handleService, final RelatedObjectTypeValidator typeValidationService, final RelatedObjectCategoryValidator categoryValidationService) {
+    public RelatedObjectValidator(final RelatedObjectTypeRepository relatedObjectTypeRepository, final DoiService doiService, final HandleService handleService, final RridService rridService, final RelatedObjectTypeValidator typeValidationService, final RelatedObjectCategoryValidator categoryValidationService) {
         this.typeValidationService = typeValidationService;
         this.categoryValidationService = categoryValidationService;
 
@@ -55,6 +57,7 @@ public class RelatedObjectValidator {
         final var map = new LinkedHashMap<String, BiFunction<String, String, List<ValidationFailure>>>();
         map.put(DOI_SCHEMA_URI, doiService::validate);
         map.put(HANDLE_SCHEMA_URI, handleService::validate);
+        map.put(RRID_SCHEMA_URI, rridService::validate);
         map.put(WEB_ARCHIVE_SCHEMA_URI, (id, fieldId) -> {
             if (WEB_ARCHIVE_URL_PATTERN.matcher(id).matches()) {
                 return List.of();

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/vocabularies/datacite/RelatedIdentifierType.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/vocabularies/datacite/RelatedIdentifierType.java
@@ -20,6 +20,7 @@ public enum RelatedIdentifierType {
     LSID("LSID"),
     PMID("PMID"),
     PURL("PURL"),
+    RRID("RRID"),
     UPC("UPC"),
     URL("URL"),
     URN("URN"),

--- a/api-svc/raid-api/src/main/resources/application.yaml
+++ b/api-svc/raid-api/src/main/resources/application.yaml
@@ -51,6 +51,9 @@ raid:
     handle:
       enabled: true
       delay: 150
+    rrid:
+      enabled: true
+      delay: 150
     open-street-map:
       enabled: true
       delay: 150

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/factory/datacite/DataciteRelatedIdentifierFactoryTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/factory/datacite/DataciteRelatedIdentifierFactoryTest.java
@@ -106,7 +106,7 @@ public class DataciteRelatedIdentifierFactoryTest {
         final var result = dataciteRelatedIdentifierFactory.create(relatedObject);
 
         assertThat(result.getRelatedIdentifier(), is(id));
-        assertThat(result.getRelatedIdentifierType(), is("URL"));
+        assertThat(result.getRelatedIdentifierType(), is("RRID"));
         assertThat(result.getResourceTypeGeneral(), is("Workflow"));
         assertThat(result.getRelationType(), is("References"));
     }

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/service/rrid/RridServiceTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/service/rrid/RridServiceTest.java
@@ -1,0 +1,101 @@
+package au.org.raid.api.service.rrid;
+
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.RequestEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RridServiceTest {
+    private final RestTemplate restTemplate = mock(RestTemplate.class);
+    private final RridService rridService = new RridService(restTemplate);
+
+    @Test
+    @DisplayName("HEAD-checks the .json resolver variant, not the bare stored URL")
+    void headsJsonVariant() {
+        final var storedUri = "https://scicrunch.org/resolver/RRID:AB_2298772";
+        when(restTemplate.exchange(any(RequestEntity.class), eq(Void.class))).thenReturn(null);
+
+        final var failures = rridService.validate(storedUri, "relatedObject[0].id");
+
+        assertThat(failures, empty());
+
+        // RequestEntity.head(String) builds a URI-template entity whose getUrl() is not
+        // resolvable until the RestTemplate expands it, so assert on the template via toString().
+        final var captor = ArgumentCaptor.forClass(RequestEntity.class);
+        verify(restTemplate).exchange(captor.capture(), eq(Void.class));
+        assertThat(captor.getValue().toString(), containsString(storedUri + ".json"));
+    }
+
+    @Test
+    @DisplayName("Returns 'uri not found' when the .json resolver returns 404")
+    void nonExistentRrid() {
+        final var fieldId = "relatedObject[0].id";
+        when(restTemplate.exchange(any(RequestEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatusCode.valueOf(404)));
+
+        final var failures = rridService.validate("https://scicrunch.org/resolver/RRID:AB_0000000", fieldId);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(fieldId)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+
+    @ParameterizedTest
+    @DisplayName("Accepts the real RRID source forms")
+    @ValueSource(strings = {
+            "https://scicrunch.org/resolver/RRID:AB_2298772",   // antibody
+            "https://scicrunch.org/resolver/RRID:SCR_003070",   // tool/software
+            "https://scicrunch.org/resolver/RRID:CVCL_0027",    // cell line
+            "https://scicrunch.org/resolver/RRID:IMSR_JAX:000664" // organism, embedded colon
+    })
+    void acceptsRealRridForms(final String storedUri) {
+        when(restTemplate.exchange(any(RequestEntity.class), eq(Void.class))).thenReturn(null);
+
+        final var failures = rridService.validate(storedUri, "relatedObject[0].id");
+
+        assertThat(failures, empty());
+    }
+
+    @ParameterizedTest
+    @DisplayName("Fails regex validation for malformed RRIDs and never calls the resolver")
+    @ValueSource(strings = {
+            "https://scicrunch.org/resolver/not-an-rrid",       // no RRID: prefix
+            "https://scicrunch.org/resolver/RRID:AB_",           // missing id
+            "https://scicrunch.org/resolver/RRID:_2298772",      // missing source
+            "https://scicrunch.org/resolver/RRID:AB_229 8772",   // whitespace in id
+            "https://scicrunch.org/resolver/RRID:AB_{0}"         // brace would break URI-template expansion
+    })
+    void rejectsMalformedRrid(final String storedUri) {
+        final var fieldId = "relatedObject[0].id";
+
+        final var failures = rridService.validate(storedUri, fieldId);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(fieldId)
+                        .errorType("invalidValue")
+                        .message("has invalid/unsupported value - should match " + rridService.getRegex())
+        )));
+    }
+}

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/AbstractUriValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/AbstractUriValidatorTest.java
@@ -3,6 +3,7 @@ package au.org.raid.api.validator;
 import au.org.raid.idl.raidv2.model.ValidationFailure;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.RequestEntity;
 import org.springframework.web.client.HttpClientErrorException;
@@ -15,6 +16,7 @@ import java.net.SocketTimeoutException;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,6 +35,18 @@ class AbstractUriValidatorTest {
 
         final var failures = uriValidator.validate("http://localhost", "field-id");
         assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("By default the resolver HEAD-checks the stored uri unchanged")
+    void resolverUriDefaultsToStoredUri() {
+        when(restTemplate.exchange(any(RequestEntity.class), eq(Void.class))).thenReturn(null);
+
+        uriValidator.validate("http://localhost", "field-id");
+
+        final var captor = ArgumentCaptor.forClass(RequestEntity.class);
+        verify(restTemplate).exchange(captor.capture(), eq(Void.class));
+        assertThat(captor.getValue().toString(), containsString("HEAD http://localhost,"));
     }
 
     @Test

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/RelatedObjectValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/RelatedObjectValidatorTest.java
@@ -2,6 +2,7 @@ package au.org.raid.api.validator;
 
 import au.org.raid.api.service.doi.DoiService;
 import au.org.raid.api.service.handle.HandleService;
+import au.org.raid.api.service.rrid.RridService;
 import au.org.raid.api.util.TestConstants;
 import au.org.raid.idl.raidv2.model.RelatedObject;
 import au.org.raid.idl.raidv2.model.RelatedObjectCategory;
@@ -44,6 +45,9 @@ class RelatedObjectValidatorTest {
 
     @Mock
     private HandleService handleService;
+
+    @Mock
+    private RridService rridService;
 
     @InjectMocks
     private RelatedObjectValidator validationService;
@@ -302,6 +306,68 @@ class RelatedObjectValidatorTest {
         assertThat(failures, empty());
         verify(handleService).validate(doiShapedHandleUri, fieldId);
         verify(doiService, never()).validate(any(), any());
+    }
+
+    @Test
+    @DisplayName("Validation passes with valid RRID related object")
+    void validRridRelatedObject() {
+        final var rridUri = "https://scicrunch.org/resolver/RRID:AB_2298772";
+
+        final var type = new RelatedObjectType()
+                .id(RelatedObjectTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_TYPE_SCHEMA_247)
+                .schemaUri(RelatedObjectTypeSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_TYPE_SCHEMA_329);
+
+        final var categories = List.of(new RelatedObjectCategory()
+                .id(RelatedObjectCategoryIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_CATEGORY_ID_190)
+                .schemaUri(RelatedObjectCategorySchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_CATEGORY_SCHEMA_URI_386));
+
+        final var relatedObject = new RelatedObject()
+                .id(rridUri)
+                .schemaUri(RelatedObjectSchemaUriEnum.HTTPS_SCICRUNCH_ORG_RESOLVER_)
+                .type(type)
+                .category(categories);
+
+        when(typeValidationService.validate(type, 0)).thenReturn(Collections.emptyList());
+        when(categoryValidationService.validate(categories, 0)).thenReturn(Collections.emptyList());
+        when(rridService.validate(rridUri, "relatedObject[0].id")).thenReturn(Collections.emptyList());
+
+        final var failures =
+                validationService.validateRelatedObjects(Collections.singletonList(relatedObject));
+
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("An RRID-shaped id under the SciCrunch schemaUri is dispatched to RridService, not DoiService or HandleService")
+    void rridShapedIdUnderScicrunchSchemaUriUsesRridService() {
+        final var rridUri = "https://scicrunch.org/resolver/RRID:AB_2298772";
+        final var fieldId = "relatedObject[0].id";
+
+        final var type = new RelatedObjectType()
+                .id(RelatedObjectTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_TYPE_SCHEMA_247)
+                .schemaUri(RelatedObjectTypeSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_TYPE_SCHEMA_329);
+
+        final var categories = List.of(new RelatedObjectCategory()
+                .id(RelatedObjectCategoryIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_CATEGORY_ID_190)
+                .schemaUri(RelatedObjectCategorySchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_CATEGORY_SCHEMA_URI_386));
+
+        final var relatedObject = new RelatedObject()
+                .id(rridUri)
+                .schemaUri(RelatedObjectSchemaUriEnum.HTTPS_SCICRUNCH_ORG_RESOLVER_)
+                .type(type)
+                .category(categories);
+
+        when(typeValidationService.validate(type, 0)).thenReturn(Collections.emptyList());
+        when(categoryValidationService.validate(categories, 0)).thenReturn(Collections.emptyList());
+        when(rridService.validate(rridUri, fieldId)).thenReturn(Collections.emptyList());
+
+        final var failures =
+                validationService.validateRelatedObjects(Collections.singletonList(relatedObject));
+
+        assertThat(failures, empty());
+        verify(rridService).validate(rridUri, fieldId);
+        verify(doiService, never()).validate(any(), any());
+        verify(handleService, never()).validate(any(), any());
     }
 
     @Test

--- a/api-svc/testFixtures/src/testFixtures/java/au/org/raid/fixtures/TestConstants.java
+++ b/api-svc/testFixtures/src/testFixtures/java/au/org/raid/fixtures/TestConstants.java
@@ -108,4 +108,7 @@ public class TestConstants {
 
     public static final String HANDLE_SCHEMA_URI = "https://hdl.handle.net/";
     public static final String VALID_HANDLE = "https://hdl.handle.net/20.500.12345/abc123";
+
+    public static final String RRID_SCHEMA_URI = "https://scicrunch.org/resolver/";
+    public static final String VALID_RRID = "https://scicrunch.org/resolver/RRID:AB_2298772";
 }

--- a/documentation/20260807-raid-787-rrid-validator.md
+++ b/documentation/20260807-raid-787-rrid-validator.md
@@ -1,0 +1,134 @@
+# RAID-787: Add RRID (SciCrunch) validator for relatedObject.schemaUri
+
+- **JIRA (Story):** [RAID-787](https://ardc.atlassian.net/browse/RAID-787)
+- **Parent epic:** [RAID-789](https://ardc.atlassian.net/browse/RAID-789) — Identifier & relatedObject validator hardening and coverage (RAID-699 follow-up)
+- **Depends on:** [RAID-786](https://ardc.atlassian.net/browse/RAID-786) (dispatch-map refactor + stub pattern) and [RAID-802](https://ardc.atlassian.net/browse/RAID-802) (`AbstractUriValidator` hardening + bounded timeouts, inherited here)
+- **PR:** [au-research/raid-au#603](https://github.com/au-research/raid-au/pull/603)
+- **ADR:** `doc/adr/2026-08-06_related-object-scheme-validator-dispatch-map.md` (dispatch-map design; this ticket adds one scheme to it)
+
+## What changed and why
+
+`relatedObject.schemaUri` accepts a controlled set of resolver schemes. The enum
+(`RelatedObjectSchemaUriEnum.HTTPS_SCICRUNCH_ORG_RESOLVER_`) and OpenAPI specs
+already declared `https://scicrunch.org/resolver/`, but `RelatedObjectValidator`'s
+dispatch map only wired DOI, Handle and Web Archive, so RRID-scoped related
+objects were rejected outright. RAID-787 adds an RRID validator, wires it into
+the dispatch map, and represents RRID as its own DataCite `relatedIdentifierType`.
+
+Per Matthias's decision (2026-07-27), RRIDs are accepted and validated now, ahead
+of public documentation catching up.
+
+RRID format is `RRID:{Source}_{id}` (e.g. `RRID:AB_2298772`), stored/URL form
+`https://scicrunch.org/resolver/RRID:AB_2298772`.
+
+### Changes
+
+- **`service/rrid/RridService.java`** (new) — extends `AbstractUriValidator`,
+  mirroring `DoiService`/`HandleService`. Regex
+  `^https://scicrunch\.org/resolver/RRID:[A-Za-z0-9]+_[A-Za-z0-9:._-]+$`
+  (restricted to the observed RRID charset rather than `\S+` so stored ids can't
+  carry braces/quotes/query-fragments into the resolver URL, DataCite metadata or
+  the static site). Overrides the new `resolverUri()` hook (see below).
+- **`validator/AbstractUriValidator.java`** — added a
+  `protected String resolverUri(final String uri)` hook that defaults to returning
+  the stored uri unchanged; the existence `HEAD` now targets `resolverUri(uri)`.
+  DOI/Handle/ORCID/ROR keep the identity behaviour and are regression-tested for it.
+- **`service/stub/RridServiceStub.java`** (new) + two sentinels
+  (`NONEXISTENT_TEST_RRID`, `SERVER_ERROR_TEST_RRID`) in `InMemoryStubTestData` —
+  lets integration tests exercise the resolver success/404/5xx paths without
+  hitting live scicrunch.org.
+- **`config/properties/StubProperties.java`** — new nested `Rrid` toggle; and
+  `raid.stub.rrid: {enabled, delay}` added to both `src/main/resources` and
+  `src/intTest/resources` `application.yaml`.
+- **`config/bean/ExternalPidService.java`** — new `@Bean @Primary rridService(...)`
+  returning the stub when `raid.stub.rrid.enabled`, else the real validator (using
+  the `uriValidatorRestTemplate` with RAID-802 bounded timeouts).
+- **`validator/RelatedObjectValidator.java`** — inject `RridService` and add one
+  dispatch-map entry `scicrunch.org/resolver/ → rridService::validate`. The
+  supported-scheme allow-list and "unsupported schemaUri" message derive from the
+  map key set, so both update automatically.
+- **`vocabularies/datacite/RelatedIdentifierType.java`** — added `RRID("RRID")`.
+- **`factory/datacite/DataciteRelatedIdentifierFactory.java`** — remapped
+  `HTTPS_SCICRUNCH_ORG_RESOLVER_` from `URL` to `RRID` in `IDENTIFIER_TYPE_MAP`.
+- **No Flyway migration** — `V29__update_vocabularies.sql` already seeds
+  `('https://scicrunch.org/resolver/', 'active')`, matching the enum exactly
+  (unlike the Handle scheme, which needed the V43 typo fix).
+
+## The `.json` resolver check (found by the live-resolver NFR)
+
+The ticket's original scope was "regex + resolver `HEAD` (pattern A)" against the
+stored URL. The live-resolver verification NFR proved this cannot work:
+
+| URL | GET | HEAD |
+|-----|-----|------|
+| `https://scicrunch.org/resolver/RRID:AB_2298772` (real, stored form) | 403 | 403 |
+| `https://scicrunch.org/resolver/RRID:AB_0000000` (bogus) | 403 | 403 |
+| `https://scicrunch.org/resolver/RRID:AB_2298772.json` (real) | 200 | 200 |
+| `https://scicrunch.org/resolver/RRID:AB_0000000.json` (bogus) | 404 | 404 |
+
+The bare resolver URL sits behind a **Cloudflare interactive challenge**
+(`cf-mitigated: challenge`, "Just a moment"), returning HTTP 403 to every
+server-side client regardless of user-agent or source IP, for valid and invalid
+RRIDs alike. Under `AbstractUriValidator` a 403 is not a 404, so it maps to a
+server error. Pattern A as written would have rejected **every** RRID related
+object in production with "uri could not be validated - server error".
+
+Resolution (agreed via the ticket): HEAD-check the `.json` resolver variant, which
+is not behind the challenge and returns a clean 200 (exists) / 404 (not found).
+`RridService.resolverUri()` appends `.json`; the stored id and the DataCite
+relatedIdentifier value remain the bare URL. The identity-default hook keeps every
+other validator unchanged. Findings are recorded on RAID-787.
+
+## Testing
+
+- **Unit** — `./gradlew :api-svc:raid-api:test` green.
+  - `RridServiceTest` — asserts the `HEAD` targets the `.json` URL; parameterised
+    accept cases (`AB_`, `SCR_`, `CVCL_`, `IMSR_JAX:` with embedded colon) and
+    reject cases (missing source/id, whitespace, brace).
+  - `AbstractUriValidatorTest` — `resolverUri` identity default regression test.
+  - `RelatedObjectValidatorTest` — RRID happy path and a negative-routing case
+    proving an RRID-shaped id under `schemaUri=scicrunch` calls `rridService` and
+    `verify(doiService/handleService, never())`.
+  - `DataciteRelatedIdentifierFactoryTest` — scicrunch case now asserts
+    `relatedIdentifierType == "RRID"`.
+- **Integration** — all 11 `RelatedObjectIntegrationTest` cases pass (3 RRID
+  scenarios + pre-existing Handle/web-archive/DOI cases, no regressions), with the
+  stubbed resolver.
+- **Live resolver check (NFR)** — see table above; one known-good and one
+  known-bad real RRID run against live scicrunch.org, which surfaced the Cloudflare
+  block and drove the `.json` decision.
+
+## Acceptance criteria
+
+- [x] Scenario 1 — RRID-scoped relatedObject accepted when resolver confirms it exists (201)
+- [x] Scenario 2 — RRID-scoped relatedObject rejected when resolver fails (400, `relatedObject[0].id` / `invalidValue` / "uri not found")
+- [x] Scenario 3 — RRID represented as `relatedIdentifierType="RRID"` in DataCite output (covered by `DataciteRelatedIdentifierFactoryTest`; no brittle outbound-payload intTest fabricated)
+
+## Follow-ups
+
+- **Cross-repo (REQUIRED before prod):** add the per-env
+  `raid.stub.rrid.enabled: false` override in the `raido-v2-aws-private` CDK env
+  config (mirroring `raid.stub.doi` / `raid.stub.handle`) so stage/prod hit the
+  real `.json` resolver. Local/intTest keep the stub enabled. Without this the RRID
+  stub is active in every environment and no real resolution happens.
+- **DataCite live-API NFR (open):** the ticket asks for an integration test hitting
+  DataCite's real test API to confirm acceptance of `relatedIdentifierType: "RRID"`.
+  No live-DataCite harness exists (all DataCite tests use MockServer under the `dev`
+  profile). `RRID` is a valid type in DataCite schema 4.6 and the payload uses the
+  unversioned `kernel-4` namespace, so it is accepted today; the mapping is covered
+  at unit level. A credentialed, gated regression test is flagged on the ticket for
+  a decision (add here vs split out).
+- **Shared URI-template 500 gap (pre-existing, affects DOI/Handle too):**
+  `RequestEntity.head(String)` treats the argument as a URI template, so a brace in
+  any validator's input throws `IllegalArgumentException` — a `RuntimeException`
+  that escapes both catch blocks in `AbstractUriValidator` and surfaces as HTTP 500
+  rather than a clean validation failure. The tightened RRID regex closes this for
+  RRID; the general fix belongs in `AbstractUriValidator` (pass the URI as a
+  variable / use the `URI` overload) and should be a follow-up ticket in the
+  RAID-802 hardening lineage.
+- **`au-research/raid-skos` (ticket task):** replace the placeholder
+  `skos:definition "RRID"@en` for `https://scicrunch.org/resolver/` in
+  `data/core/relatedObject.ttl` with a real definition, regenerate the aggregated
+  vocabulary, and publish to Research Vocabularies Australia.
+- **Public docs (ticket task):** document that RRID is now accepted and validated
+  (reassign to docs owner if not dev work).


### PR DESCRIPTION
## What

Adds an RRID (SciCrunch) validator for `relatedObject.schemaUri` `https://scicrunch.org/resolver/`, mirroring the Handle validator from RAID-786. Part of the RAID-789 epic (identifier & relatedObject validator hardening).

JIRA: [RAID-787](https://ardc.atlassian.net/browse/RAID-787) (parent [RAID-789](https://ardc.atlassian.net/browse/RAID-789))

## Changes

- **`RridService`** extends `AbstractUriValidator`; regex `^https://scicrunch\.org/resolver/RRID:[A-Za-z0-9]+_[A-Za-z0-9:._-]+$`. Wired into the `RelatedObjectValidator` scheme→validator dispatch map, with `RridServiceStub`, sentinels, `StubProperties.Rrid`, the `rridService` bean, and `rrid:` stub config in both `application.yaml` files.
- **DataCite mapping**: added `RelatedIdentifierType.RRID` (`"RRID"`, native in DataCite schema 4.6) and remapped `scicrunch.org/resolver/` from `URL` to `RRID`.
- **No Flyway migration**: V29 already seeds `('https://scicrunch.org/resolver/', 'active')` matching the enum.

## Key decision — `.json` resolver check (Cloudflare)

The bare stored URL `https://scicrunch.org/resolver/RRID:AB_2298772` sits behind a **Cloudflare interactive challenge** and returns **HTTP 403 to every server-side client** (verified against the live service, valid and bogus RRIDs alike). Under `AbstractUriValidator` a 403 becomes a server error, so the ticket's original "HEAD the bare URL" design would have **rejected every RRID in production**.

Fix: a new `resolverUri(uri)` hook on `AbstractUriValidator` (identity by default, so DOI/Handle are untouched and regression-tested as such) that `RridService` overrides to HEAD-check the **`.json`** resolver variant, which is not challenged and returns a clean **200 (exists) / 404 (not found)**. The stored id and the DataCite relatedIdentifier value stay the bare URL. Full findings recorded on the JIRA ticket.

## Testing

- **Unit**: `RridServiceTest` (asserts the HEAD targets the `.json` URL; parameterised accept/reject cases across `AB_`/`SCR_`/`CVCL_`/`IMSR_JAX:` and malformed inputs), `AbstractUriValidatorTest` (identity-default regression), `RelatedObjectValidatorTest` (RRID dispatch + negative routing), `DataciteRelatedIdentifierFactoryTest` (scicrunch → `"RRID"`).
- **Integration**: `RelatedObjectIntegrationTest` — 11/11 pass, covering the three RAID-787 Gherkin scenarios (valid → 201, non-existent → 400 "uri not found", server-error → 400).
- Full `:api-svc:raid-api:test` suite green.

## Follow-ups (not in this PR)

- **DataCite live-API NFR**: the ticket asks for a regression test hitting DataCite's real test API to confirm it accepts `relatedIdentifierType: "RRID"`. No live-DataCite test harness exists today (all DataCite tests use MockServer). Mapping is covered at unit level; a credentialed gated test is flagged on the ticket for a decision.
- **Shared URI-template 500 gap** (pre-existing, affects DOI/Handle too): `RequestEntity.head(String)` treats the arg as a URI template, so a brace in any validator's input throws an `IllegalArgumentException` that escapes both catch blocks as a 500. The tightened RRID regex closes this for RRID; the general fix belongs in `AbstractUriValidator` and should be a follow-up ticket.
- **`raid-skos` SKOS definition** update + **public docs** update (separate repo / docs owner) remain as ticket checklist items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)