### PR TITLE
RAID-608: require approved membership for flat group-admin fallback

### DIFF
--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/GroupServicePointAdminIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/GroupServicePointAdminIntegrationTest.java
@@ -189,7 +189,8 @@ class GroupServicePointAdminIntegrationTest extends AbstractIntegrationTest {
     class FlatGroupAdminFallbackTests {
 
         private UserContext operator;
-        private UserContext flatAdminMemberOfA;
+        private UserContext flatAdminApprovedMemberOfA;
+        private UserContext flatAdminPendingMemberOfA;
         private UserContext flatAdminNotMemberOfB;
         private UserContext targetUser;
         private Group groupA;
@@ -201,11 +202,23 @@ class GroupServicePointAdminIntegrationTest extends AbstractIntegrationTest {
             groupA = createGroup(operator, "flat-a");
             groupB = createGroup(operator, "flat-b");
 
-            flatAdminMemberOfA = userService.createUser("raid-au", "group-admin");
-            joinGroup(flatAdminMemberOfA, groupA.getId());
+            final var operatorApi = keycloakClient.keycloakApi(operator.getToken());
+
+            // Flat group-admin who has actually been granted service-point-user for groupA - an
+            // approved member, not merely a raw one.
+            flatAdminApprovedMemberOfA = userService.createUser("raid-au", "group-admin");
+            joinGroup(flatAdminApprovedMemberOfA, groupA.getId());
+            operatorApi.grant(grant(flatAdminApprovedMemberOfA.getId(), groupA.getId()));
+
+            // Flat group-admin who has only self-joined groupA (e.g. via the self-service access
+            // request flow) and was never actually approved (granted service-point-user) for it -
+            // the exact RAiD-608 / HELP-2844 scenario: a raw, pending membership must not be
+            // enough to administer the group.
+            flatAdminPendingMemberOfA = userService.createUser("raid-au", "group-admin");
+            joinGroup(flatAdminPendingMemberOfA, groupA.getId());
 
             // Flat group-admin, but never joins groupA or groupB - fallback requires both the
-            // flat role AND membership.
+            // flat role AND approved membership.
             flatAdminNotMemberOfB = userService.createUser("raid-au", "group-admin");
 
             targetUser = userService.createUser("raid-au", "service-point-user");
@@ -214,7 +227,8 @@ class GroupServicePointAdminIntegrationTest extends AbstractIntegrationTest {
 
         @AfterEach
         void tearDown() {
-            deleteUserQuietly(flatAdminMemberOfA);
+            deleteUserQuietly(flatAdminApprovedMemberOfA);
+            deleteUserQuietly(flatAdminPendingMemberOfA);
             deleteUserQuietly(flatAdminNotMemberOfB);
             deleteUserQuietly(targetUser);
             deleteGroupQuietly(operator, idOf(groupA));
@@ -223,9 +237,9 @@ class GroupServicePointAdminIntegrationTest extends AbstractIntegrationTest {
         }
 
         @Test
-        @DisplayName("Flat group-admin who is a member of groupA can administer groupA")
-        void flatAdminMemberCanAdministerOwnGroup() {
-            final var api = keycloakClient.keycloakApi(flatAdminMemberOfA.getToken());
+        @DisplayName("Flat group-admin who is an approved member of groupA can administer groupA")
+        void flatAdminApprovedMemberCanAdministerOwnGroup() {
+            final var api = keycloakClient.keycloakApi(flatAdminApprovedMemberOfA.getToken());
 
             final var group = api.findById(groupA.getId()).getBody();
             assertThat(group).isNotNull();
@@ -241,6 +255,16 @@ class GroupServicePointAdminIntegrationTest extends AbstractIntegrationTest {
                     .findFirst()
                     .orElseThrow();
             assertThat(member.getRoles()).contains("service-point-user");
+        }
+
+        @Test
+        @DisplayName("RAiD-608 / HELP-2844: flat group-admin who only self-joined (pending, never approved) groupA is denied on groupA")
+        void flatAdminPendingMemberDeniedForOwnGroup() {
+            final var api = keycloakClient.keycloakApi(flatAdminPendingMemberOfA.getToken());
+
+            assertDenied(() -> api.findById(groupA.getId()));
+            assertDenied(() -> api.grant(grant(targetUser.getId(), groupA.getId())));
+            assertDenied(() -> api.revoke(grant(targetUser.getId(), groupA.getId())));
         }
 
         @Test
@@ -435,16 +459,18 @@ class GroupServicePointAdminIntegrationTest extends AbstractIntegrationTest {
             final var freshGroupId = userService.createGroup(freshGroupName, "/" + freshGroupName);
             final var flatAdminUser = userService.createUser("raid-au", "group-admin");
             joinGroup(flatAdminUser, freshGroupId);
+            // Must be an approved member (not merely a raw self-joiner) for migration to back
+            // them onto the scoped role - see RAiD-608 / HELP-2844.
+            final var operatorApi = keycloakClient.keycloakApi(operator.getToken());
+            operatorApi.grant(grant(flatAdminUser.getId(), freshGroupId));
 
             try {
-                final var api = keycloakClient.keycloakApi(operator.getToken());
-
-                final var firstRun = api.migrateServicePointAdmins().getBody();
+                final var firstRun = operatorApi.migrateServicePointAdmins().getBody();
                 assertThat(firstRun).isNotNull();
                 assertThat(firstRun.getRolesCreated()).isGreaterThanOrEqualTo(1);
                 assertThat(firstRun.getGrantsAdded()).isGreaterThanOrEqualTo(1);
 
-                final var secondRun = api.migrateServicePointAdmins().getBody();
+                final var secondRun = operatorApi.migrateServicePointAdmins().getBody();
                 assertThat(secondRun).isNotNull();
                 assertThat(secondRun.getRolesCreated()).isEqualTo(0);
                 assertThat(secondRun.getGrantsAdded()).isEqualTo(0);
@@ -463,9 +489,11 @@ class GroupServicePointAdminIntegrationTest extends AbstractIntegrationTest {
             final var freshGroupId = userService.createGroup(freshGroupName, "/" + freshGroupName);
             final var flatAdminUser = userService.createUser("raid-au", "group-admin");
             joinGroup(flatAdminUser, freshGroupId);
+            final var operatorApi = keycloakClient.keycloakApi(operator.getToken());
+            operatorApi.grant(grant(flatAdminUser.getId(), freshGroupId));
 
             try {
-                keycloakClient.keycloakApi(operator.getToken()).migrateServicePointAdmins();
+                operatorApi.migrateServicePointAdmins();
 
                 // Strip the flat role directly via the admin API (not via the SPI's dual-revoke,
                 // which would also remove the scoped role) so only the scoped role remains.
@@ -475,6 +503,31 @@ class GroupServicePointAdminIntegrationTest extends AbstractIntegrationTest {
                 final var group = userApi.findById(freshGroupId).getBody();
                 assertThat(group).isNotNull();
                 assertThat(group.getId()).isEqualTo(freshGroupId);
+            } finally {
+                userService.deleteUser(flatAdminUser.getId());
+                deleteGroupQuietly(operator, freshGroupId);
+                userService.deleteUser(operator.getId());
+            }
+        }
+
+        @Test
+        @DisplayName("RAiD-608 / HELP-2844: migration does not backfill a pending, never-approved membership")
+        void doesNotBackfillPendingUnapprovedMembership() {
+            final var operator = createOperator();
+            final var freshGroupName = "migrate-pending-" + UUID.randomUUID();
+            final var freshGroupId = userService.createGroup(freshGroupName, "/" + freshGroupName);
+            // Self-joined only - never granted service-point-user for this group.
+            final var flatAdminUser = userService.createUser("raid-au", "group-admin");
+            joinGroup(flatAdminUser, freshGroupId);
+
+            try {
+                keycloakClient.keycloakApi(operator.getToken()).migrateServicePointAdmins();
+
+                // If migration had (incorrectly) granted the scoped role, this call would succeed
+                // even with the flat fallback out of the picture entirely.
+                userService.removeRole(flatAdminUser.getId(), "group-admin");
+                final var userApi = keycloakClient.keycloakApi(flatAdminUser.getToken());
+                assertDenied(() -> userApi.findById(freshGroupId));
             } finally {
                 userService.deleteUser(flatAdminUser.getId());
                 deleteGroupQuietly(operator, freshGroupId);

--- a/iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java
@@ -439,7 +439,8 @@ public class GroupController {
     /**
      * A user is an admin of the given group if they hold the scoped
      * "service-point-admin:&lt;groupId&gt;" realm role, or - while the flat group-admin fallback is
-     * enabled - if they hold the legacy flat group-admin role and are a member of the group.
+     * enabled - if they hold the legacy flat group-admin role and are an approved member of the
+     * group.
      */
     private boolean isGroupAdminOf(final UserModel user, final String groupId) {
         final var scopedRoleName = servicePointAdminRoleName(groupId);
@@ -450,13 +451,28 @@ public class GroupController {
             return true;
         }
 
-        return flatGroupAdminFallbackEnabled && isGroupAdmin(user) && isGroupMember(user, groupId);
+        return flatGroupAdminFallbackEnabled && isGroupAdmin(user) && isApprovedGroupMember(user, groupId);
     }
 
     private boolean isGroupMember(final UserModel user, final String groupId) {
         return !user.getGroupsStream()
                 .filter(g -> g.getId().equals(groupId))
                 .toList().isEmpty();
+    }
+
+    /**
+     * A user is an approved member of a group if they are a Keycloak group member AND hold the
+     * service-point-user role for that membership to mean anything - service-point-user is only
+     * ever granted via an explicit grant() approval, never automatically. This distinguishes a
+     * legitimate, approved service point affiliation from a raw, unapproved self-join via
+     * /group/join (see RAiD-608 / HELP-2844: a self-joined-but-never-approved membership was
+     * previously enough to satisfy the flat group-admin fallback).
+     */
+    private boolean isApprovedGroupMember(final UserModel user, final String groupId) {
+        return isGroupMember(user, groupId) &&
+                !user.getRoleMappingsStream()
+                        .filter(r -> r.getName().equals(SERVICE_POINT_USER_ROLE))
+                        .toList().isEmpty();
     }
 
     private boolean isOperator(final UserModel user) {
@@ -660,18 +676,22 @@ public class GroupController {
     /**
      * One-off, idempotent backfill for RAID-712: grants the scoped
      * "service-point-admin:&lt;groupId&gt;" realm role to every current holder of the legacy flat
-     * GROUP_ADMIN_ROLE_NAME, for each group they belong to. This preserves each flat
-     * group-admin's existing effective access while service points transition onto scoped roles
-     * (see role-permissions.md section 9).
+     * GROUP_ADMIN_ROLE_NAME, for each group they are an approved member of (see
+     * isApprovedGroupMember). This preserves each flat group-admin's existing *legitimate*
+     * effective access while service points transition onto scoped roles (see
+     * role-permissions.md section 9).
      *
      * <p>Operator-only. Safe to re-run: users who already hold the scoped role for a group are
      * counted as skipped rather than re-granted, and existing scoped roles are reused rather than
      * recreated.
      *
-     * <p>Note: this intentionally over-grants - a flat group-admin is granted the scoped admin
-     * role for every group they are a member of, not just the group(s) they were originally
-     * intended to administer. Pruning any resulting excess scoped grants is deferred to a future
-     * RAID-712 follow-up once service points have reviewed their membership.
+     * <p>Note: raw/pending memberships (groups the user has self-joined but was never granted
+     * service-point-user for) are deliberately excluded - backfilling those would silently grant
+     * admin authority the user was never approved for (RAiD-608 / HELP-2844). Within a group the
+     * member is genuinely approved for, this may still over-grant relative to what they were
+     * originally intended to administer if they are an approved member of more than one group;
+     * pruning that is deferred to a future RAID-712 follow-up once service points have reviewed
+     * their membership.
      */
     @POST
     @Path("/migrate-service-point-admins")
@@ -725,8 +745,12 @@ public class GroupController {
 
                     // Materialise before granting roles below - member.grantRole mutates this
                     // user's role mappings, and we must not mutate them while consuming a live
-                    // stream over the same underlying data.
-                    final var groups = member.getGroupsStream().toList();
+                    // stream over the same underlying data. Only backfill groups the member is
+                    // an approved (not merely raw/pending self-joined) member of - see
+                    // isApprovedGroupMember and RAiD-608 / HELP-2844.
+                    final var groups = member.getGroupsStream()
+                            .filter(g -> isApprovedGroupMember(member, g.getId()))
+                            .toList();
 
                     for (final var group : groups) {
                         final var roleName = servicePointAdminRoleName(group.getId());

--- a/iam/src/test/java/au/org/raid/iam/provider/group/GroupControllerTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/group/GroupControllerTest.java
@@ -101,6 +101,18 @@ class GroupControllerTest {
         when(user.getRoleMappingsStream()).thenAnswer(inv -> Stream.of(groupAdminRole));
     }
 
+    // Represents a flat group-admin who has actually been granted service-point-user for the
+    // group in question, i.e. an approved member - as opposed to setupGroupAdminRole() alone,
+    // which represents a flat group-admin whose only tie to the group is raw/pending membership
+    // (see RAiD-608 / HELP-2844).
+    private void setupGroupAdminAndServicePointUserRoles() {
+        var groupAdminRole = mock(RoleModel.class);
+        when(groupAdminRole.getName()).thenReturn("group-admin");
+        var servicePointUserRole = mock(RoleModel.class);
+        when(servicePointUserRole.getName()).thenReturn("service-point-user");
+        when(user.getRoleMappingsStream()).thenAnswer(inv -> Stream.of(groupAdminRole, servicePointUserRole));
+    }
+
     private void setupNoRoles() {
         when(user.getRoleMappingsStream()).thenAnswer(inv -> Stream.empty());
     }
@@ -300,9 +312,9 @@ class GroupControllerTest {
     }
 
     @Test
-    void grant_allowsFlatGroupAdminMemberWhenFallbackEnabled() {
+    void grant_allowsFlatGroupAdminApprovedMemberWhenFallbackEnabled() {
         var controller = createAuthenticatedController(true);
-        setupGroupAdminRole();
+        setupGroupAdminAndServicePointUserRoles();
         setupGroupMembership("g1");
 
         var targetUser = mock(UserModel.class);
@@ -322,6 +334,22 @@ class GroupControllerTest {
         var controller = createAuthenticatedController(true);
         setupGroupAdminRole();
         setupNoGroupMembership();
+
+        var grant = new Grant();
+        grant.setUserId("u1");
+        grant.setGroupId("g1");
+
+        assertThrows(NotAuthorizedException.class, () -> controller.grant(grant));
+    }
+
+    // Regression test for RAiD-608 / HELP-2844: a flat group-admin whose only tie to the group is
+    // a raw, self-joined (never approved) membership must not be treated as an admin of that
+    // group, even though isGroupMember alone would say they are "in" it.
+    @Test
+    void grant_deniesFlatGroupAdminPendingUnapprovedMemberWhenFallbackEnabled() {
+        var controller = createAuthenticatedController(true);
+        setupGroupAdminRole();
+        setupGroupMembership("g1");
 
         var grant = new Grant();
         grant.setUserId("u1");
@@ -390,6 +418,18 @@ class GroupControllerTest {
         assertThrows(NotAuthorizedException.class, () -> controller.get("g1"));
     }
 
+    // Regression test for RAiD-608 / HELP-2844: this is what populates the service-point-request
+    // notification - a flat group-admin who only self-joined (never approved) must not be able to
+    // list members of, or see pending requests for, that group.
+    @Test
+    void get_deniesFlatGroupAdminPendingUnapprovedMemberWhenFallbackEnabled() {
+        var controller = createAuthenticatedController(true);
+        setupGroupAdminRole();
+        setupGroupMembership("g1");
+
+        assertThrows(NotAuthorizedException.class, () -> controller.get("g1"));
+    }
+
     // --- revoke tests ---
 
     @Test
@@ -424,6 +464,22 @@ class GroupControllerTest {
         var response = controller.revoke(grant);
         assertThat(response.getStatus(), is(200));
         verify(targetUser).deleteRoleMapping(servicePointUserRole);
+    }
+
+    // Regression test for RAiD-608 / HELP-2844: a flat group-admin whose only tie to the group is
+    // a raw, self-joined (never approved) membership must not be able to revoke other users'
+    // access either.
+    @Test
+    void revoke_deniesFlatGroupAdminPendingUnapprovedMemberWhenFallbackEnabled() {
+        var controller = createAuthenticatedController(true);
+        setupGroupAdminRole();
+        setupGroupMembership("g1");
+
+        var grant = new Grant();
+        grant.setUserId("u1");
+        grant.setGroupId("g1");
+
+        assertThrows(NotAuthorizedException.class, () -> controller.revoke(grant));
     }
 
     // --- join tests ---
@@ -1021,7 +1077,7 @@ class GroupControllerTest {
     }
 
     @Test
-    void migrate_grantsScopedRoleForEachGroupOfFlatAdmin() {
+    void migrate_grantsScopedRoleForEachApprovedGroupOfFlatAdmin() {
         var controller = createAuthenticatedController();
         setupOperatorRole();
 
@@ -1039,6 +1095,12 @@ class GroupControllerTest {
         var g2 = mock(GroupModel.class);
         when(g2.getId()).thenReturn("g2");
         when(member.getGroupsStream()).thenAnswer(inv -> Stream.of(g1, g2));
+
+        // Member has actually been approved (holds service-point-user) - required for either
+        // group to be backfilled under the new isApprovedGroupMember check.
+        var servicePointUserRole = mock(RoleModel.class);
+        when(servicePointUserRole.getName()).thenReturn("service-point-user");
+        when(member.getRoleMappingsStream()).thenAnswer(inv -> Stream.of(servicePointUserRole));
 
         when(realm.getRole("service-point-admin:g1")).thenReturn(null);
         var scopedRole1 = mock(RoleModel.class);
@@ -1069,6 +1131,43 @@ class GroupControllerTest {
         assertThat(body, containsString("\"grantsSkipped\":0"));
     }
 
+    // Regression test for RAiD-608 / HELP-2844: the migration must not hand a flat group-admin
+    // the scoped admin role for a group they've only raw/pending self-joined and were never
+    // actually approved (granted service-point-user) for.
+    @Test
+    void migrate_skipsGroupMemberNeverApprovedFor() {
+        var controller = createAuthenticatedController();
+        setupOperatorRole();
+
+        var flatGroupAdminRole = mock(RoleModel.class);
+        when(realm.getRole("group-admin")).thenReturn(flatGroupAdminRole);
+
+        when(session.users()).thenReturn(userProvider);
+
+        var member = mock(UserModel.class);
+        when(userProvider.getRoleMembersStream(eq(realm), eq(flatGroupAdminRole), anyInt(), anyInt()))
+                .thenReturn(Stream.of(member), Stream.empty());
+
+        var pendingGroup = mock(GroupModel.class);
+        when(pendingGroup.getId()).thenReturn("pending-group");
+        when(member.getGroupsStream()).thenAnswer(inv -> Stream.of(pendingGroup));
+        // Never granted service-point-user for any group - i.e. only self-joined, never approved.
+        when(member.getRoleMappingsStream()).thenAnswer(inv -> Stream.empty());
+
+        var response = controller.migrateServicePointAdmins();
+        assertThat(response.getStatus(), is(200));
+
+        verify(member, never()).grantRole(any(RoleModel.class));
+        verify(realm, never()).addRole(anyString());
+        verify(realm, never()).addRole(anyString(), anyString());
+
+        var body = response.getEntity().toString();
+        assertThat(body, containsString("\"flatGroupAdminUsers\":1"));
+        assertThat(body, containsString("\"rolesCreated\":0"));
+        assertThat(body, containsString("\"grantsAdded\":0"));
+        assertThat(body, containsString("\"grantsSkipped\":0"));
+    }
+
     @Test
     void migrate_isIdempotentOnSecondRun() {
         var controller = createAuthenticatedController();
@@ -1086,6 +1185,10 @@ class GroupControllerTest {
         var g1 = mock(GroupModel.class);
         when(g1.getId()).thenReturn("g1");
         when(member.getGroupsStream()).thenAnswer(inv -> Stream.of(g1));
+
+        var servicePointUserRole = mock(RoleModel.class);
+        when(servicePointUserRole.getName()).thenReturn("service-point-user");
+        when(member.getRoleMappingsStream()).thenAnswer(inv -> Stream.of(servicePointUserRole));
 
         var scopedRole1 = mock(RoleModel.class);
         when(realm.getRole("service-point-admin:g1")).thenReturn(scopedRole1);
@@ -1122,6 +1225,10 @@ class GroupControllerTest {
         var g1 = mock(GroupModel.class);
         when(g1.getId()).thenReturn("g1");
         when(member.getGroupsStream()).thenAnswer(inv -> Stream.of(g1));
+
+        var servicePointUserRole = mock(RoleModel.class);
+        when(servicePointUserRole.getName()).thenReturn("service-point-user");
+        when(member.getRoleMappingsStream()).thenAnswer(inv -> Stream.of(servicePointUserRole));
 
         var scopedRole1 = mock(RoleModel.class);
         when(realm.getRole("service-point-admin:g1")).thenReturn(scopedRole1);


### PR DESCRIPTION
## Summary

Fixes RAID-608 / HELP-2844: a Service Point Admin who was never explicitly granted access to a specific Service Point could still view and approve pending access requests for it via the notification centre.

**Root cause**: `isGroupAdminOf`'s flat `group-admin` fallback authorised group administration based on raw Keycloak group membership (`isGroupMember`) alone. Raw membership is created the instant a user self-requests access to a Service Point (before anyone approves them) — so a user who self-requested access to a Service Point and was separately elevated to the flat `group-admin` role (without ever being approved for that specific Service Point) could still list and approve other users' pending requests there.

**Fix**: the flat fallback now requires *approved* membership — holding `service-point-user`, which is only ever granted via an explicit `grant()` approval — not just raw membership. Applied via a new `isApprovedGroupMember` check used by `isGroupAdminOf` (covering `get()`, `grant()`, `revoke()`, and `/group-admin` PUT/DELETE). The `migrate-service-point-admins` backfill is updated the same way, so it no longer over-grants the scoped `service-point-admin:<groupId>` role to pending, unapproved memberships either.

**Known residual scope**: `service-point-user` is still a realm-wide role, not scoped per group, so an admin already approved for one Service Point who separately self-joins a second would still pass this check for the second. Closing that fully requires RAID-727 (already tracked) to make the scoped `service-point-admin:<groupId>` role the sole source of truth. Out of scope for this fix.

## Changes

- `iam/.../GroupController.java` — added `isApprovedGroupMember`; `isGroupAdminOf`'s flat fallback and the migration backfill now use it instead of raw `isGroupMember`.
- `iam/.../GroupControllerTest.java` — 6 new regression tests, 4 existing tests updated where their setup previously encoded the vulnerable behaviour as expected.
- `api-svc/.../GroupServicePointAdminIntegrationTest.java` — matching regression coverage against a live Keycloak stack.

## Test plan

- [x] `iam` unit suite: 112 tests, 0 failures (`./gradlew test` in `iam/`)
- [x] Manually reproduced the vulnerability end-to-end in the test environment prior to the fix
- [ ] `GroupServicePointAdminIntegrationTest` run against a live stack (blocked locally on Windows by an unrelated pre-existing Gradle glob issue in `idl-raid-v2`; should run clean in CI/Linux)

## Changelog

## IAM
* Fixed a Service Point Admin privilege escalation: a flat `group-admin` whose only tie to a
  service point was a raw, self-joined (never approved) membership could view and approve pending
  access requests for that service point via the notification centre, despite never being
  explicitly granted access. The flat-role fallback now requires an actual approved membership
  (`service-point-user`), and the `migrate-service-point-admins` backfill no longer over-grants the
  scoped admin role to such pending memberships (RAID-608).