### PR TITLE
RAID-791: Reject malformed ISNIs via local checksum before SRU check

### DIFF
--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/ContributorsIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/ContributorsIntegrationTest.java
@@ -32,6 +32,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 // TODO: Test that pre-existing contributors have UNVERIFIED status
 
 public class ContributorsIntegrationTest extends AbstractIntegrationTest {
+    // Deliberately checksum-INVALID under ISO 27729 MOD 11-2 (the calculated check character for
+    // these digits is "1", not "0"), used to exercise the RAID-791 local checksum rejection, which
+    // must reject before ever calling the ISNI resolver. The intTest source set is a black-box HTTP
+    // client and cannot see the api-svc main classes, so this mirrors
+    // InMemoryStubTestData.MALFORMED_TEST_ISNI locally (same pattern as the ROR sentinels).
+    private static final String MALFORMED_TEST_ISNI = "https://isni.org/isni/0000000000000000";
+
     @Autowired
     private RaidUpdateRequestFactory raidUpdateRequestFactory;
 
@@ -71,7 +78,25 @@ public class ContributorsIntegrationTest extends AbstractIntegrationTest {
             }
         }
 
+        @Test
+        @DisplayName("RAID-791: Minting a RAiD with a checksum-invalid ISNI contributor fails")
+        void raidWithMalformedIsniContributorFails() {
+            createRequest.contributor(List.of(
+                    isniContributor(MALFORMED_TEST_ISNI, PRINCIPAL_INVESTIGATOR_POSITION, SOFTWARE_CONTRIBUTOR_ROLE, today, null)));
 
+            try {
+                raidApi.mintRaid(createRequest);
+                fail("No exception thrown with checksum-invalid ISNI contributor");
+            } catch (RaidApiValidationException e) {
+                final var failures = e.getFailures();
+                assertThat(failures, hasItem(
+                        new ValidationFailure()
+                                .fieldId("contributor[0].id")
+                                .errorType("invalidValue")
+                                .message("has invalid/unsupported value")
+                ));
+            }
+        }
 
         @Test
         @DisplayName("Minting a RAiD with no contributor fails")

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/ContributorValidationConfig.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/ContributorValidationConfig.java
@@ -6,6 +6,7 @@ import au.org.raid.api.config.properties.ContributorValidationProperties;
 import au.org.raid.api.validator.ContributorPositionValidator;
 import au.org.raid.api.validator.ContributorRoleValidator;
 import au.org.raid.api.validator.ContributorTypeValidator;
+import au.org.raid.api.validator.IsniValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,7 +27,8 @@ public class ContributorValidationConfig {
                 orcidClient,
                 roleValidator,
                 positionValidator,
-                "ORCID"
+                "ORCID",
+                null
         );
     }
 
@@ -37,7 +39,8 @@ public class ContributorValidationConfig {
                 isniClient,
                 roleValidator,
                 positionValidator,
-                "ISNI"
+                "ISNI",
+                new IsniValidator()
         );
     }
 }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/InMemoryStubTestData.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/InMemoryStubTestData.java
@@ -32,8 +32,16 @@ public class InMemoryStubTestData {
     public static String NONEXISTENT_TEST_OPENSTREETMAP_URI = "https://www.openstreetmap.org/not-found";
     public static String SERVER_ERROR_TEST_OPENSTREETMAP_URI = "https://www.openstreetmap.org/server-error";
 
-    public static String NONEXISTENT_TEST_ISNI = "https://isni.org/isni/0000000000000000";
+    // Must be checksum-valid (ISO 27729 MOD 11-2) so the RAID-791 local checksum gate lets it
+    // through to the stub's existence check - calculated check character for digits
+    // "000000000000002" is "8".
+    public static String NONEXISTENT_TEST_ISNI = "https://isni.org/isni/0000000000000028";
+    // Checksum-valid - calculated check character for digits "000000000000000" is "1".
     public static String SERVER_ERROR_TEST_ISNI = "https://isni.org/isni/0000000000000001";
+    // Deliberately checksum-INVALID (calculated check character for digits
+    // "000000000000000" is "1", not "0") - used to test the RAID-791 local checksum rejection
+    // path, which must reject before ever calling the stub/live resolver.
+    public static String MALFORMED_TEST_ISNI = "https://isni.org/isni/0000000000000000";
 
     public static String NONEXISTENT_TEST_ROR = "https://ror.org/000000000";
     public static String SERVER_ERROR_TEST_ROR = "https://ror.org/000000001";

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/validator/ContributorTypeValidator.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/validator/ContributorTypeValidator.java
@@ -29,6 +29,7 @@ public class ContributorTypeValidator {
     private final ContributorRoleValidator roleValidator;
     private final ContributorPositionValidator positionValidator;
     private final String resolverName;
+    private final IsniValidator localIdValidator;
 
     public ContributorTypeValidator(
             ContributorTypeValidationProperties validationProperties,
@@ -37,11 +38,23 @@ public class ContributorTypeValidator {
             ContributorPositionValidator positionValidator,
             String resolverName
     ) {
+        this(validationProperties, contributorClient, roleValidator, positionValidator, resolverName, null);
+    }
+
+    public ContributorTypeValidator(
+            ContributorTypeValidationProperties validationProperties,
+            ContributorClient contributorClient,
+            ContributorRoleValidator roleValidator,
+            ContributorPositionValidator positionValidator,
+            String resolverName,
+            IsniValidator localIdValidator
+    ) {
         this.validationProperties = validationProperties;
         this.contributorClient = contributorClient;
         this.roleValidator = roleValidator;
         this.positionValidator = positionValidator;
         this.resolverName = resolverName;
+        this.localIdValidator = localIdValidator;
     }
 
     public List<ValidationFailure> validate(final Contributor contributor, final int index) {
@@ -56,21 +69,27 @@ public class ContributorTypeValidator {
             );
         }
         else if (contributor.getId().startsWith(validationProperties.getUrlPrefix())) {
-            try {
-                if (!contributorClient.exists(contributor.getId())) {
-                    failures.add(
-                            new ValidationFailure()
-                                    .fieldId("contributor[%d].id".formatted(index))
-                                    .errorType(NOT_FOUND_TYPE)
-                                    .message("This id does not exist")
-                    );
+            if (localIdValidator != null && !localIdValidator.validate(contributor.getId())) {
+                // Fail fast on a locally-detectable checksum error, without calling out to the
+                // live resolver (RAID-791).
+                failures.add(contribIdInvalid(index));
+            } else {
+                try {
+                    if (!contributorClient.exists(contributor.getId())) {
+                        failures.add(
+                                new ValidationFailure()
+                                        .fieldId("contributor[%d].id".formatted(index))
+                                        .errorType(NOT_FOUND_TYPE)
+                                        .message("This id does not exist")
+                        );
+                    }
+                } catch (RestClientException e) {
+                    // The resolver, not the contributor id, is at fault (RAID-809 gap: this
+                    // exists() call previously propagated straight to an opaque HTTP 500).
+                    throw new ResolverUnavailableException(List.of(
+                            toUnavailableResolver(
+                                    "contributor[%d].id".formatted(index), contributor.getId(), resolverName, e)));
                 }
-            } catch (RestClientException e) {
-                // The resolver, not the contributor id, is at fault (RAID-809 gap: this
-                // exists() call previously propagated straight to an opaque HTTP 500).
-                throw new ResolverUnavailableException(List.of(
-                        toUnavailableResolver(
-                                "contributor[%d].id".formatted(index), contributor.getId(), resolverName, e)));
             }
         } else {
             failures.add(

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/validator/IsniValidator.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/validator/IsniValidator.java
@@ -1,15 +1,16 @@
 package au.org.raid.api.validator;
 
-
-import org.springframework.stereotype.Component;
+import java.util.Locale;
 
 public class IsniValidator {
 
     public boolean validate(String isni) {
 
-        final var id = isni.substring(isni.lastIndexOf("/") + 1);
+        // Normalise case so a lowercase trailing 'x' check character is accepted.
+        // This is internal to validation only - it must not mutate any stored/round-tripped value.
+        final var id = isni.substring(isni.lastIndexOf("/") + 1).toUpperCase(Locale.ROOT);
 
-        if (id == null || id.length() != 16) {
+        if (id.length() != 16) {
             return false;
         }
 

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/ContributorTypeValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/ContributorTypeValidatorTest.java
@@ -864,6 +864,104 @@ class ContributorTypeValidatorTest {
         ));
     }
 
+    @Test
+    @DisplayName("RAID-791: a checksum-invalid ISNI is rejected locally without calling contributorClient.exists()")
+    void isniVariant_checksumInvalidIdIsRejectedWithoutCallingExists() {
+        final var isniUrlPrefix = "https://isni.org/isni/";
+        final var isniValidationProperties = ContributorTypeValidationProperties.builder()
+                .urlPrefix(isniUrlPrefix)
+                .schemaUri("https://isni.org/")
+                .build();
+
+        final var isniValidator = new ContributorTypeValidator(
+                isniValidationProperties,
+                contributorClient,
+                roleValidator,
+                positionValidator,
+                "ISNI",
+                new IsniValidator()
+        );
+
+        // Same 16-character shape as a valid ISNI, but the check character does not satisfy
+        // MOD 11-2 (calculated check character for these digits is "1", not "0").
+        final var checksumInvalidIsni = isniUrlPrefix + "0000000000000000";
+
+        final var role = new ContributorRole()
+                .schemaUri(ContributorRoleSchemaUriEnum.HTTPS_CREDIT_NISO_ORG_)
+                .id(ContributorRoleIdEnum.HTTPS_CREDIT_NISO_ORG_CONTRIBUTOR_ROLES_SUPERVISION_);
+
+        final var position = new ContributorPosition()
+                .schemaUri(ContributorPositionSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_305)
+                .id(ContributorPositionIdEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_307)
+                .startDate(LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
+
+        final var contributor = new Contributor()
+                .id(checksumInvalidIsni)
+                .schemaUri(ContributorSchemaUriEnum.HTTPS_ISNI_ORG_)
+                .role(List.of(role))
+                .position(List.of(position));
+
+        when(roleValidator.validate(role, CONTRIBUTOR_INDEX, 0)).thenReturn(Collections.emptyList());
+        when(positionValidator.validate(position, CONTRIBUTOR_INDEX, 0)).thenReturn(Collections.emptyList());
+
+        final var failures = isniValidator.validate(contributor, CONTRIBUTOR_INDEX);
+
+        assertThat(failures, hasItem(
+                new ValidationFailure()
+                        .fieldId("contributor[0].id")
+                        .errorType(INVALID_VALUE_TYPE)
+                        .message(INVALID_VALUE_MESSAGE)
+        ));
+
+        verify(contributorClient, never()).exists(anyString());
+    }
+
+    @Test
+    @DisplayName("RAID-791: a checksum-valid ISNI still proceeds to contributorClient.exists()")
+    void isniVariant_checksumValidIdStillCallsExists() {
+        final var isniUrlPrefix = "https://isni.org/isni/";
+        final var isniValidationProperties = ContributorTypeValidationProperties.builder()
+                .urlPrefix(isniUrlPrefix)
+                .schemaUri("https://isni.org/")
+                .build();
+
+        final var isniValidator = new ContributorTypeValidator(
+                isniValidationProperties,
+                contributorClient,
+                roleValidator,
+                positionValidator,
+                "ISNI",
+                new IsniValidator()
+        );
+
+        final var checksumValidIsni = isniUrlPrefix + "0000000121032683";
+
+        final var role = new ContributorRole()
+                .schemaUri(ContributorRoleSchemaUriEnum.HTTPS_CREDIT_NISO_ORG_)
+                .id(ContributorRoleIdEnum.HTTPS_CREDIT_NISO_ORG_CONTRIBUTOR_ROLES_SUPERVISION_);
+
+        final var position = new ContributorPosition()
+                .schemaUri(ContributorPositionSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_305)
+                .id(ContributorPositionIdEnum.HTTPS_VOCABULARY_RAID_ORG_CONTRIBUTOR_POSITION_SCHEMA_307)
+                .startDate(LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
+
+        final var contributor = new Contributor()
+                .id(checksumValidIsni)
+                .schemaUri(ContributorSchemaUriEnum.HTTPS_ISNI_ORG_)
+                .role(List.of(role))
+                .position(List.of(position));
+
+        when(contributorClient.exists(checksumValidIsni)).thenReturn(true);
+        when(roleValidator.validate(role, CONTRIBUTOR_INDEX, 0)).thenReturn(Collections.emptyList());
+        when(positionValidator.validate(position, CONTRIBUTOR_INDEX, 0)).thenReturn(Collections.emptyList());
+
+        final var failures = isniValidator.validate(contributor, CONTRIBUTOR_INDEX);
+
+        assertThat(failures, empty());
+
+        verify(contributorClient).exists(checksumValidIsni);
+    }
+
     private ContributorTypeValidator validatorWith(final String urlPrefix, final String schemaUri) {
         return new ContributorTypeValidator(
                 ContributorTypeValidationProperties.builder()

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/IsniValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/IsniValidatorTest.java
@@ -32,4 +32,22 @@ class IsniValidatorTest {
 
         invalidIsni.forEach(isni -> assertThat("%s is not a valid isni".formatted(isni), validator.validate(isni), is(true)));
     }
+
+    @Test
+    void passesWithLowercaseTrailingXCheckCharacter() {
+        // Derived from the valid "...1X" fixture above, but with a lowercase check character -
+        // RAID-791 requires this to be accepted, without mutating the original value.
+        final var isniWithLowercaseX = "https://isni.org/000000000000001x";
+
+        assertThat(validator.validate(isniWithLowercaseX), is(true));
+    }
+
+    @Test
+    void failsWithChecksumInvalidIsni() {
+        // Same 16-character shape as a valid ISNI, but the check character does not satisfy
+        // MOD 11-2 (calculated check character for these digits is "1", not "0").
+        final var checksumInvalidIsni = "https://isni.org/isni/0000000000000000";
+
+        assertThat(validator.validate(checksumInvalidIsni), is(false));
+    }
 }


### PR DESCRIPTION
## Summary

Wires the previously dead `IsniValidator` into the ISNI contributor validation path so malformed ISNIs are rejected locally via ISO 27729 MOD 11-2 checksum **before** the live ISNI SRU existence check. This avoids unnecessary network round trips and returns an accurate `invalidValue` error instead of a misleading `notFound`.

JIRA: [RAID-791](https://ardc.atlassian.net/browse/RAID-791) (parent epic [RAID-789](https://ardc.atlassian.net/browse/RAID-789))

## Changes

- **`IsniValidator`** — instantiated inline in `ContributorValidationConfig` rather than as a `@Component`, to avoid a bean-name collision with the existing `isniValidator()` `@Bean` (which would throw `BeanDefinitionOverrideException` at startup). Normalises a lowercase trailing `x` check character to uppercase during validation only (no mutation of stored values).
- **`ContributorTypeValidator`** — an optional local id validator gates the ISNI path and is `null` for ORCID (ORCID behaviour unchanged). The checksum runs before `exists()`, so a malformed ISNI never calls the resolver. RAID-809 resolver-unavailable handling is preserved verbatim.
- **`InMemoryStubTestData`** — `NONEXISTENT_TEST_ISNI` is now checksum-valid (`...0028`) so the `notFound` path still exercises the resolver stub; added a checksum-invalid `MALFORMED_TEST_ISNI` (`...0000`) for the rejection test.

## Testing

- Unit test asserts `exists()` is **never** called for a checksum-invalid ISNI (`verify(..., never())`), and is still called for a valid one.
- IntTest asserts a mint with a checksum-invalid ISNI returns `400` with `invalidValue` on `contributor[0].id`.
- Full local `:api-svc:raid-api:intTest` green (0 failures / 0 errors).
- Branch-Build-Deploy pipeline green (Api-Integration-Test + E2e-Test against the deployed branch env).
- Manual live-SRU check: known-good ISNI `0000000121032683` returns `numberOfRecords=1`; well-formed nonexistent `0000000000000028` returns `0`.

## Follow-up (out of scope)

The raid-skos SKOS definition for the ISNI contributor id scheme and the Research Vocabularies Australia republish are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)