### PR TITLE
RAID-798: accept dx.doi.org DOIs in relatedObject validation

### DIFF
--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RelatedObjectIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/RelatedObjectIntegrationTest.java
@@ -148,6 +148,18 @@ public class RelatedObjectIntegrationTest extends AbstractIntegrationTest {
         }
     }
 
+    private RelatedObject doiRelatedObject(String id) {
+        return new RelatedObject()
+                .id(id)
+                .schemaUri(RelatedObjectSchemaUriEnum.fromValue(DOI_SCHEMA_URI))
+                .type(new RelatedObjectType()
+                        .id(RelatedObjectTypeIdEnum.fromValue(BOOK_CHAPTER_RELATED_OBJECT_TYPE))
+                        .schemaUri(RelatedObjectTypeSchemaUriEnum.fromValue(RELATED_OBJECT_TYPE_SCHEMA_URI)))
+                .category(List.of(new RelatedObjectCategory()
+                        .id(RelatedObjectCategoryIdEnum.fromValue(INPUT_RELATED_OBJECT_CATEGORY_ID))
+                        .schemaUri(RelatedObjectCategorySchemaUriEnum.fromValue(RELATED_OBJECT_CATEGORY_SCHEMA_URI))));
+    }
+
     private RelatedObject rridRelatedObject(String id) {
         return new RelatedObject()
                 .id(id)
@@ -233,6 +245,43 @@ public class RelatedObjectIntegrationTest extends AbstractIntegrationTest {
             assertThat(raid).isNotNull();
             assertThat(raid.getRelatedObject()).hasSize(1);
             assertThat(raid.getRelatedObject().get(0).getId()).isEqualTo("https://hdl.handle.net/10.1234/xyz");
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with a dx.doi.org DOI related object succeeds and stores the id unchanged (RAID-798)")
+    void validDxDoiRelatedObject() {
+        createRequest.setRelatedObject(List.of(doiRelatedObject(VALID_DX_DOI)));
+
+        try {
+            final var result = raidApi.mintRaid(createRequest);
+            final var raid = result.getBody();
+            assertThat(raid).isNotNull();
+            assertThat(raid.getRelatedObject()).hasSize(1);
+            // The submitted dx.doi.org form is stored verbatim, not normalised to doi.org.
+            assertThat(raid.getRelatedObject().get(0).getId()).isEqualTo(VALID_DX_DOI);
+            assertThat(raid.getRelatedObject().get(0).getSchemaUri())
+                    .isEqualTo(RelatedObjectSchemaUriEnum.fromValue(DOI_SCHEMA_URI));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with a dx.doi.org id that fails DOI format is rejected (RAID-798 regression guard)")
+    void malformedDxDoiIsRejected() {
+        createRequest.setRelatedObject(List.of(doiRelatedObject("https://dx.doi.org/not-a-doi")));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown with malformed dx.doi.org DOI");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures.get(0).getFieldId()).isEqualTo("relatedObject[0].id");
+            assertThat(failures.get(0).getErrorType()).isEqualTo("invalidValue");
         } catch (Exception e) {
             failOnError(e);
         }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/doi/DoiService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/doi/DoiService.java
@@ -8,7 +8,10 @@ import org.springframework.web.client.RestTemplate;
 @Getter
 @RequiredArgsConstructor
 public class DoiService extends AbstractUriValidator {
-    public final String regex = "^https?://(doi\\.org/10\\..+|web\\.archive\\.org/.*)";
+    // Both doi.org and dx.doi.org are valid DOI proxy hosts (RAID-798). We accept either as
+    // submitted without normalising, consistent with the Handle (RAID-786) and ARK (RAID-793)
+    // decisions to store the exact form supplied.
+    public final String regex = "^https?://((dx\\.)?doi\\.org/10\\..+|web\\.archive\\.org/.*)";
     private final RestTemplate restTemplate;
 
     @Override

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/service/doi/DoiServiceTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/service/doi/DoiServiceTest.java
@@ -1,0 +1,106 @@
+package au.org.raid.api.service.doi;
+
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.RequestEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DoiServiceTest {
+    private final RestTemplate restTemplate = mock(RestTemplate.class);
+    private final DoiService doiService = new DoiService(restTemplate);
+
+    @ParameterizedTest
+    @DisplayName("Accepts a DOI regardless of which proxy host it uses (RAID-798)")
+    @ValueSource(strings = {
+            "https://doi.org/10.1234/xyz",      // preferred host
+            "https://dx.doi.org/10.1234/xyz",   // legacy proxy, https
+            "http://dx.doi.org/10.1234/xyz"     // legacy proxy, http
+    })
+    void acceptsBothProxyHosts(final String storedUri) {
+        when(restTemplate.exchange(any(RequestEntity.class), eq(Void.class))).thenReturn(null);
+
+        final var failures = doiService.validate(storedUri, "relatedObject[0].id");
+
+        assertThat(failures, empty());
+    }
+
+    @ParameterizedTest
+    @DisplayName("HEAD-checks the submitted URL as-is, without normalising the proxy host")
+    @ValueSource(strings = {
+            "https://doi.org/10.1234/xyz",
+            "https://dx.doi.org/10.1234/xyz"
+    })
+    void headsSubmittedUrlWithoutNormalising(final String storedUri) {
+        when(restTemplate.exchange(any(RequestEntity.class), eq(Void.class))).thenReturn(null);
+
+        final var failures = doiService.validate(storedUri, "relatedObject[0].id");
+
+        assertThat(failures, empty());
+
+        // RequestEntity.head(String) builds a URI-template entity whose getUrl() is not
+        // resolvable until the RestTemplate expands it, so assert on the template via toString().
+        final var captor = ArgumentCaptor.forClass(RequestEntity.class);
+        verify(restTemplate).exchange(captor.capture(), eq(Void.class));
+        assertThat(captor.getValue().toString(), containsString(storedUri));
+    }
+
+    @ParameterizedTest
+    @DisplayName("Returns 'uri not found' when the resolver 404s a dx.doi.org DOI, same as any other")
+    @ValueSource(strings = {
+            "https://doi.org/10.1234/does-not-exist",
+            "https://dx.doi.org/10.1234/does-not-exist"
+    })
+    void nonExistentDoi(final String storedUri) {
+        final var fieldId = "relatedObject[0].id";
+        when(restTemplate.exchange(any(RequestEntity.class), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatusCode.valueOf(404)));
+
+        final var failures = doiService.validate(storedUri, fieldId);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(fieldId)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+
+    @ParameterizedTest
+    @DisplayName("Fails regex validation for malformed DOIs and never calls the resolver (regression guard)")
+    @ValueSource(strings = {
+            "https://dx.doi.org/not-a-doi",     // dx host but no 10. DOI prefix
+            "https://doi.org/not-a-doi",         // preferred host but no 10. DOI prefix
+            "https://dxx.doi.org/10.1234/xyz",   // not a recognised proxy host
+            "https://doi.org/",                  // missing DOI entirely
+            "ftp://doi.org/10.1234/xyz"          // unsupported scheme
+    })
+    void rejectsMalformedDoi(final String storedUri) {
+        final var fieldId = "relatedObject[0].id";
+
+        final var failures = doiService.validate(storedUri, fieldId);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(fieldId)
+                        .errorType("invalidValue")
+                        .message("has invalid/unsupported value - should match " + doiService.getRegex())
+        )));
+    }
+}

--- a/api-svc/testFixtures/src/testFixtures/java/au/org/raid/fixtures/TestConstants.java
+++ b/api-svc/testFixtures/src/testFixtures/java/au/org/raid/fixtures/TestConstants.java
@@ -111,4 +111,8 @@ public class TestConstants {
 
     public static final String RRID_SCHEMA_URI = "https://scicrunch.org/resolver/";
     public static final String VALID_RRID = "https://scicrunch.org/resolver/RRID:AB_2298772";
+
+    public static final String DOI_SCHEMA_URI = "https://doi.org/";
+    // The dx.doi.org proxy host is accepted verbatim under the same DOI scheme (RAID-798).
+    public static final String VALID_DX_DOI = "https://dx.doi.org/10.1234/xyz";
 }

--- a/documentation/20260814-raid-798-dx-doi-org-validation.md
+++ b/documentation/20260814-raid-798-dx-doi-org-validation.md
@@ -1,0 +1,59 @@
+# RAID-798: Accept dx.doi.org-formatted DOIs in relatedObject validation
+
+- **JIRA:** [RAID-798](https://ardc.atlassian.net/browse/RAID-798) (Bug)
+- **PR:** [au-research/raid-au#613](https://github.com/au-research/raid-au/pull/613)
+- **Branch:** `feature/RAID-798`
+- **Date:** 2026-08-14
+
+## What changed and why
+
+The RAiD API rejected DOI `relatedObject` ids submitted through the `dx.doi.org`
+proxy host, accepting only the bare `doi.org` host. This surfaced in the RAiD US
+pilot. Both `doi.org` and `dx.doi.org` are valid DOI proxy services maintained by
+the DOI Foundation; `dx.doi.org` is no longer preferred but remains functional.
+
+`DoiService.regex` was broadened from:
+
+```
+^https?://(doi\.org/10\..+|web\.archive\.org/.*)
+```
+
+to:
+
+```
+^https?://((dx\.)?doi\.org/10\..+|web\.archive\.org/.*)
+```
+
+The submitted form is stored **verbatim, without normalisation**, consistent with
+the store-as-submitted decisions for Handle (RAID-786) and ARK (RAID-793). DataCite
+handling is unaffected because it keys off `schemaUri`, not the submitted id. The
+in-memory `DoiServiceStub` reuses `getRegex()`, so the change flows through the
+stubbed test path automatically.
+
+No database migration and no backfill were required (no existing RAiD could carry
+this format, since it was previously rejected at validation).
+
+## Tests
+
+- **`DoiServiceTest`** (new, mirrors `RridServiceTest`): accepts both proxy hosts
+  over `http`/`https`; asserts the resolver HEAD target is the submitted URL (proving
+  no normalisation); resolver-404 maps to "uri not found"; regex regression guard
+  rejects `dx.doi.org/not-a-doi`, an unsupported scheme, and an unrecognised host.
+- **`RelatedObjectIntegrationTest`**: a `dx.doi.org` DOI mints and stores the id
+  unchanged; a malformed `dx.doi.org/not-a-doi` is rejected with HTTP 400.
+- **`TestConstants`** (testFixtures): added `DOI_SCHEMA_URI` and `VALID_DX_DOI`.
+
+## Verification
+
+- `./gradlew build` (compile + unit tests across modules): green.
+- Full `:api-svc:raid-api:intTest`: green.
+- **Live resolver check** against the real `dx.doi.org` proxy (the ticket's
+  non-functional requirement): a known-good DOI (`10.1038/nphys1170`) returned
+  `302 -> 200`; a known-bad DOI returned `404`. Behaviour is identical to `doi.org`,
+  so the app validator behaves correctly against the live proxy.
+
+## Follow-up
+
+- Companion documentation task (Matthias): update metadata.raid.org to state that
+  both `doi.org` and `dx.doi.org` are accepted, with `doi.org` preferred. Neither
+  raid-skos nor metadata.raid.org currently documents the accepted proxy hosts.


### PR DESCRIPTION
## Summary

Accept DOI `relatedObject` ids submitted via the `dx.doi.org` proxy host, not just `doi.org`. Feedback from the RAiD US pilot: the API rejected `https://dx.doi.org/10.xxxx/yyyy` even though `dx.doi.org` is a valid (if no longer preferred) DOI proxy maintained by the DOI Foundation.

JIRA: [RAID-798](https://ardc.atlassian.net/browse/RAID-798)

## Change

- **`DoiService.java`** — broadened the regex from `doi\.org/10\..+` to `(dx\.)?doi\.org/10\..+`. The `https?` scheme range and the `web.archive.org` branch are unchanged.
- The submitted form is stored **verbatim, without normalisation**, consistent with the Handle (RAID-786) and ARK (RAID-793) store-as-submitted decisions. DataCite handling is unaffected (it keys off `schemaUri`, not the submitted id).
- The in-memory `DoiServiceStub` reuses `getRegex()`, so the same behaviour flows through automatically.

## Tests

- **`DoiServiceTest`** (new, mirrors `RridServiceTest`): accepts both proxy hosts over `http`/`https`; asserts the resolver HEAD target is the submitted URL (no normalisation); resolver-404 → "uri not found"; regex regression guard rejecting `dx.doi.org/not-a-doi`, a bad scheme, and an unrecognised host.
- **`RelatedObjectIntegrationTest`**: `dx.doi.org` DOI mints and stores the id unchanged; malformed `dx.doi.org/not-a-doi` is rejected (400).

## Verification

- Full `:api-svc:raid-api:intTest` green locally; full `./gradlew build` green.
- **Live resolver check** against the real `dx.doi.org` proxy: a known-good DOI returned `302 → 200`; a known-bad DOI returned `404` — identical to `doi.org`.

## Notes

- No migration and no backfill (no existing RAiDs could carry this format).
- A companion documentation task (Matthias) will note on metadata.raid.org that both `doi.org` and `dx.doi.org` are accepted, with `doi.org` preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)