### PR TITLE
RAID-793: add ARK (arks.org) validator for relatedObject.schemaUri

### DIFF
--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/ArkRelatedObjectIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/ArkRelatedObjectIntegrationTest.java
@@ -32,8 +32,11 @@ public class ArkRelatedObjectIntegrationTest extends AbstractIntegrationTest {
     // A normal (non-99999 NAAN) well-formed arks.org ARK, accepted by the in-memory ArkServiceStub.
     private static final String VALID_ARK = "https://arks.org/ark:/12148/cc9wq2rq";
 
-    /* confirmed sentinel values understood by the in-memory ARK stub, see
-       au.org.raid.api.service.stub.InMemoryStubTestData lines 56-57 */
+    /* Sentinel values understood by the in-memory ARK stub, mirrored here because the intTest
+       source set cannot import au.org.raid.api.service.stub.InMemoryStubTestData (NONEXISTENT_TEST_ARK
+       / SERVER_ERROR_TEST_ARK). NAAN 99999 is a reserved test NAAN (ARK Alliance spec) used only as a
+       deterministic stub trigger; the real unregistered-NAAN reject signal is host-based and not
+       specific to 99999 (see RAID-793 / ArkService.isUnregistered). */
     private static final String NONEXISTENT_TEST_ARK = "https://arks.org/ark:/99999/not-found";
     private static final String SERVER_ERROR_TEST_ARK = "https://arks.org/ark:/99999/server-error";
 

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/ArkRelatedObjectIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/ArkRelatedObjectIntegrationTest.java
@@ -1,0 +1,147 @@
+package au.org.raid.inttest;
+
+import au.org.raid.idl.raidv2.model.RelatedObject;
+import au.org.raid.idl.raidv2.model.RelatedObjectCategory;
+import au.org.raid.idl.raidv2.model.RelatedObjectCategoryIdEnum;
+import au.org.raid.idl.raidv2.model.RelatedObjectCategorySchemaUriEnum;
+import au.org.raid.idl.raidv2.model.RelatedObjectSchemaUriEnum;
+import au.org.raid.idl.raidv2.model.RelatedObjectType;
+import au.org.raid.idl.raidv2.model.RelatedObjectTypeIdEnum;
+import au.org.raid.idl.raidv2.model.RelatedObjectTypeSchemaUriEnum;
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import au.org.raid.inttest.service.RaidApiValidationException;
+import feign.RetryableException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static au.org.raid.fixtures.TestConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ArkRelatedObjectIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String RELATED_OBJECT_CATEGORY_SCHEMA_URI =
+            "https://vocabulary.raid.org/relatedObject.category.schemaUri/386";
+    private static final String INPUT_RELATED_OBJECT_CATEGORY_ID =
+            "https://vocabulary.raid.org/relatedObject.category.id/191";
+
+    private static final String ARK_SCHEMA_URI = "https://arks.org/";
+
+    // A normal (non-99999 NAAN) well-formed arks.org ARK, accepted by the in-memory ArkServiceStub.
+    private static final String VALID_ARK = "https://arks.org/ark:/12148/cc9wq2rq";
+
+    /* confirmed sentinel values understood by the in-memory ARK stub, see
+       au.org.raid.api.service.stub.InMemoryStubTestData lines 56-57 */
+    private static final String NONEXISTENT_TEST_ARK = "https://arks.org/ark:/99999/not-found";
+    private static final String SERVER_ERROR_TEST_ARK = "https://arks.org/ark:/99999/server-error";
+
+    private static final String INVALID_ARK_URL_MESSAGE =
+            "has invalid/unsupported value - must be a valid ARK URL (e.g. https://arks.org/ark:/12148/cc9wq2rq)";
+
+    private RelatedObject arkRelatedObject(String id) {
+        return new RelatedObject()
+                .id(id)
+                .schemaUri(RelatedObjectSchemaUriEnum.fromValue(ARK_SCHEMA_URI))
+                .type(new RelatedObjectType()
+                        .id(RelatedObjectTypeIdEnum.fromValue(BOOK_CHAPTER_RELATED_OBJECT_TYPE))
+                        .schemaUri(RelatedObjectTypeSchemaUriEnum.fromValue(RELATED_OBJECT_TYPE_SCHEMA_URI)))
+                .category(List.of(new RelatedObjectCategory()
+                        .id(RelatedObjectCategoryIdEnum.fromValue(INPUT_RELATED_OBJECT_CATEGORY_ID))
+                        .schemaUri(RelatedObjectCategorySchemaUriEnum.fromValue(RELATED_OBJECT_CATEGORY_SCHEMA_URI))));
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with a valid ARK related object succeeds")
+    void validArkRelatedObject() {
+        createRequest.setRelatedObject(List.of(arkRelatedObject(VALID_ARK)));
+
+        try {
+            final var result = raidApi.mintRaid(createRequest);
+            final var raid = result.getBody();
+            assertThat(raid).isNotNull();
+            assertThat(raid.getRelatedObject()).hasSize(1);
+            assertThat(raid.getRelatedObject().get(0).getId()).isEqualTo(VALID_ARK);
+            assertThat(raid.getRelatedObject().get(0).getSchemaUri())
+                    .isEqualTo(RelatedObjectSchemaUriEnum.fromValue(ARK_SCHEMA_URI));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with an ARK related object that the resolver reports as non-existent fails validation")
+    void nonExistentArk() {
+        createRequest.setRelatedObject(List.of(arkRelatedObject(NONEXISTENT_TEST_ARK)));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown with non-existent ARK");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures).contains(new ValidationFailure()
+                    .fieldId("relatedObject[0].id")
+                    .errorType("invalidValue")
+                    .message("uri not found"));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with an ARK id that has a too-short NAAN fails format validation")
+    void naanTooShortFailsValidation() {
+        createRequest.setRelatedObject(List.of(arkRelatedObject("https://arks.org/ark:/1234/x")));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown with ARK NAAN shorter than 5 digits");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures).contains(new ValidationFailure()
+                    .fieldId("relatedObject[0].id")
+                    .errorType("invalidValue")
+                    .message(INVALID_ARK_URL_MESSAGE));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with a bare ARK id (no arks.org host) fails format validation")
+    void bareArkWithNoHostFailsValidation() {
+        createRequest.setRelatedObject(List.of(arkRelatedObject("ark:/12148/cc9wq2rq")));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown with bare ARK id lacking the arks.org host");
+        } catch (RaidApiValidationException e) {
+            final var failures = e.getFailures();
+            assertThat(failures).hasSize(1);
+            assertThat(failures).contains(new ValidationFailure()
+                    .fieldId("relatedObject[0].id")
+                    .errorType("invalidValue")
+                    .message(INVALID_ARK_URL_MESSAGE));
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with an ARK related object fails with 503 when the resolver is unavailable, not a validation error")
+    void arkServerError() {
+        createRequest.setRelatedObject(List.of(arkRelatedObject(SERVER_ERROR_TEST_ARK)));
+
+        try {
+            raidApi.mintRaid(createRequest);
+            fail("No exception thrown when ARK resolver is unavailable");
+        } catch (RetryableException e) {
+            assertThat(e.status()).isEqualTo(503);
+        } catch (Exception e) {
+            failOnError(e);
+        }
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/Api.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/Api.java
@@ -74,6 +74,35 @@ public class Api {
         return new RestTemplate(requestFactory);
     }
 
+    /**
+     * RestTemplate for the ARK (arks.org) resolver check (RAID-793). Shares the same bounded
+     * connect/read timeouts as {@link #uriValidatorRestTemplate}, but with redirect-following
+     * DISABLED - the ARK existence check's signal is which host a 302 redirects to (arks.org
+     * itself = unregistered NAAN, a different host = registered NAAN), which is only visible if
+     * the redirect isn't transparently followed first.
+     */
+    @Bean
+    public RestTemplate arkResolverRestTemplate(
+            @Value("${raid.uri-validation.connect-timeout:5s}") final Duration connectTimeout,
+            @Value("${raid.uri-validation.read-timeout:10s}") final Duration readTimeout) {
+
+        // SimpleClientHttpRequestFactory doesn't expose HttpURLConnection#setInstanceFollowRedirects
+        // itself (unlike the JVM-wide static HttpURLConnection#setFollowRedirects), so it's
+        // overridden here via the connection-preparation hook it does expose.
+        final var requestFactory = new SimpleClientHttpRequestFactory() {
+            @Override
+            protected void prepareConnection(final java.net.HttpURLConnection connection, final String httpMethod)
+                    throws java.io.IOException {
+                super.prepareConnection(connection, httpMethod);
+                connection.setInstanceFollowRedirects(false);
+            }
+        };
+        requestFactory.setConnectTimeout(connectTimeout);
+        requestFactory.setReadTimeout(readTimeout);
+
+        return new RestTemplate(requestFactory);
+    }
+
     public static void main(String[] args) {
         SpringApplication.run(Api.class, args);
     }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/bean/ExternalPidService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/bean/ExternalPidService.java
@@ -7,6 +7,7 @@ import au.org.raid.api.client.contributor.orcid.OrcidRequestEntityFactory;
 import au.org.raid.api.client.ror.RorClient;
 import au.org.raid.api.client.ror.RorRequestEntityFactory;
 import au.org.raid.api.config.properties.StubProperties;
+import au.org.raid.api.service.ark.ArkService;
 import au.org.raid.api.service.doi.DoiService;
 import au.org.raid.api.service.handle.HandleService;
 import au.org.raid.api.service.rrid.RridService;
@@ -138,6 +139,20 @@ public class ExternalPidService {
         }
 
         return new WebArchiveService(restTemplate, clock, availabilityUrl);
+    }
+
+    @Bean
+    @Primary
+    public ArkService arkService(
+            StubProperties stubProperties,
+            @Qualifier("arkResolverRestTemplate") RestTemplate restTemplate
+    ) {
+        if (stubProperties.getArk() != null && stubProperties.getArk().isEnabled()) {
+            log.warn("using the in-memory ARK service");
+            return new ArkServiceStub(stubProperties.getArk().getDelay());
+        }
+
+        return new ArkService(restTemplate);
     }
 
     @Bean

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/properties/StubProperties.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/properties/StubProperties.java
@@ -18,6 +18,7 @@ public class StubProperties {
     private Isni isni;
     private Ror ror;
     private WebArchive webArchive;
+    private Ark ark;
 
     @Data
     public static class Doi {
@@ -73,6 +74,12 @@ public class StubProperties {
 
     @Data
     public static class WebArchive {
+        private boolean enabled;
+        private Long delay;
+    }
+
+    @Data
+    public static class Ark {
         private boolean enabled;
         private Long delay;
     }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/ark/ArkService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/ark/ArkService.java
@@ -1,0 +1,183 @@
+package au.org.raid.api.service.ark;
+
+import au.org.raid.api.exception.ResolverUnavailableException;
+import au.org.raid.api.validator.UriValidator;
+import au.org.raid.idl.raidv2.model.UnavailableResolver;
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static au.org.raid.api.endpoint.message.ValidationMessage.INVALID_VALUE_MESSAGE;
+import static au.org.raid.api.endpoint.message.ValidationMessage.INVALID_VALUE_TYPE;
+import static au.org.raid.api.endpoint.message.ValidationMessage.URI_DOES_NOT_EXIST;
+import static au.org.raid.api.exception.ResolverUnavailableException.toUnavailableResolver;
+
+/**
+ * Existence check for {@code https://arks.org/} relatedObject URLs (RAID-793).
+ * <p>
+ * ARK resolution moved from n2t.net to arks.org. n2t.net now blindly 302-redirects every
+ * syntactically-valid ARK (real or fake) to arks.org, so it can no longer be used as an
+ * existence check. arks.org itself gives a clean NAAN-registry signal instead:
+ * <ul>
+ *     <li>A <b>registered</b> NAAN: a no-follow GET to {@code https://arks.org/ark:NAAN/name}
+ *     302s with a {@code Location} whose host is a real Name Mapping Authority - i.e. NOT
+ *     arks.org (e.g. ezid.cdlib.org, ark.bnf.fr).</li>
+ *     <li>An <b>unregistered</b> NAAN: the 302 {@code Location} is a self-loop back to arks.org
+ *     (or one of its subdomains), including relative/protocol-relative Locations resolved
+ *     against the request URI.</li>
+ * </ul>
+ * This deliberately implements {@link UriValidator} directly rather than extending
+ * {@link au.org.raid.api.validator.AbstractUriValidator}: the base class's HEAD/404 machinery
+ * doesn't fit the resolver semantics here - the existence signal is which host a 302 redirects
+ * to, not the HTTP status of the resolver call itself, and following the redirect (as the
+ * shared {@code uriValidatorRestTemplate} does) would hide that signal. What is reused is the
+ * {@link UriValidator} contract and {@link ResolverUnavailableException} for the fail-closed
+ * RAID-809 pattern.
+ * <p>
+ * Requires a {@link RestTemplate} configured with redirect-following DISABLED
+ * (see {@code arkResolverRestTemplate} in {@code Api.java}) so the {@code Location} header of a
+ * 302 response is visible rather than transparently followed.
+ */
+@Slf4j
+public class ArkService implements UriValidator {
+    /*
+     * https://arks.org/ark:/NAAN/name[/qualifier], with an optional slash after "ark:" (both
+     * ark:12148/x and ark:/12148/x resolve). NAAN is 5-9 digits (ARK Alliance spec). The host
+     * must be arks.org - bare/unqualified ARKs are not accepted, the submitted id must be a
+     * fully-qualified resolvable URL.
+     *
+     * Anchored with \z (not $) so a trailing newline can't sneak past the end-of-input check -
+     * Java's $ matches immediately before a trailing line terminator, so "...\n" would otherwise
+     * pass.
+     */
+    protected static final Pattern ARK_URL_PATTERN =
+            Pattern.compile("^https://arks\\.org/ark:/?\\d{5,9}/\\S+\\z");
+
+    protected static final String INVALID_ARK_URL_MESSAGE =
+            INVALID_VALUE_MESSAGE + " - " + "must be a valid ARK URL (e.g. https://arks.org/ark:/12148/cc9wq2rq)";
+
+    private final RestTemplate restTemplate;
+
+    public ArkService(final RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    protected String resolverName() {
+        return "ARK";
+    }
+
+    @Override
+    public List<ValidationFailure> validate(final String uri, final String fieldId) {
+        if (!ARK_URL_PATTERN.matcher(uri).matches()) {
+            return List.of(new ValidationFailure()
+                    .fieldId(fieldId)
+                    .errorType(INVALID_VALUE_TYPE)
+                    .message(INVALID_ARK_URL_MESSAGE));
+        }
+
+        try {
+            final var response = restTemplate.exchange(URI.create(uri), HttpMethod.GET, HttpEntity.EMPTY, Void.class);
+            return validateResponse(response, uri, fieldId);
+        } catch (RestClientException e) {
+            // Covers HttpClientErrorException/HttpServerErrorException (4xx/5xx from arks.org
+            // itself) and ResourceAccessException (connect/read timeout, DNS failure, connection
+            // refused). Any of these means the resolver, not the ARK, is at fault (RAID-809) -
+            // we can't determine registration from a resolver that isn't working.
+            log.error("External resolver check failed during ARK URI validation of {}", uri, e);
+            throw new ResolverUnavailableException(
+                    List.of(toUnavailableResolver(fieldId, uri, resolverName(), e)));
+        } catch (IllegalArgumentException e) {
+            // URI.create(uri) throws IllegalArgumentException (not a RestClientException) for a
+            // syntactically-invalid URI that nonetheless matched ARK_URL_PATTERN (e.g. a name
+            // containing an unencoded '{'/'}'). Fail closed the same way as a resolver failure
+            // rather than let it escape as an uncaught 500.
+            log.error("Malformed ARK URI could not be resolved: {}", uri, e);
+            throw new ResolverUnavailableException(List.of(new UnavailableResolver()
+                    .field(fieldId)
+                    .value(uri)
+                    .resolver(resolverName())
+                    .downstreamMessage("%s resolve %s -> malformed URI".formatted(resolverName(), uri))));
+        }
+    }
+
+    private List<ValidationFailure> validateResponse(
+            final ResponseEntity<Void> response, final String uri, final String fieldId) {
+        final var status = response.getStatusCode();
+
+        if (!status.is3xxRedirection()) {
+            // Not a redirect at all - including an unexpected 2xx from arks.org itself - means we
+            // could not determine registration from a working resolver.
+            log.error("Unexpected non-redirect response ({}) from arks.org during ARK URI validation of {}",
+                    status, uri);
+            throw new ResolverUnavailableException(List.of(
+                    unavailableResolver(fieldId, uri, status.value(), "unexpected response status")));
+        }
+
+        try {
+            // HttpHeaders.getLocation() (and URI.resolve() against a malformed value) throws
+            // IllegalArgumentException - NOT a RestClientException - on an unparseable Location
+            // header, so this must be guarded separately from the RestClientException catch around
+            // the HTTP call - otherwise it escapes as an uncaught 500 instead of the fail-closed
+            // 503 every other resolver failure gets here.
+            final var location = response.getHeaders().getLocation();
+
+            if (location == null) {
+                log.error("Redirect response ({}) with no Location header during ARK URI validation of {}",
+                        status, uri);
+                throw new ResolverUnavailableException(List.of(
+                        unavailableResolver(fieldId, uri, status.value(), "redirect with no Location header")));
+            }
+
+            if (isUnregistered(uri, location)) {
+                return List.of(new ValidationFailure()
+                        .fieldId(fieldId)
+                        .errorType(INVALID_VALUE_TYPE)
+                        .message(URI_DOES_NOT_EXIST));
+            }
+
+            return List.of();
+        } catch (IllegalArgumentException e) {
+            log.error("Redirect response ({}) with an unparseable/unresolvable Location header during ARK URI validation of {}",
+                    status, uri, e);
+            throw new ResolverUnavailableException(List.of(
+                    unavailableResolver(fieldId, uri, status.value(), "unparseable Location header")));
+        }
+    }
+
+    /**
+     * An unregistered NAAN redirects back to arks.org itself (a self-loop, possibly via a
+     * relative or protocol-relative Location, or a www./other arks.org subdomain). A registered
+     * NAAN redirects to a genuinely different host - the Name Mapping Authority that owns the
+     * NAAN.
+     * <p>
+     * The Location header is resolved against the submitted request URI before inspecting its
+     * host, so a relative Location (host == null on the raw header value) is correctly treated as
+     * a same-host self-loop rather than false-ACCEPTed. A null resolved host (which should not be
+     * possible once resolved against an absolute base) is treated as unregistered - fail-safe
+     * rather than a silent accept.
+     */
+    private boolean isUnregistered(final String uri, final URI location) {
+        final var resolved = URI.create(uri).resolve(location);
+        final var host = resolved.getHost();
+
+        return host == null || "arks.org".equalsIgnoreCase(host) || host.toLowerCase().endsWith(".arks.org");
+    }
+
+    private UnavailableResolver unavailableResolver(
+            final String fieldId, final String uri, final int status, final String reason) {
+        return new UnavailableResolver()
+                .field(fieldId)
+                .value(uri)
+                .resolver(resolverName())
+                .downstreamStatus(status)
+                .downstreamMessage("%s resolve %s -> %d (%s)".formatted(resolverName(), uri, status, reason));
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/ArkServiceStub.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/ArkServiceStub.java
@@ -1,0 +1,70 @@
+package au.org.raid.api.service.stub;
+
+import au.org.raid.api.exception.ResolverUnavailableException;
+import au.org.raid.api.service.ark.ArkService;
+import au.org.raid.idl.raidv2.model.UnavailableResolver;
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static au.org.raid.api.endpoint.message.ValidationMessage.INVALID_VALUE_TYPE;
+import static au.org.raid.api.endpoint.message.ValidationMessage.URI_DOES_NOT_EXIST;
+import static au.org.raid.api.service.stub.InMemoryStubTestData.NONEXISTENT_TEST_ARK;
+import static au.org.raid.api.service.stub.InMemoryStubTestData.SERVER_ERROR_TEST_ARK;
+import static au.org.raid.api.util.ObjectUtil.areEqual;
+
+@Slf4j
+public class ArkServiceStub extends ArkService {
+    private final Long delayMilliseconds;
+
+    public ArkServiceStub(final Long delayMilliseconds) {
+        super(null);
+        this.delayMilliseconds = delayMilliseconds != null ? delayMilliseconds : 0L;
+    }
+
+    @Override
+    @SneakyThrows
+    public List<ValidationFailure> validate(final String uri, final String fieldId) {
+        final var failures = new ArrayList<ValidationFailure>();
+
+        if (!ARK_URL_PATTERN.matcher(uri).matches()) {
+            failures.add(new ValidationFailure()
+                    .fieldId(fieldId)
+                    .errorType(INVALID_VALUE_TYPE)
+                    .message(INVALID_ARK_URL_MESSAGE));
+            return failures;
+        }
+
+        log.debug("delay {}", delayMilliseconds);
+        log.debug("simulate ARK validation check");
+
+        final var start = Instant.now();
+        Thread.sleep(delayMilliseconds);
+        final var end = Instant.now();
+        final var duration = Duration.between(start, end);
+        log.info("request to {} took {}.{} seconds", uri, duration.getSeconds(), duration.getNano());
+
+        if (areEqual(uri, NONEXISTENT_TEST_ARK)) {
+            failures.add(new ValidationFailure()
+                    .fieldId(fieldId)
+                    .errorType(INVALID_VALUE_TYPE)
+                    .message(URI_DOES_NOT_EXIST));
+        } else if (areEqual(uri, SERVER_ERROR_TEST_ARK)) {
+            throw new ResolverUnavailableException(List.of(
+                    new UnavailableResolver()
+                            .field(fieldId)
+                            .value(uri)
+                            .resolver(resolverName())
+                            .downstreamStatus(503)
+                            .downstreamMessage("%s resolve %s -> 503".formatted(resolverName(), uri))
+            ));
+        }
+
+        return failures;
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/InMemoryStubTestData.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/InMemoryStubTestData.java
@@ -51,8 +51,13 @@ public class InMemoryStubTestData {
     public static String SERVER_ERROR_TEST_WEB_ARCHIVE =
             "https://web.archive.org/web/20200101000000/https://server-error.example.com";
 
-    // NAAN 99999 is reserved (per the ARK Alliance spec) for test/example use and is not
-    // registered to any Name Mapping Authority, so it reliably self-loops back to arks.org.
+    // NAAN 99999 is a reserved test NAAN (ARK Alliance spec / draft-kunze-ark-43 s2.3), used here
+    // only as a deterministic stub trigger; these constants exercise the in-memory ArkServiceStub
+    // and never hit the real arks.org resolver.
+    // The "reject" signal is not specific to 99999 (verified live 2026-08-18, RAID-793): genuinely
+    // unregistered, non-reserved NAANs self-loop to https://arks.org/.info/ark:..., while reserved
+    // arks-managed NAANs (incl. 99999) self-loop to http://arks.org/ark:/... — both keep the host
+    // on arks.org, which is what ArkService.isUnregistered() matches on, so both are rejected.
     public static String NONEXISTENT_TEST_ARK = "https://arks.org/ark:/99999/not-found";
     public static String SERVER_ERROR_TEST_ARK = "https://arks.org/ark:/99999/server-error";
 }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/InMemoryStubTestData.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/stub/InMemoryStubTestData.java
@@ -50,4 +50,9 @@ public class InMemoryStubTestData {
             "https://web.archive.org/web/20200101000000/https://nonexistent.example.com";
     public static String SERVER_ERROR_TEST_WEB_ARCHIVE =
             "https://web.archive.org/web/20200101000000/https://server-error.example.com";
+
+    // NAAN 99999 is reserved (per the ARK Alliance spec) for test/example use and is not
+    // registered to any Name Mapping Authority, so it reliably self-loops back to arks.org.
+    public static String NONEXISTENT_TEST_ARK = "https://arks.org/ark:/99999/not-found";
+    public static String SERVER_ERROR_TEST_ARK = "https://arks.org/ark:/99999/server-error";
 }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/validator/RelatedObjectValidator.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/validator/RelatedObjectValidator.java
@@ -2,6 +2,7 @@ package au.org.raid.api.validator;
 
 import au.org.raid.api.exception.ResolverUnavailableException;
 import au.org.raid.api.repository.RelatedObjectTypeRepository;
+import au.org.raid.api.service.ark.ArkService;
 import au.org.raid.api.service.doi.DoiService;
 import au.org.raid.api.service.handle.HandleService;
 import au.org.raid.api.service.rrid.RridService;
@@ -42,12 +43,13 @@ public class RelatedObjectValidator {
     private static final String WEB_ARCHIVE_SCHEMA_URI = "https://web.archive.org/";
     private static final String HANDLE_SCHEMA_URI = "https://hdl.handle.net/";
     private static final String RRID_SCHEMA_URI = "https://scicrunch.org/resolver/";
+    private static final String ARKS_SCHEMA_URI = "https://arks.org/";
 
     private final RelatedObjectTypeValidator typeValidationService;
     private final RelatedObjectCategoryValidator categoryValidationService;
     private final Map<String, BiFunction<String, String, List<ValidationFailure>>> relatedObjectSchemaUriValidatorMap;
 
-    public RelatedObjectValidator(final RelatedObjectTypeRepository relatedObjectTypeRepository, final DoiService doiService, final HandleService handleService, final RridService rridService, final WebArchiveService webArchiveService, final RelatedObjectTypeValidator typeValidationService, final RelatedObjectCategoryValidator categoryValidationService) {
+    public RelatedObjectValidator(final RelatedObjectTypeRepository relatedObjectTypeRepository, final DoiService doiService, final HandleService handleService, final RridService rridService, final WebArchiveService webArchiveService, final ArkService arkService, final RelatedObjectTypeValidator typeValidationService, final RelatedObjectCategoryValidator categoryValidationService) {
         this.typeValidationService = typeValidationService;
         this.categoryValidationService = categoryValidationService;
 
@@ -59,6 +61,7 @@ public class RelatedObjectValidator {
         map.put(HANDLE_SCHEMA_URI, handleService::validate);
         map.put(RRID_SCHEMA_URI, rridService::validate);
         map.put(WEB_ARCHIVE_SCHEMA_URI, webArchiveService::validate);
+        map.put(ARKS_SCHEMA_URI, arkService::validate);
         this.relatedObjectSchemaUriValidatorMap = Collections.unmodifiableMap(map);
     }
 

--- a/api-svc/raid-api/src/main/resources/application-dev.yaml
+++ b/api-svc/raid-api/src/main/resources/application-dev.yaml
@@ -55,6 +55,9 @@ raid:
     web-archive:
       enabled: true
       delay: 150
+    ark:
+      enabled: true
+      delay: 150
 spring:
   security:
     oauth2:

--- a/api-svc/raid-api/src/main/resources/application.yaml
+++ b/api-svc/raid-api/src/main/resources/application.yaml
@@ -66,6 +66,9 @@ raid:
     web-archive:
       enabled: false
       delay: 150
+    ark:
+      enabled: false
+      delay: 150
   identifier:
     schema-uri: https://raid.org/
     license: Creative Commons CC-0

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/service/ark/ArkServiceTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/service/ark/ArkServiceTest.java
@@ -1,0 +1,301 @@
+package au.org.raid.api.service.ark;
+
+import au.org.raid.api.exception.ResolverUnavailableException;
+import au.org.raid.idl.raidv2.model.ValidationFailure;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ArkServiceTest {
+    private static final String FIELD_ID = "relatedObject[0].id";
+
+    private final RestTemplate restTemplate = mock(RestTemplate.class);
+    private final ArkService arkService = new ArkService(restTemplate);
+
+    private void stubRedirect(final String uri, final HttpStatus status, final String location) {
+        final var headers = new HttpHeaders();
+        if (location != null) {
+            headers.setLocation(URI.create(location));
+        }
+        final var response = new ResponseEntity<Void>(headers, status);
+        when(restTemplate.exchange(eq(URI.create(uri)), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(Void.class)))
+                .thenReturn(response);
+    }
+
+    @Test
+    @DisplayName("A 302 redirect to a different (Name Mapping Authority) host is accepted - registered NAAN")
+    void registeredNaanRedirectsToDifferentHostAccepted() {
+        final var uri = "https://arks.org/ark:/12148/cc9wq2rq";
+        stubRedirect(uri, HttpStatus.FOUND, "https://ark.bnf.fr/ark:/12148/cc9wq2rq");
+
+        final var failures = arkService.validate(uri, FIELD_ID);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("A 302 self-loop redirect back to arks.org is rejected - unregistered NAAN")
+    void unregisteredNaanSelfLoopRejected() {
+        final var uri = "https://arks.org/ark:/99999/not-found";
+        stubRedirect(uri, HttpStatus.FOUND, "https://arks.org/.info/ark:/99999/not-found");
+
+        final var failures = arkService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+
+    @Test
+    @DisplayName("A 302 to arks.org with a different (non-.info) path is still treated as unregistered")
+    void unregisteredNaanArksOrgHostAnyPathRejected() {
+        final var uri = "https://arks.org/ark:/99999/not-found";
+        stubRedirect(uri, HttpStatus.FOUND, "https://arks.org/ark:/99999/not-found");
+
+        final var failures = arkService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+
+    @Test
+    @DisplayName("NAAN too short (fewer than 5 digits) fails format validation without an HTTP call")
+    void naanTooShortFormatFailure() {
+        final var uri = "https://arks.org/ark:/1234/cc9wq2rq";
+
+        final var failures = arkService.validate(uri, FIELD_ID);
+
+        assertThat(failures, hasSize(1));
+        assertThat(failures.get(0).getFieldId(), is(FIELD_ID));
+        assertThat(failures.get(0).getErrorType(), is("invalidValue"));
+    }
+
+    @Test
+    @DisplayName("A bare ARK with no host fails format validation without an HTTP call")
+    void bareArkNoHostFormatFailure() {
+        final var uri = "ark:/12148/cc9wq2rq";
+
+        final var failures = arkService.validate(uri, FIELD_ID);
+
+        assertThat(failures, hasSize(1));
+        assertThat(failures.get(0).getFieldId(), is(FIELD_ID));
+        assertThat(failures.get(0).getErrorType(), is("invalidValue"));
+    }
+
+    @Test
+    @DisplayName("A NAAN with no leading slash after ark: is still accepted by the format check")
+    void naanWithoutLeadingSlashIsValidFormat() {
+        final var uri = "https://arks.org/ark:12148/cc9wq2rq";
+        stubRedirect(uri, HttpStatus.FOUND, "https://ark.bnf.fr/ark:12148/cc9wq2rq");
+
+        final var failures = arkService.validate(uri, FIELD_ID);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("5xx response from arks.org throws ResolverUnavailableException")
+    void serverErrorThrowsResolverUnavailable() {
+        final var uri = "https://arks.org/ark:/12148/cc9wq2rq";
+        when(restTemplate.exchange(eq(URI.create(uri)), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(Void.class)))
+                .thenThrow(HttpServerErrorException.create(
+                        HttpStatusCode.valueOf(503), "Service Unavailable", null, null, null));
+
+        final var e = assertThrows(ResolverUnavailableException.class,
+                () -> arkService.validate(uri, FIELD_ID));
+
+        assertThat(e.getUnavailableResolvers(), hasSize(1));
+        assertThat(e.getUnavailableResolvers().get(0).getResolver(), is("ARK"));
+        assertThat(e.getUnavailableResolvers().get(0).getDownstreamStatus(), is(503));
+    }
+
+    @Test
+    @DisplayName("4xx response from arks.org throws ResolverUnavailableException")
+    void clientErrorThrowsResolverUnavailable() {
+        final var uri = "https://arks.org/ark:/12148/cc9wq2rq";
+        when(restTemplate.exchange(eq(URI.create(uri)), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(Void.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatusCode.valueOf(404)));
+
+        final var e = assertThrows(ResolverUnavailableException.class,
+                () -> arkService.validate(uri, FIELD_ID));
+
+        assertThat(e.getUnavailableResolvers().get(0).getResolver(), is("ARK"));
+        assertThat(e.getUnavailableResolvers().get(0).getDownstreamStatus(), is(404));
+    }
+
+    @Test
+    @DisplayName("Timeout throws ResolverUnavailableException with resolver name ARK")
+    void timeoutThrowsResolverUnavailable() {
+        final var uri = "https://arks.org/ark:/12148/cc9wq2rq";
+        when(restTemplate.exchange(eq(URI.create(uri)), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(Void.class)))
+                .thenThrow(new ResourceAccessException("Read timed out"));
+
+        final var e = assertThrows(ResolverUnavailableException.class,
+                () -> arkService.validate(uri, FIELD_ID));
+
+        assertThat(e.getUnavailableResolvers(), hasSize(1));
+        assertThat(e.getUnavailableResolvers().get(0).getResolver(), is("ARK"));
+    }
+
+    @Test
+    @DisplayName("An unexpected 200 response from arks.org (not a redirect) throws ResolverUnavailableException")
+    void unexpected200ThrowsResolverUnavailable() {
+        final var uri = "https://arks.org/ark:/12148/cc9wq2rq";
+        when(restTemplate.exchange(eq(URI.create(uri)), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(Void.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        final var e = assertThrows(ResolverUnavailableException.class,
+                () -> arkService.validate(uri, FIELD_ID));
+
+        assertThat(e.getUnavailableResolvers(), hasSize(1));
+        assertThat(e.getUnavailableResolvers().get(0).getResolver(), is("ARK"));
+    }
+
+    @Test
+    @DisplayName("A redirect with no Location header throws ResolverUnavailableException")
+    void redirectWithNoLocationThrowsResolverUnavailable() {
+        final var uri = "https://arks.org/ark:/12148/cc9wq2rq";
+        stubRedirect(uri, HttpStatus.FOUND, null);
+
+        final var e = assertThrows(ResolverUnavailableException.class,
+                () -> arkService.validate(uri, FIELD_ID));
+
+        assertThat(e.getUnavailableResolvers(), hasSize(1));
+        assertThat(e.getUnavailableResolvers().get(0).getResolver(), is("ARK"));
+    }
+
+    @Test
+    @DisplayName("The submitted URL is never rewritten - the same string that was submitted is the one checked")
+    void submittedUrlIsNotRewritten() {
+        final var uri = "https://arks.org/ark:/12148/cc9wq2rq/qualifier";
+        stubRedirect(uri, HttpStatus.FOUND, "https://ark.bnf.fr/ark:/12148/cc9wq2rq/qualifier");
+
+        final var failures = arkService.validate(uri, FIELD_ID);
+
+        assertThat(failures, empty());
+        // stubRedirect's `eq(URI.create(uri))` matcher on restTemplate.exchange already asserts
+        // the exact submitted uri was used for the resolver call; verifying no other overload was
+        // invoked confirms no rewritten variant was ever sent.
+        org.mockito.Mockito.verify(restTemplate)
+                .exchange(eq(URI.create(uri)), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(Void.class));
+    }
+
+    @Test
+    @DisplayName("A relative Location header is resolved against the request URI and treated as an unregistered self-loop")
+    void relativeLocationTreatedAsUnregistered() {
+        final var uri = "https://arks.org/ark:/99999/not-found";
+        stubRedirect(uri, HttpStatus.FOUND, "/ark:/99999/not-found");
+
+        final var failures = arkService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+
+    @Test
+    @DisplayName("A www.arks.org subdomain self-loop Location is rejected as unregistered")
+    void wwwSubdomainSelfLoopRejected() {
+        final var uri = "https://arks.org/ark:/99999/not-found";
+        stubRedirect(uri, HttpStatus.FOUND, "https://www.arks.org/ark:/99999/not-found");
+
+        final var failures = arkService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+
+    @Test
+    @DisplayName("A protocol-relative Location back to arks.org is rejected as unregistered")
+    void protocolRelativeSelfLoopRejected() {
+        final var uri = "https://arks.org/ark:/99999/not-found";
+        stubRedirect(uri, HttpStatus.FOUND, "//arks.org/ark:/99999/not-found");
+
+        final var failures = arkService.validate(uri, FIELD_ID);
+
+        assertThat(failures, is(List.of(
+                new ValidationFailure()
+                        .fieldId(FIELD_ID)
+                        .errorType("invalidValue")
+                        .message("uri not found")
+        )));
+    }
+
+    @Test
+    @DisplayName("A genuine off-host NMA redirect whose path happens to contain /.info/ is still accepted")
+    void offHostRedirectWithInfoInPathAccepted() {
+        final var uri = "https://arks.org/ark:/12148/cc9wq2rq";
+        stubRedirect(uri, HttpStatus.FOUND, "https://ark.bnf.fr/.info/ark:/12148/cc9wq2rq");
+
+        final var failures = arkService.validate(uri, FIELD_ID);
+
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("A malformed/unparseable Location header throws ResolverUnavailableException, not a 500")
+    void malformedLocationThrowsResolverUnavailable() {
+        final var uri = "https://arks.org/ark:/12148/cc9wq2rq";
+        final var headers = mock(HttpHeaders.class);
+        when(headers.getLocation()).thenThrow(new IllegalArgumentException("Invalid location header"));
+        @SuppressWarnings("unchecked")
+        final var response = (ResponseEntity<Void>) mock(ResponseEntity.class);
+        when(response.getStatusCode()).thenReturn(HttpStatus.FOUND);
+        when(response.getHeaders()).thenReturn(headers);
+        when(restTemplate.exchange(eq(URI.create(uri)), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(Void.class)))
+                .thenReturn(response);
+
+        final var e = assertThrows(ResolverUnavailableException.class,
+                () -> arkService.validate(uri, FIELD_ID));
+
+        assertThat(e.getUnavailableResolvers(), hasSize(1));
+        assertThat(e.getUnavailableResolvers().get(0).getResolver(), is("ARK"));
+    }
+
+    @Test
+    @DisplayName("An ARK name containing '{' is handled without a 500 (resolver-unavailable, not an uncaught exception)")
+    void nameWithBraceHandledWithoutServerError() {
+        final var uri = "https://arks.org/ark:/12148/{foo}";
+
+        final var e = assertThrows(ResolverUnavailableException.class,
+                () -> arkService.validate(uri, FIELD_ID));
+
+        assertThat(e.getUnavailableResolvers(), hasSize(1));
+        assertThat(e.getUnavailableResolvers().get(0).getResolver(), is("ARK"));
+    }
+}

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/validator/RelatedObjectValidatorTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/validator/RelatedObjectValidatorTest.java
@@ -1,6 +1,7 @@
 package au.org.raid.api.validator;
 
 import au.org.raid.api.exception.ResolverUnavailableException;
+import au.org.raid.api.service.ark.ArkService;
 import au.org.raid.api.service.doi.DoiService;
 import au.org.raid.api.service.handle.HandleService;
 import au.org.raid.api.service.rrid.RridService;
@@ -54,6 +55,9 @@ class RelatedObjectValidatorTest {
 
     @Mock
     private WebArchiveService webArchiveService;
+
+    @Mock
+    private ArkService arkService;
 
     @InjectMocks
     private RelatedObjectValidator validationService;

--- a/documentation/20260818-raid-793-ark-validator.md
+++ b/documentation/20260818-raid-793-ark-validator.md
@@ -1,0 +1,56 @@
+# RAID-793: ARK (arks.org) validator for relatedObject.schemaUri
+
+- **JIRA (Story):** [RAID-793](https://ardc.atlassian.net/browse/RAID-793)
+- **JIRA (parent epic):** [RAID-789](https://ardc.atlassian.net/browse/RAID-789)
+- **PR (raid-au):** [#616](https://github.com/au-research/raid-au/pull/616)
+- **PR (CDK companion, raido-v2-aws-private):** [#38](https://github.com/au-research/raido-v2-aws-private/pull/38) (merged)
+- **Date:** 2026-08-18
+
+## What changed
+
+Added validation for ARK related-object identifiers (`relatedObject.schemaUri = https://arks.org/`). ARKs were previously rejected because `https://arks.org/`, although already seeded in the `related_object_schema` vocabulary (V29) and present as `SchemaValues.ARKS_SCHEMA`, was not registered in the `RelatedObjectValidator` dispatch map.
+
+New and changed code (raid-au):
+
+- **`service/ark/ArkService.java`** (new) — the validator. Implements `UriValidator` directly (following the `WebArchiveService` precedent) because its resolver semantics do not fit the `AbstractUriValidator` HEAD/404 model.
+- **`service/ark/ArkServiceStub.java`** (new) and stub wiring — `raid.stub.ark.enabled`, `StubProperties.Ark`, `InMemoryStubTestData` constants, `ExternalPidService` bean.
+- **`Api.java`** — new `arkResolverRestTemplate` bean with redirect-following disabled (needed to inspect the `Location` header), same bounded timeouts as the shared resolver template.
+- **`validator/RelatedObjectValidator.java`** — registered `https://arks.org/` in the dispatch map.
+- **Tests** — `ArkServiceTest` (unit) and `ArkRelatedObjectIntegrationTest` (intTest).
+
+No Flyway migration was required. DataCite mapping already emits `relatedIdentifierType = "ARK"` and is regression-covered.
+
+## Why this approach (and why not the ticket's original design)
+
+The ticket originally specified a dual-resolver model: try the published ARK domain first, fall back to n2t.net, accept if either resolves. Live-resolver verification (recorded as a comment on RAID-793) showed that model is no longer valid:
+
+- The ARK Alliance migrated the global resolver from **n2t.net to arks.org**. n2t.net now blindly 302-redirects **every** syntactically-valid ARK, real or fabricated, to arks.org. It gives no existence signal, so an n2t.net fallback would accept invalid ARKs.
+- Published Name Mapping Authority (NMA) domains (for example `ark.bnf.fr`, `gallica.bnf.fr`) are bot-protected and return 403 to non-browser clients, so a server-side HEAD/GET cannot rely on a 200.
+
+The implemented design is a single-resolver **NAAN-registry check** against arks.org:
+
+1. Format check: fully-qualified `https://arks.org/ark:[/]NAAN/name`, NAAN 5 to 9 digits, no bare ARKs (regex anchored with `\z`).
+2. No-follow GET to arks.org and inspect the redirect `Location` (resolved against the request URI):
+   - redirects **off-host** to a real NMA (host is not `arks.org` and not `*.arks.org`) -> registered NAAN -> **accept**;
+   - **self-loops** back to the arks.org registrable domain (or a null/relative host after resolution) -> unregistered NAAN -> **reject** (400).
+3. Fail-closed per RAID-809: client errors -> 400; downstream/resolver failures (timeout, DNS, 5xx, unparseable or missing `Location`, or a template-breaking URI) -> `ResolverUnavailableException` (503). The validator never falsely rejects on a transient outage.
+
+This validates NAAN registration, not exact-object existence (object-level checks are infeasible because the NMAs are bot-protected). The submitted URL is stored as-is and never rewritten.
+
+## Deployment dependency
+
+The new `raid.stub.ark.enabled` flag required a companion in the CDK (raido-v2-aws-private): `branch-api-stack.ts` and `config/environment-properties.ts`, set to `true` for test/branch and `false` for demo/stage/prod, mirroring the RAID-816 web-archive-stub companion. Without it, the branch and test environments run the ARK intTests against the real arks.org resolver and fail deterministically (the stub-only 503 path).
+
+The companion (PR #38) was merged to `main`, then the branch stack (`BranchApi-raid-793`) was deployed manually with `cdk deploy` (merging to main does not self-deploy). The Branch-Build-Deploy pipeline for `feature/RAID-793` is green (execution `6ce2510b`) with the ARK intTest passing and `raid.stub.ark.enabled=true` confirmed live on the branch task definition.
+
+## Testing
+
+- Full unit test suite green, including `ArkServiceTest` (registered/unregistered NAAN, relative and protocol-relative and subdomain self-loops, off-host redirect with `/.info/` in path, format failures, and the 503 fail-closed paths).
+- Full intTest suite green locally: 202 tests, 0 failures.
+- Branch pipeline intTests green after the CDK stub companion was deployed.
+- Live-resolver verification (NFR) performed and documented on RAID-793.
+
+## Follow-ups (not in this PR)
+
+- Update the SKOS definition for arks.org and the public docs to say ARK is now accepted and validated via arks.org NAAN registration (not via resolving the published URL).
+- The `metadata.raid.org` ARK entry is Matthias's action.


### PR DESCRIPTION
## Summary

Adds an ARK/arks.org validator for `relatedObject.schemaUri = https://arks.org/`. Validates via an arks.org NAAN-registry check — a no-follow GET to arks.org; if it redirects off-host to a real Name Mapping Authority the NAAN is registered (accept), if it self-loops back to the arks.org registrable domain it's unregistered (reject, 400).

## Why not the original n2t.net dual-resolver model

Live testing showed n2t.net now blindly 302-redirects every ARK (real or fake) to arks.org, so it gives no existence signal and would accept invalid ARKs. Published NMA domains are bot-protected (403 to non-browser clients). Full live-resolver findings are recorded as a comment on RAID-793.

## Fail-closed per RAID-809

Client errors → 400, resolver/downstream failures (timeout/DNS/5xx/unparseable Location) → 503.

## Migrations

No Flyway migration needed (`https://arks.org/` already seeded in V29 / SchemaValues.ARKS_SCHEMA). DataCite mapping already emits relatedIdentifierType "ARK" (regression-covered).

## Tests

New unit tests (ArkServiceTest, incl. redirect-host edge cases) + intTest (ArkRelatedObjectIntegrationTest). Full unit suite and full intTest suite green locally (202 intTests, 0 failures).

## Dependency (satisfied)

The CDK stub companion `raid.stub.ark.enabled` is merged (raido-v2-aws-private PR #38) and the Branch-Build-Deploy pipeline for this branch is GREEN (execution 6ce2510b) with the ARK intTest passing.

## Links

- [RAID-793](https://ardc.atlassian.net/browse/RAID-793) — ARK validator implementation
- [RAID-789](https://ardc.atlassian.net/browse/RAID-789) — Parent epic

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)