### PR TITLE
RAID-788: Add live Wayback existence check for web.archive.org relatedObjects

### DIFF
--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RelatedObjectIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RelatedObjectIntegrationTest.java
@@ -10,6 +10,7 @@ import au.org.raid.idl.raidv2.model.RelatedObjectTypeIdEnum;
 import au.org.raid.idl.raidv2.model.RelatedObjectTypeSchemaUriEnum;
 import au.org.raid.idl.raidv2.model.ValidationFailure;
 import au.org.raid.inttest.service.RaidApiValidationException;
+import feign.RetryableException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -143,6 +144,62 @@ public class RelatedObjectIntegrationTest extends AbstractIntegrationTest {
                     .fieldId("relatedObject[0].id")
                     .errorType("invalid")
                     .message("Must be a valid Web Archive URL (e.g. https://web.archive.org/web/20220101000000/https://example.com)"));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with a web archive related object that the resolver reports as non-existent fails validation")
+    void nonExistentWebArchiveSnapshot() {
+        createRequest.setRelatedObject(List.of(webArchiveRelatedObject(NONEXISTENT_TEST_WEB_ARCHIVE)));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown with non-existent Web Archive snapshot");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures).contains(new ValidationFailure()
+                    .fieldId("relatedObject[0].id")
+                    .errorType("invalidValue")
+                    .message("uri not found"));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with a web archive related object fails with 503 when the resolver is unavailable, not a validation error")
+    void webArchiveServerError() {
+        createRequest.setRelatedObject(List.of(webArchiveRelatedObject(SERVER_ERROR_TEST_WEB_ARCHIVE)));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown when Web Archive resolver is unavailable");
+        } catch (RetryableException e) {
+            assertThat(e.status()).isEqualTo(503);
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with an implausible web archive timestamp year fails validation without calling the resolver")
+    void webArchiveImplausibleYear() {
+        createRequest.setRelatedObject(List.of(
+                webArchiveRelatedObject("https://web.archive.org/web/14062026010101/https://example.com")));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown with implausible Web Archive timestamp year");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures).contains(new ValidationFailure()
+                    .fieldId("relatedObject[0].id")
+                    .errorType("invalidValue")
+                    .message("web archive timestamp year 1406 is implausible"));
         } catch (Exception e) {
             failOnError(e);
         }

--- a/api-svc/raid-api/src/intTest/resources/application.yaml
+++ b/api-svc/raid-api/src/intTest/resources/application.yaml
@@ -29,6 +29,9 @@ raid:
     ror:
       enabled: true
       delay: 150
+    web-archive:
+      enabled: true
+      delay: 150
   identifier:
     name-prefix: http://raid.local/
     license: Creative Commons CC-0

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/bean/ExternalPidService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/bean/ExternalPidService.java
@@ -11,6 +11,7 @@ import au.org.raid.api.service.doi.DoiService;
 import au.org.raid.api.service.handle.HandleService;
 import au.org.raid.api.service.rrid.RridService;
 import au.org.raid.api.service.stub.*;
+import au.org.raid.api.service.webarchive.WebArchiveService;
 import au.org.raid.api.util.Log;
 import au.org.raid.api.validator.GeoNamesUriValidator;
 import au.org.raid.api.validator.OpenStreetMapUriValidator;
@@ -22,6 +23,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -120,6 +122,22 @@ public class ExternalPidService {
         }
 
         return new RridService(restTemplate);
+    }
+
+    @Bean
+    @Primary
+    public WebArchiveService webArchiveService(
+            StubProperties stubProperties,
+            @Qualifier("uriValidatorRestTemplate") RestTemplate restTemplate,
+            Clock clock,
+            @Value("${raid.uri-validation.web-archive.availability-url:https://archive.org/wayback/available}") String availabilityUrl
+    ) {
+        if (stubProperties.getWebArchive() != null && stubProperties.getWebArchive().isEnabled()) {
+            log.warn("using the in-memory Web Archive service");
+            return new WebArchiveServiceStub(stubProperties.getWebArchive().getDelay());
+        }
+
+        return new WebArchiveService(restTemplate, clock, availabilityUrl);
     }
 
     @Bean

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/properties/StubProperties.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/properties/StubProperties.java
@@ -17,6 +17,7 @@ public class StubProperties {
     private OpenStreetMap openStreetMap;
     private Isni isni;
     private Ror ror;
+    private WebArchive webArchive;
 
     @Data
     public static class Doi {
@@ -66,6 +67,12 @@ public class StubProperties {
 
     @Data
     public static class Ror {
+        private boolean enabled;
+        private Long delay;
+    }
+
+    @Data
+    public static class WebArchive {
         private boolean enabled;
         private Long delay;
     }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/InMemoryStubTestData.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/InMemoryStubTestData.java
@@ -37,4 +37,9 @@ public class InMemoryStubTestData {
 
     public static String NONEXISTENT_TEST_ROR = "https://ror.org/000000000";
     public static String SERVER_ERROR_TEST_ROR = "https://ror.org/000000001";
+
+    public static String NONEXISTENT_TEST_WEB_ARCHIVE =
+            "https://web.archive.org/web/20200101000000/https://nonexistent.example.com";
+    public static String SERVER_ERROR_TEST_WEB_ARCHIVE =
+            "https://web.archive.org/web/20200101000000/https://server-error.example.com";
 }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/WebArchiveServiceStub.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/WebArchiveServiceStub.java
@@ -1,0 +1,77 @@
+package au.org.raid.api.service.stub;
+
+import au.org.raid.api.exception.ResolverUnavailableException;
+import au.org.raid.api.service.webarchive.WebArchiveService;
+import au.org.raid.idl.raidv2.model.UnavailableResolver;
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static au.org.raid.api.endpoint.message.ValidationMessage.INVALID_VALUE_TYPE;
+import static au.org.raid.api.endpoint.message.ValidationMessage.URI_DOES_NOT_EXIST;
+import static au.org.raid.api.service.stub.InMemoryStubTestData.NONEXISTENT_TEST_WEB_ARCHIVE;
+import static au.org.raid.api.service.stub.InMemoryStubTestData.SERVER_ERROR_TEST_WEB_ARCHIVE;
+import static au.org.raid.api.util.ObjectUtil.areEqual;
+
+@Slf4j
+public class WebArchiveServiceStub extends WebArchiveService {
+    private final Long delayMilliseconds;
+
+    public WebArchiveServiceStub(final Long delayMilliseconds) {
+        super(null, Clock.systemUTC(), null);
+        this.delayMilliseconds = delayMilliseconds != null ? delayMilliseconds : 0L;
+    }
+
+    @Override
+    @SneakyThrows
+    public List<ValidationFailure> validate(final String uri, final String fieldId) {
+        final var failures = new ArrayList<ValidationFailure>();
+
+        if (!WEB_ARCHIVE_URL_PATTERN.matcher(uri).matches()) {
+            failures.add(new ValidationFailure()
+                    .fieldId(fieldId)
+                    .errorType("invalid")
+                    .message(INVALID_WEB_ARCHIVE_URL_MESSAGE));
+            return failures;
+        }
+
+        final var yearFailure = checkPlausibleYear(extractTimestamp(uri), fieldId);
+        if (yearFailure != null) {
+            failures.add(yearFailure);
+            return failures;
+        }
+
+        log.debug("delay {}", delayMilliseconds);
+        log.debug("simulate Web Archive validation check");
+
+        final var start = Instant.now();
+        Thread.sleep(delayMilliseconds);
+        final var end = Instant.now();
+        final var duration = Duration.between(start, end);
+        log.info("request to {} took {}.{} seconds", uri, duration.getSeconds(), duration.getNano());
+
+        if (areEqual(uri, NONEXISTENT_TEST_WEB_ARCHIVE)) {
+            failures.add(new ValidationFailure()
+                    .fieldId(fieldId)
+                    .errorType(INVALID_VALUE_TYPE)
+                    .message(URI_DOES_NOT_EXIST));
+        } else if (areEqual(uri, SERVER_ERROR_TEST_WEB_ARCHIVE)) {
+            throw new ResolverUnavailableException(List.of(
+                    new UnavailableResolver()
+                            .field(fieldId)
+                            .value(uri)
+                            .resolver(resolverName())
+                            .downstreamStatus(503)
+                            .downstreamMessage("%s resolve %s -> 503".formatted(resolverName(), uri))
+            ));
+        }
+
+        return failures;
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/webarchive/WebArchiveService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/webarchive/WebArchiveService.java
@@ -1,0 +1,184 @@
+package au.org.raid.api.service.webarchive;
+
+import au.org.raid.api.exception.ResolverUnavailableException;
+import au.org.raid.api.validator.UriValidator;
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Year;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static au.org.raid.api.endpoint.message.ValidationMessage.INVALID_VALUE_TYPE;
+import static au.org.raid.api.endpoint.message.ValidationMessage.URI_DOES_NOT_EXIST;
+import static au.org.raid.api.exception.ResolverUnavailableException.toUnavailableResolver;
+
+/**
+ * Existence check for {@code web.archive.org} relatedObject URLs against the Wayback Machine
+ * "availability" API (RAID-788).
+ * <p>
+ * This deliberately implements {@link UriValidator} directly rather than extending
+ * {@link au.org.raid.api.validator.AbstractUriValidator}. The base class's shared machinery is
+ * built around a HEAD request that either succeeds, 404s, or errors - i.e. HTTP status carries
+ * the existence signal. The Wayback availability API is different in every respect that matters
+ * here: it's a GET, it returns a JSON body (not a bare status), and it always responds
+ * HTTP 200 even when there's no archived snapshot (an empty {@code archived_snapshots} object
+ * means "not found"). None of AbstractUriValidator's HEAD/404/503 machinery applies, so
+ * reusing it would mean overriding away most of what it does. What is reused is the
+ * {@link UriValidator} contract, the shared {@code uriValidatorRestTemplate} bean, and
+ * {@link ResolverUnavailableException} for the fail-closed RAID-809 pattern.
+ */
+@Slf4j
+public class WebArchiveService implements UriValidator {
+    protected static final Pattern WEB_ARCHIVE_URL_PATTERN =
+            Pattern.compile("https://web\\.archive\\.org/web/\\d{14}/https?://.+");
+
+    protected static final String INVALID_WEB_ARCHIVE_URL_MESSAGE =
+            "Must be a valid Web Archive URL (e.g. https://web.archive.org/web/20220101000000/https://example.com)";
+
+    /* first 14 chars of the Wayback path are the capture timestamp, yyyyMMddHHmmss */
+    private static final Pattern TIMESTAMP_PATTERN = Pattern.compile("/web/(\\d{14})/");
+    private static final Pattern ORIGINAL_URL_PATTERN = Pattern.compile("/web/\\d{14}/(.+)$");
+    private static final int EARLIEST_PLAUSIBLE_YEAR = 1996;
+
+    private final RestTemplate restTemplate;
+    private final Clock clock;
+    private final String availabilityUrl;
+
+    public WebArchiveService(final RestTemplate restTemplate, final Clock clock, final String availabilityUrl) {
+        this.restTemplate = restTemplate;
+        this.clock = clock;
+        this.availabilityUrl = availabilityUrl;
+    }
+
+    protected String resolverName() {
+        return "Web Archive";
+    }
+
+    @Override
+    public List<ValidationFailure> validate(final String uri, final String fieldId) {
+        if (!WEB_ARCHIVE_URL_PATTERN.matcher(uri).matches()) {
+            return List.of(new ValidationFailure()
+                    .fieldId(fieldId)
+                    .errorType("invalid")
+                    .message(INVALID_WEB_ARCHIVE_URL_MESSAGE));
+        }
+
+        final var timestamp = extractTimestamp(uri);
+        final var yearFailure = checkPlausibleYear(timestamp, fieldId);
+        if (yearFailure != null) {
+            return List.of(yearFailure);
+        }
+
+        final var originalUrl = extractOriginalUrl(uri);
+        final var requestUrl = buildAvailabilityUrl(originalUrl, timestamp);
+
+        try {
+            final var response = restTemplate.exchange(requestUrl, HttpMethod.GET, HttpEntity.EMPTY, JsonNode.class);
+            final var body = response.getBody();
+
+            if (snapshotExists(body)) {
+                return List.of();
+            }
+
+            return List.of(new ValidationFailure()
+                    .fieldId(fieldId)
+                    .errorType(INVALID_VALUE_TYPE)
+                    .message(URI_DOES_NOT_EXIST));
+        } catch (HttpClientErrorException e) {
+            // The Wayback availability API itself returning a client error means the resolver,
+            // not the URI, is at fault (RAID-809) - it doesn't use 404 to mean "no snapshot"
+            // (that's communicated via an empty archived_snapshots in a 200 body instead).
+            log.error("Request failed during Web Archive URI validation", e);
+            throw new ResolverUnavailableException(
+                    List.of(toUnavailableResolver(fieldId, uri, resolverName(), e)));
+        } catch (RestClientException e) {
+            // Covers ResourceAccessException (connect/read timeout, DNS failure, connection
+            // refused), HttpServerErrorException (5xx) and, defensively, any other
+            // RestClientException.
+            log.error("External resolver check failed during Web Archive URI validation of {}", uri, e);
+            throw new ResolverUnavailableException(
+                    List.of(toUnavailableResolver(fieldId, uri, resolverName(), e)));
+        }
+    }
+
+    private String buildAvailabilityUrl(final String originalUrl, final String timestamp) {
+        final var encodedUrl = URLEncoder.encode(originalUrl, StandardCharsets.UTF_8);
+        return "%s?url=%s&timestamp=%s".formatted(availabilityUrl, encodedUrl, timestamp);
+    }
+
+    private boolean snapshotExists(final JsonNode body) {
+        if (body == null) {
+            return false;
+        }
+
+        final var closest = body.path("archived_snapshots").path("closest");
+
+        if (closest.isMissingNode() || closest.isEmpty()) {
+            return false;
+        }
+
+        final var available = closest.path("available").asBoolean(false);
+        final var status = closest.path("status").asText("");
+
+        return available && (status.startsWith("2") || status.startsWith("3"));
+    }
+
+    /**
+     * Extracts the 14-digit Wayback capture timestamp from an already format-validated
+     * (see {@link #WEB_ARCHIVE_URL_PATTERN}) URI, e.g. "20220101000000" from
+     * "https://web.archive.org/web/20220101000000/https://example.com".
+     * <p>
+     * Precondition: only call this after the uri has matched {@link #WEB_ARCHIVE_URL_PATTERN}
+     * (as {@link #validate} does before calling it). That guarantees {@code matcher.find()}
+     * succeeds, so the result isn't checked here.
+     */
+    protected String extractTimestamp(final String uri) {
+        final var matcher = TIMESTAMP_PATTERN.matcher(uri);
+        matcher.find();
+        return matcher.group(1);
+    }
+
+    /**
+     * Extracts the original (archived) URL from an already format-validated uri, e.g.
+     * "https://example.com" from
+     * "https://web.archive.org/web/20220101000000/https://example.com".
+     * <p>
+     * Precondition: only call this after the uri has matched {@link #WEB_ARCHIVE_URL_PATTERN}
+     * (as {@link #validate} does before calling it). That guarantees {@code matcher.find()}
+     * succeeds, so the result isn't checked here.
+     */
+    protected String extractOriginalUrl(final String uri) {
+        final var matcher = ORIGINAL_URL_PATTERN.matcher(uri);
+        matcher.find();
+        return matcher.group(1);
+    }
+
+    /**
+     * Rejects capture timestamps whose year is implausible - before the Wayback Machine existed
+     * (1996) or after today - without making any HTTP call. Returns null when the year is
+     * plausible.
+     */
+    protected ValidationFailure checkPlausibleYear(final String timestamp, final String fieldId) {
+        final var year = Integer.parseInt(timestamp.substring(0, 4));
+        final var currentYear = Year.now(clock).getValue();
+
+        if (year < EARLIEST_PLAUSIBLE_YEAR || year > currentYear) {
+            return new ValidationFailure()
+                    .fieldId(fieldId)
+                    .errorType(INVALID_VALUE_TYPE)
+                    .message("web archive timestamp year %d is implausible".formatted(year));
+        }
+
+        return null;
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/validator/RelatedObjectValidator.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/validator/RelatedObjectValidator.java
@@ -5,6 +5,7 @@ import au.org.raid.api.repository.RelatedObjectTypeRepository;
 import au.org.raid.api.service.doi.DoiService;
 import au.org.raid.api.service.handle.HandleService;
 import au.org.raid.api.service.rrid.RridService;
+import au.org.raid.api.service.webarchive.WebArchiveService;
 import au.org.raid.idl.raidv2.model.RelatedObject;
 import au.org.raid.idl.raidv2.model.UnavailableResolver;
 import au.org.raid.idl.raidv2.model.ValidationFailure;
@@ -16,7 +17,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 import static au.org.raid.api.endpoint.message.ValidationMessage.NOT_SET_MESSAGE;
@@ -42,34 +42,23 @@ public class RelatedObjectValidator {
     private static final String WEB_ARCHIVE_SCHEMA_URI = "https://web.archive.org/";
     private static final String HANDLE_SCHEMA_URI = "https://hdl.handle.net/";
     private static final String RRID_SCHEMA_URI = "https://scicrunch.org/resolver/";
-    private static final Pattern WEB_ARCHIVE_URL_PATTERN =
-            Pattern.compile("https://web\\.archive\\.org/web/\\d{14}/https?://.+");
 
     private final RelatedObjectTypeValidator typeValidationService;
     private final RelatedObjectCategoryValidator categoryValidationService;
     private final Map<String, BiFunction<String, String, List<ValidationFailure>>> relatedObjectSchemaUriValidatorMap;
 
-    public RelatedObjectValidator(final RelatedObjectTypeRepository relatedObjectTypeRepository, final DoiService doiService, final HandleService handleService, final RridService rridService, final RelatedObjectTypeValidator typeValidationService, final RelatedObjectCategoryValidator categoryValidationService) {
+    public RelatedObjectValidator(final RelatedObjectTypeRepository relatedObjectTypeRepository, final DoiService doiService, final HandleService handleService, final RridService rridService, final WebArchiveService webArchiveService, final RelatedObjectTypeValidator typeValidationService, final RelatedObjectCategoryValidator categoryValidationService) {
         this.typeValidationService = typeValidationService;
         this.categoryValidationService = categoryValidationService;
 
         // Built here (rather than as a Spring @Bean, cf. ExternalPidService#spatialCoverageUriValidatorMap)
-        // because the web-archive entry is a local regex check with no injectable collaborator - keeping the
-        // whole dispatch map private to this validator avoids splitting a single-owner concern across two classes.
+        // because keeping the whole dispatch map private to this validator avoids splitting a
+        // single-owner concern across two classes.
         final var map = new LinkedHashMap<String, BiFunction<String, String, List<ValidationFailure>>>();
         map.put(DOI_SCHEMA_URI, doiService::validate);
         map.put(HANDLE_SCHEMA_URI, handleService::validate);
         map.put(RRID_SCHEMA_URI, rridService::validate);
-        map.put(WEB_ARCHIVE_SCHEMA_URI, (id, fieldId) -> {
-            if (WEB_ARCHIVE_URL_PATTERN.matcher(id).matches()) {
-                return List.of();
-            }
-
-            return List.of(new ValidationFailure()
-                    .fieldId(fieldId)
-                    .errorType("invalid")
-                    .message("Must be a valid Web Archive URL (e.g. https://web.archive.org/web/20220101000000/https://example.com)"));
-        });
+        map.put(WEB_ARCHIVE_SCHEMA_URI, webArchiveService::validate);
         this.relatedObjectSchemaUriValidatorMap = Collections.unmodifiableMap(map);
     }
 

--- a/api-svc/raid-api/src/main/resources/application-dev.yaml
+++ b/api-svc/raid-api/src/main/resources/application-dev.yaml
@@ -52,6 +52,9 @@ raid:
     open-street-map:
       enabled: true
       delay: 150
+    web-archive:
+      enabled: true
+      delay: 150
 spring:
   security:
     oauth2:

--- a/api-svc/raid-api/src/main/resources/application.yaml
+++ b/api-svc/raid-api/src/main/resources/application.yaml
@@ -63,6 +63,9 @@ raid:
     ror:
       enabled: false
       delay: 150
+    web-archive:
+      enabled: false
+      delay: 150
   identifier:
     schema-uri: https://raid.org/
     license: Creative Commons CC-0
@@ -82,6 +85,8 @@ raid:
     # to validators only; the shared RestTemplate (minting etc.) is unaffected (RAID-802).
     connect-timeout: 5s
     read-timeout: 10s
+    web-archive:
+      availability-url: https://archive.org/wayback/available
   history:
     baseline-interval: 50
 server:

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/service/stub/WebArchiveServiceStubTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/service/stub/WebArchiveServiceStubTest.java
@@ -1,0 +1,83 @@
+package au.org.raid.api.service.stub;
+
+import au.org.raid.api.exception.ResolverUnavailableException;
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static au.org.raid.api.service.stub.InMemoryStubTestData.NONEXISTENT_TEST_WEB_ARCHIVE;
+import static au.org.raid.api.service.stub.InMemoryStubTestData.SERVER_ERROR_TEST_WEB_ARCHIVE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WebArchiveServiceStubTest {
+    private static final String FIELD_ID = "relatedObject[0].id";
+
+    private final WebArchiveServiceStub webArchiveServiceStub = new WebArchiveServiceStub(0L);
+
+    @Test
+    @DisplayName("A valid, non-sentinel URL passes")
+    void validNonSentinelUrlPasses() {
+        final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
+
+        final var failures = webArchiveServiceStub.validate(uri, FIELD_ID);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("NONEXISTENT_TEST_WEB_ARCHIVE returns URI_DOES_NOT_EXIST")
+    void nonexistentSentinelReturnsUriDoesNotExist() {
+        final var failures = webArchiveServiceStub.validate(NONEXISTENT_TEST_WEB_ARCHIVE, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+
+    @Test
+    @DisplayName("SERVER_ERROR_TEST_WEB_ARCHIVE throws ResolverUnavailableException")
+    void serverErrorSentinelThrowsResolverUnavailable() {
+        final var e = assertThrows(ResolverUnavailableException.class,
+                () -> webArchiveServiceStub.validate(SERVER_ERROR_TEST_WEB_ARCHIVE, FIELD_ID));
+
+        assertThat(e.getUnavailableResolvers().get(0).getResolver(), is("Web Archive"));
+    }
+
+    @Test
+    @DisplayName("A sentinel-shaped but implausible-year URL is rejected by the year check, with no sentinel dispatch")
+    void implausibleYearRejectedEvenForSentinelShapedUrl() {
+        final var uri = "https://web.archive.org/web/14060101000000/https://nonexistent.example.com";
+
+        final var failures = webArchiveServiceStub.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("web archive timestamp year 1406 is implausible")
+        )));
+    }
+
+    @Test
+    @DisplayName("A malformed URL fails format validation")
+    void malformedUrlFailsFormatValidation() {
+        final var uri = "https://web.archive.org/foo/bar";
+
+        final var failures = webArchiveServiceStub.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalid")
+                        .message("Must be a valid Web Archive URL (e.g. https://web.archive.org/web/20220101000000/https://example.com)")
+        )));
+    }
+}

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/service/webarchive/WebArchiveServiceTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/service/webarchive/WebArchiveServiceTest.java
@@ -1,0 +1,301 @@
+package au.org.raid.api.service.webarchive;
+
+import au.org.raid.api.exception.ResolverUnavailableException;
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WebArchiveServiceTest {
+    private static final String AVAILABILITY_URL = "https://archive.org/wayback/available";
+
+    private final RestTemplate restTemplate = mock(RestTemplate.class);
+    private final Clock clock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WebArchiveService webArchiveService =
+            new WebArchiveService(restTemplate, clock, AVAILABILITY_URL);
+
+    private static final String FIELD_ID = "relatedObject[0].id";
+
+    private JsonNode json(final String json) throws Exception {
+        return objectMapper.readTree(json);
+    }
+
+    private void stubResponse(final JsonNode body) {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
+                .thenReturn(ResponseEntity.ok(body));
+    }
+
+    @Test
+    @DisplayName("Year too old (implausible timestamp) fails without an HTTP call")
+    void yearTooOldNoHttpCall() {
+        final var uri = "https://web.archive.org/web/14062026010101/https://example.com";
+
+        final var failures = webArchiveService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("web archive timestamp year 1406 is implausible")
+        )));
+        verify(restTemplate, never()).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
+    }
+
+    @Test
+    @DisplayName("Year in the future fails without an HTTP call")
+    void yearInFutureNoHttpCall() {
+        final var uri = "https://web.archive.org/web/21000101000000/https://example.com";
+
+        final var failures = webArchiveService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("web archive timestamp year 2100 is implausible")
+        )));
+        verify(restTemplate, never()).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
+    }
+
+    @Test
+    @DisplayName("Year 1996 is the earliest plausible year and passes the year check")
+    void year1996Passes() throws Exception {
+        final var uri = "https://web.archive.org/web/19960101000000/https://example.com";
+        stubResponse(json("""
+                {"archived_snapshots":{"closest":{"available":true,"status":"200"}}}
+                """));
+
+        final var failures = webArchiveService.validate(uri, FIELD_ID);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("Year 1995 is rejected with no HTTP call")
+    void year1995Rejected() {
+        final var uri = "https://web.archive.org/web/19950101000000/https://example.com";
+
+        final var failures = webArchiveService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("web archive timestamp year 1995 is implausible")
+        )));
+        verify(restTemplate, never()).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
+    }
+
+    @Test
+    @DisplayName("Malformed URL fails format validation without an HTTP call")
+    void malformedUrlFormatFailure() {
+        final var uri = "https://web.archive.org/foo/bar";
+
+        final var failures = webArchiveService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalid")
+                        .message("Must be a valid Web Archive URL (e.g. https://web.archive.org/web/20220101000000/https://example.com)")
+        )));
+        verify(restTemplate, never()).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
+    }
+
+    @Test
+    @DisplayName("Valid snapshot passes")
+    void validSnapshotPasses() throws Exception {
+        final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
+        stubResponse(json("""
+                {"archived_snapshots":{"closest":{"available":true,"status":"200"}}}
+                """));
+
+        final var failures = webArchiveService.validate(uri, FIELD_ID);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("No snapshot present returns URI_DOES_NOT_EXIST")
+    void noSnapshot() throws Exception {
+        final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
+        stubResponse(json("""
+                {"archived_snapshots":{}}
+                """));
+
+        final var failures = webArchiveService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+
+    @Test
+    @DisplayName("Snapshot present but status 404 returns URI_DOES_NOT_EXIST")
+    void snapshotStatus404() throws Exception {
+        final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
+        stubResponse(json("""
+                {"archived_snapshots":{"closest":{"available":true,"status":"404"}}}
+                """));
+
+        final var failures = webArchiveService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+
+    @Test
+    @DisplayName("Snapshot available=false returns URI_DOES_NOT_EXIST")
+    void snapshotNotAvailable() throws Exception {
+        final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
+        stubResponse(json("""
+                {"archived_snapshots":{"closest":{"available":false,"status":"200"}}}
+                """));
+
+        final var failures = webArchiveService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+
+    @Test
+    @DisplayName("A 3xx snapshot status is treated as existing")
+    void threeXxSnapshotStatusPasses() throws Exception {
+        final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
+        stubResponse(json("""
+                {"archived_snapshots":{"closest":{"available":true,"status":"302"}}}
+                """));
+
+        final var failures = webArchiveService.validate(uri, FIELD_ID);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("Timeout throws ResolverUnavailableException with resolver name Web Archive")
+    void timeoutThrowsResolverUnavailable() {
+        final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
+                .thenThrow(new ResourceAccessException("Read timed out"));
+
+        final var e = assertThrows(ResolverUnavailableException.class,
+                () -> webArchiveService.validate(uri, FIELD_ID));
+
+        assertThat(e.getUnavailableResolvers(), org.hamcrest.Matchers.hasSize(1));
+        assertThat(e.getUnavailableResolvers().get(0).getResolver(), is("Web Archive"));
+    }
+
+    @Test
+    @DisplayName("5xx response throws ResolverUnavailableException")
+    void serverErrorThrowsResolverUnavailable() {
+        final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
+                .thenThrow(HttpServerErrorException.create(
+                        HttpStatusCode.valueOf(503), "Service Unavailable", null, null, null));
+
+        final var e = assertThrows(ResolverUnavailableException.class,
+                () -> webArchiveService.validate(uri, FIELD_ID));
+
+        assertThat(e.getUnavailableResolvers().get(0).getResolver(), is("Web Archive"));
+        assertThat(e.getUnavailableResolvers().get(0).getDownstreamStatus(), is(503));
+    }
+
+    @Test
+    @DisplayName("Non-404 4xx response throws ResolverUnavailableException")
+    void nonNotFoundClientErrorThrowsResolverUnavailable() {
+        final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatusCode.valueOf(403)));
+
+        final var e = assertThrows(ResolverUnavailableException.class,
+                () -> webArchiveService.validate(uri, FIELD_ID));
+
+        assertThat(e.getUnavailableResolvers().get(0).getResolver(), is("Web Archive"));
+        assertThat(e.getUnavailableResolvers().get(0).getDownstreamStatus(), is(403));
+    }
+
+    @Test
+    @DisplayName("The original url query param is URL-encoded when it contains reserved characters")
+    void originalUrlIsEncodedInAvailabilityRequest() throws Exception {
+        final var originalUrl = "https://example.com/path?a=b&c=d";
+        final var uri = "https://web.archive.org/web/20220101000000/" + originalUrl;
+        stubResponse(json("""
+                {"archived_snapshots":{"closest":{"available":true,"status":"200"}}}
+                """));
+
+        webArchiveService.validate(uri, FIELD_ID);
+
+        final var captor = ArgumentCaptor.forClass(String.class);
+        verify(restTemplate).exchange(captor.capture(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class));
+        final var requestUrl = captor.getValue();
+
+        assertThat(requestUrl, is(
+                "https://archive.org/wayback/available?url=https%3A%2F%2Fexample.com%2Fpath%3Fa%3Db%26c%3Dd&timestamp=20220101000000"
+        ));
+
+        // the reserved characters from the original url must not survive unescaped into the
+        // url param's value - only the "?timestamp=" separator we control is allowed through.
+        final var urlParamValue = requestUrl.substring(requestUrl.indexOf("url=") + 4, requestUrl.indexOf("&timestamp="));
+        assertThat(urlParamValue, not(containsString("?")));
+        assertThat(urlParamValue, not(containsString("&")));
+        assertThat(urlParamValue, not(containsString("=")));
+    }
+
+    @Test
+    @DisplayName("A 200 response with a null body is treated as no snapshot found")
+    void nullResponseBodyReturnsUriDoesNotExist() {
+        final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
+                .thenReturn(ResponseEntity.ok(null));
+
+        final var failures = webArchiveService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+}

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/util/TestConstants.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/util/TestConstants.java
@@ -82,6 +82,12 @@ public class TestConstants {
 
     public static final String INVALID_WEB_ARCHIVE_URL = "https://web.archive.org/foo/bar";
 
+    public static final String NONEXISTENT_TEST_WEB_ARCHIVE =
+            "https://web.archive.org/web/20200101000000/https://nonexistent.example.com";
+
+    public static final String SERVER_ERROR_TEST_WEB_ARCHIVE =
+            "https://web.archive.org/web/20200101000000/https://server-error.example.com";
+
     public static final String PRIMARY_DESCRIPTION_TYPE =
             "https://github.com/au-research/raid-metadata/blob/main/scheme/description/type/v1/primary.json";
 

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/RelatedObjectValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/RelatedObjectValidatorTest.java
@@ -4,6 +4,7 @@ import au.org.raid.api.exception.ResolverUnavailableException;
 import au.org.raid.api.service.doi.DoiService;
 import au.org.raid.api.service.handle.HandleService;
 import au.org.raid.api.service.rrid.RridService;
+import au.org.raid.api.service.webarchive.WebArchiveService;
 import au.org.raid.api.util.TestConstants;
 import au.org.raid.idl.raidv2.model.RelatedObject;
 import au.org.raid.idl.raidv2.model.RelatedObjectCategory;
@@ -50,6 +51,9 @@ class RelatedObjectValidatorTest {
 
     @Mock
     private RridService rridService;
+
+    @Mock
+    private WebArchiveService webArchiveService;
 
     @InjectMocks
     private RelatedObjectValidator validationService;
@@ -461,5 +465,107 @@ class RelatedObjectValidatorTest {
         verify(handleService).validate(handleUri, handleFieldId);
         verify(typeValidationService).validate(type, 1);
         verify(categoryValidationService).validate(categories, 1);
+    }
+
+    @Test
+    @DisplayName("Validation passes with valid Web Archive related object")
+    void validWebArchiveRelatedObject() {
+        final var webArchiveUri = "https://web.archive.org/web/20220101000000/https://example.com";
+
+        final var type = new RelatedObjectType()
+                .id(RelatedObjectTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_TYPE_SCHEMA_247)
+                .schemaUri(RelatedObjectTypeSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_TYPE_SCHEMA_329);
+
+        final var categories = List.of(new RelatedObjectCategory()
+                .id(RelatedObjectCategoryIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_CATEGORY_ID_190)
+                .schemaUri(RelatedObjectCategorySchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_CATEGORY_SCHEMA_URI_386));
+
+        final var relatedObject = new RelatedObject()
+                .id(webArchiveUri)
+                .schemaUri(RelatedObjectSchemaUriEnum.HTTPS_WEB_ARCHIVE_ORG_)
+                .type(type)
+                .category(categories);
+
+        when(typeValidationService.validate(type, 0)).thenReturn(Collections.emptyList());
+        when(categoryValidationService.validate(categories, 0)).thenReturn(Collections.emptyList());
+        when(webArchiveService.validate(webArchiveUri, "relatedObject[0].id")).thenReturn(Collections.emptyList());
+
+        final var failures =
+                validationService.validateRelatedObjects(Collections.singletonList(relatedObject)).failures();
+
+        assertThat(failures, empty());
+        verify(webArchiveService).validate(webArchiveUri, "relatedObject[0].id");
+    }
+
+    @Test
+    @DisplayName("Validation fails if Web Archive service reports a failure")
+    void addsFailureIfWebArchiveValidationFails() {
+        final var webArchiveUri = "https://web.archive.org/web/20220101000000/https://example.com";
+        final var fieldId = "relatedObject[0].id";
+
+        final var type = new RelatedObjectType()
+                .id(RelatedObjectTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_TYPE_SCHEMA_247)
+                .schemaUri(RelatedObjectTypeSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_TYPE_SCHEMA_329);
+
+        final var categories = List.of(new RelatedObjectCategory()
+                .id(RelatedObjectCategoryIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_CATEGORY_ID_190)
+                .schemaUri(RelatedObjectCategorySchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_CATEGORY_SCHEMA_URI_386));
+
+        final var relatedObject = new RelatedObject()
+                .id(webArchiveUri)
+                .schemaUri(RelatedObjectSchemaUriEnum.HTTPS_WEB_ARCHIVE_ORG_)
+                .type(type)
+                .category(categories);
+
+        final var failure = new ValidationFailure()
+                .fieldId(fieldId)
+                .errorType("invalidValue")
+                .message("uri not found");
+
+        when(typeValidationService.validate(type, 0)).thenReturn(Collections.emptyList());
+        when(categoryValidationService.validate(categories, 0)).thenReturn(Collections.emptyList());
+        when(webArchiveService.validate(webArchiveUri, fieldId)).thenReturn(List.of(failure));
+
+        final var failures =
+                validationService.validateRelatedObjects(Collections.singletonList(relatedObject)).failures();
+
+        assertThat(failures, is(List.of(failure)));
+    }
+
+    @Test
+    @DisplayName("A resolver failure from the Web Archive service is collected into the unavailable list")
+    void webArchiveResolverUnavailableIsCollected() {
+        final var webArchiveUri = "https://web.archive.org/web/20220101000000/https://example.com";
+        final var fieldId = "relatedObject[0].id";
+
+        final var type = new RelatedObjectType()
+                .id(RelatedObjectTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_TYPE_SCHEMA_247)
+                .schemaUri(RelatedObjectTypeSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_TYPE_SCHEMA_329);
+
+        final var categories = List.of(new RelatedObjectCategory()
+                .id(RelatedObjectCategoryIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_CATEGORY_ID_190)
+                .schemaUri(RelatedObjectCategorySchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_OBJECT_CATEGORY_SCHEMA_URI_386));
+
+        final var relatedObject = new RelatedObject()
+                .id(webArchiveUri)
+                .schemaUri(RelatedObjectSchemaUriEnum.HTTPS_WEB_ARCHIVE_ORG_)
+                .type(type)
+                .category(categories);
+
+        final var unavailable = new UnavailableResolver()
+                .field(fieldId)
+                .value(webArchiveUri)
+                .resolver("Web Archive")
+                .downstreamStatus(null);
+
+        when(typeValidationService.validate(type, 0)).thenReturn(Collections.emptyList());
+        when(categoryValidationService.validate(categories, 0)).thenReturn(Collections.emptyList());
+        when(webArchiveService.validate(webArchiveUri, fieldId))
+                .thenThrow(new ResolverUnavailableException(List.of(unavailable)));
+
+        final var result = validationService.validateRelatedObjects(Collections.singletonList(relatedObject));
+
+        assertThat(result.failures(), empty());
+        assertThat(result.unavailableResolvers(), is(List.of(unavailable)));
     }
 }

--- a/api-svc/testFixtures/src/testFixtures/java/au/org/raid/fixtures/TestConstants.java
+++ b/api-svc/testFixtures/src/testFixtures/java/au/org/raid/fixtures/TestConstants.java
@@ -105,6 +105,10 @@ public class TestConstants {
     public static final String VALID_WEB_ARCHIVE_URL =
             "https://web.archive.org/web/20220101000000/https://example.com";
     public static final String INVALID_WEB_ARCHIVE_URL = "https://web.archive.org/foo/bar";
+    public static final String NONEXISTENT_TEST_WEB_ARCHIVE =
+            "https://web.archive.org/web/20200101000000/https://nonexistent.example.com";
+    public static final String SERVER_ERROR_TEST_WEB_ARCHIVE =
+            "https://web.archive.org/web/20200101000000/https://server-error.example.com";
 
     public static final String HANDLE_SCHEMA_URI = "https://hdl.handle.net/";
     public static final String VALID_HANDLE = "https://hdl.handle.net/20.500.12345/abc123";

--- a/documentation/20260813-raid-788-web-archive-existence-check.md
+++ b/documentation/20260813-raid-788-web-archive-existence-check.md
@@ -1,0 +1,87 @@
+# RAID-788: live Wayback existence check for web.archive.org relatedObjects
+
+Date: 2026-08-13
+
+## What changed and why
+
+`RelatedObjectValidator` only validated the *format* of `web.archive.org`
+relatedObject URLs (a 14-digit timestamp regex), never confirming the snapshot
+existed. Real bad data slipped through: RAiD 10.71613/18ae7426 (NESP RL Project
+2.2) used timestamp `14062026010101` (a DD-MM-YYYY date written as digits, not
+YYYYMMDDHHMMSS). It passes the 14-digit regex but no Wayback snapshot exists, and
+sixteen other Resilient Landscapes RAiDs shared the same malformed pattern.
+
+### The change
+
+- **New `WebArchiveService`** (implements `UriValidator` directly, not
+  `AbstractUriValidator`). The Wayback availability API is GET+JSON and returns
+  HTTP 200 even when nothing is archived, so the base class's HEAD/404 machinery
+  does not apply; a class Javadoc records this rationale. Validation order:
+  1. **Format check** (unchanged regex + message, so existing behaviour/tests hold).
+  2. **Year sanity check** (protected helper): reject year < 1996 or > current year
+     (from an injected `Clock`) as a clean `invalidValue` failure **before any
+     network call**. This alone catches `14062026010101` (year 1406) with zero
+     external traffic.
+  3. **Availability call:** `GET https://archive.org/wayback/available?url=<enc>&timestamp=<ts>`,
+     parsed as `JsonNode`; a snapshot exists iff `archived_snapshots.closest.available == true`
+     and `closest.status` is 2xx/3xx. Otherwise a clean `uri not found` (400) failure.
+  4. **Fail-closed (RAID-802/809):** timeouts / DNS / connection-refused / 5xx /
+     non-404 4xx are surfaced as `ResolverUnavailableException` (HTTP 503 +
+     `Retry-After`), never a validation failure.
+- **In-memory `WebArchiveServiceStub`** (gated on `raid.stub.web-archive.enabled`)
+  reuses the inherited format + year checks, then dispatches on sentinels; the
+  server-error sentinel throws `ResolverUnavailableException` to exercise the real
+  503 contract (unlike the older DOI/Handle/RRID stubs that predate RAID-809).
+- **Wiring:** `RelatedObjectValidator` dispatch map now routes web-archive to
+  `webArchiveService::validate`; `ExternalPidService` builds the `@Bean @Primary`
+  (real vs stub) on the timeout-bounded `uriValidatorRestTemplate`; `StubProperties`
+  gains a `webArchive` block. Config: `application.yaml` stub disabled by default +
+  `raid.uri-validation.web-archive.availability-url`; `application-dev.yaml` and the
+  intTest profile enable the stub.
+
+## Scope and follow-ups
+
+- **CDK companion [RAID-816]** (`raido-v2-aws-private` #37, merged): adds
+  `raid.stub.web-archive.enabled` to the branch/test task definition (test = `true`,
+  demo/stage/prod = `false`). Without it, branch/test deployments validated against
+  the real archive.org and the stub-dependent intTests (esp. the 503 case) failed
+  deterministically. The branch pipeline pulls this CDK from `main` (InfraSource),
+  so #37 had to merge before the branch/test run could go green.
+- **Out of scope:** fixing the existing bad data in the Resilient Landscapes hub
+  (Matthias is handling that with their contact). Validation only runs on
+  mint/update, so existing minted RAiDs are not retroactively rejected on read; an
+  update that re-submits a bad web-archive relatedObject will now be rejected.
+- **Behaviour note:** stage/prod validate against real archive.org. The check runs
+  inside the concurrent I/O-bound validator set, adding one bounded (5s/10s) call.
+
+## Testing
+
+- Unit: new `WebArchiveServiceTest` (15 — year boundaries, no-snapshot, 2xx/3xx/4xx
+  statuses, null body, URL-encoding, timeout/5xx/non-404 -> 503) and
+  `WebArchiveServiceStubTest` (5); updated `RelatedObjectValidatorTest` adds the
+  previously-missing web-archive dispatch coverage. `./gradlew :api-svc:raid-api:test`
+  green.
+- Integration: new `RelatedObjectIntegrationTest` cases — valid snapshot,
+  non-existent snapshot (400), implausible-year (400, no external call, the AC3
+  regression guard), resolver-unavailable (503). Full `:api-svc:raid-api:intTest`
+  green locally.
+- Branch/test pipeline (after #37 merged): all web-archive cases pass in the test
+  environment, including the 503 case (which only passes with the stub active,
+  confirming RAID-816 took effect). The Api-Integration-Test stage is currently red
+  only on 3 pre-existing, branch-wide IAM group-SPI 401 failures ("Group Service
+  Point Admin" / "Migration endpoint"), which fail identically on unrelated branches
+  (bug/RAiD-790) and are unrelated to this change.
+
+## Reviews
+
+- api-code-reviewer: one blocker (missing `@Value` default on the availability-url,
+  which would fail the intTest context) fixed with an inline default; URL-encoding
+  and null-body test suggestions folded in. No remaining blocking issues.
+
+## Links
+
+- Parent story: [RAID-788](https://ardc.atlassian.net/browse/RAID-788) (epic
+  [RAID-789](https://ardc.atlassian.net/browse/RAID-789), resolver availability hardening)
+- Sub-task: [RAID-816](https://ardc.atlassian.net/browse/RAID-816) (branch/test CDK stub)
+- PR (api): https://github.com/au-research/raid-au/pull/612
+- PR (CDK): https://github.com/au-research/raido-v2-aws-private/pull/37


### PR DESCRIPTION
## Summary
Replaces the pure-regex validation of `web.archive.org` relatedObject URLs with a live existence check. Previously the RelatedObjectValidator only checked the URL *format* (14-digit timestamp), so malformed-but-well-formed timestamps passed (e.g. RAiD 10.71613/18ae7426 used `14062026010101`, a DD-MM-YYYY string, with no real Wayback snapshot).

Introduces a new `WebArchiveService` that:
- Keeps the existing format check (unchanged message).
- Adds a **year sanity check** (rejects year < 1996 or > current year) *before any network call*, using an injected `Clock`.
- Calls the Wayback Machine availability API (`https://archive.org/wayback/available?url=...&timestamp=...`) and confirms a snapshot exists (`archived_snapshots.closest.available == true` and a 2xx/3xx capture status).
- Follows the RAID-802/809 fail-closed pattern: timeouts / DNS / connection-refused / 5xx / non-404 4xx are surfaced as `ResolverUnavailableException` (HTTP 503 with Retry-After), not a validation failure.

It implements `UriValidator` directly rather than extending `AbstractUriValidator`, because the availability API is GET+JSON and returns HTTP 200 even when nothing is archived, so the base class's HEAD/404 machinery does not apply (documented in a class Javadoc).

## Acceptance criteria
- Wayback availability check in addition to format check.
- Implausible-year timestamps rejected before any external call.
- RAiD 10.71613/18ae7426 (timestamp 14062026010101) would now fail validation on resubmission.

## Testing
- Unit: new `WebArchiveServiceTest` (15) + `WebArchiveServiceStubTest` (5); updated `RelatedObjectValidatorTest` (adds the previously-missing web-archive dispatch coverage).
- Integration: new `RelatedObjectIntegrationTest` cases — valid snapshot, non-existent snapshot (400), implausible-year (400, no external call), resolver-unavailable (503).
- Full `:api-svc:raid-api:intTest` green locally.
- Branch/test pipeline: the web-archive cases all pass in the test environment (including the 503 case, which confirms the stub is active). NOTE: the branch pipeline's Api-Integration-Test stage is currently red only due to 3 pre-existing, branch-wide IAM group-SPI 401 failures ("Group Service Point Admin" / "Migration endpoint" tests) that fail identically on unrelated branches (e.g. bug/RAiD-790) — unrelated to this change.

## Related
- Parent story: RAID-788 (under epic RAID-789, resolver availability hardening).
- CDK companion **RAID-816** (raido-v2-aws-private #37, merged): enables `raid.stub.web-archive.enabled` for the branch/test environment so the web-archive validator uses the in-memory stub there. Stage/prod validate against real archive.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)