### PR TITLE
RAID-797: Emit related RAiDs with DataCite native RAiD relatedIdentifierType

### DIFF
--- a/api-svc/db/src/main/resources/db/migration/V45__resync_datacite_for_related_raids.sql
+++ b/api-svc/db/src/main/resources/db/migration/V45__resync_datacite_for_related_raids.sql
@@ -1,0 +1,19 @@
+-- RAID-797: back-fill already-minted DataCite records so their related RAiDs are
+-- re-emitted with DataCite's native "RAiD" relatedIdentifierType instead of the
+-- generic "DOI".
+--
+-- This is the targeting migration for the reusable DataCite re-sync mechanism added
+-- in RAID-832 (V44). It flags every DataCite (DOI) RAiD that references another RAiD.
+-- The re-sync worker then re-pushes each flagged record through the idempotent
+-- full-document PUT and clears the flag, so no manual step and no bespoke backfill is
+-- needed, in any environment.
+--
+-- Only DOI handles are flagged (handle like '10.%', matching DataciteService.isDoi,
+-- which checks handle.startsWith("10.")). Legacy/non-DOI handles are not registered in
+-- DataCite, so re-pushing them would be wasted work; they are deliberately left alone.
+update raid
+set datacite_resync_required = true
+where handle like '10.%'
+  and exists (
+      select 1 from related_raid rr where rr.handle = raid.handle
+  );

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/DataciteRelatedRaidMockIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/DataciteRelatedRaidMockIntegrationTest.java
@@ -1,0 +1,182 @@
+package au.org.raid.inttest;
+
+import au.org.raid.fixtures.APIFixtures;
+import au.org.raid.idl.raidv2.model.RelatedRaid;
+import au.org.raid.idl.raidv2.model.RelatedRaidType;
+import au.org.raid.idl.raidv2.model.RelatedRaidTypeIdEnum;
+import au.org.raid.idl.raidv2.model.RelatedRaidTypeSchemaUriEnum;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Black-box, non-gated companion to {@code DataciteLiveRelatedRaidIntegrationTest}
+ * (api-svc/raid-api/src/test/java/au/org/raid/api/datacite/DataciteLiveRelatedRaidIntegrationTest.java),
+ * which requires real DataCite credentials and is disabled by default. This test runs in the normal
+ * intTest suite with no external credentials, driving the full app (controller -&gt; service -&gt;
+ * DataciteAttributesDtoFactory -&gt; DataciteService -&gt; DataciteRelatedIdentifierFactory) against
+ * the local DataCite MockServer instance, and proves the outbound DataCite payload for a RAiD minted
+ * with a {@code relatedRaid} contains a {@code relatedIdentifier} of type {@code "RAiD"} (RAID-797).
+ *
+ * <p>It does not clear or override MockServer's static {@code /dois} expectations (see
+ * docker-compose/mockserver/expectations.json) - other tests, including the sentinel-title 429
+ * expectation used by {@link DataciteErrorIntegrationTest}, rely on that shared state remaining
+ * intact. Instead, it identifies its own request among any recorded traffic by embedding a unique
+ * random handle value (via the freshly minted target RAiD's identifier) and matching MockServer's
+ * recorded request bodies against it.
+ */
+public class DataciteRelatedRaidMockIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String MOCKSERVER_HOST = "localhost";
+    private static final int MOCKSERVER_PORT = 1080;
+    private static final int MOCKSERVER_CONNECT_TIMEOUT_MILLIS = 2000;
+    // MockServer 5.x unifies request/log/expectation retrieval behind /mockserver/retrieve with a
+    // `type` query param (the older /mockserver/retrieveRecordedRequests path 404s on this version).
+    private static final String MOCKSERVER_RETRIEVE_RECORDED_REQUESTS_URL =
+            "http://" + MOCKSERVER_HOST + ":" + MOCKSERVER_PORT + "/mockserver/retrieve?type=REQUESTS";
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @BeforeEach
+    void checkMockServerIsReachable() {
+        Assumptions.assumeTrue(isMockServerReachable(),
+                "mockserver not reachable - skipping DataCite related RAiD mock test");
+    }
+
+    private static boolean isMockServerReachable() {
+        try (var socket = new Socket()) {
+            socket.connect(new InetSocketAddress(MOCKSERVER_HOST, MOCKSERVER_PORT), MOCKSERVER_CONNECT_TIMEOUT_MILLIS);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    @Test
+    @DisplayName("Minting a RAiD with a relatedRaid emits a DataCite relatedIdentifier of type RAiD (RAID-797)")
+    void mintWithRelatedRaidEmitsDataciteRaidType() {
+        final var uniqueMarker = UUID.randomUUID().toString();
+
+        // 1. Mint the target RAiD that the source RAiD below will point at.
+        createRequest.getTitle().get(0).setText("RAID-797-target-" + uniqueMarker);
+
+        final var targetRaid = raidApi.mintRaid(createRequest).getBody();
+        assertThat(targetRaid).isNotNull();
+
+        final var targetHandle = targetRaid.getIdentifier().getId();
+        assertThat(targetHandle).isNotBlank();
+
+        // 2. Mint a second (source) RAiD with a relatedRaid pointing at the target's handle, using
+        // a valid related-raid type from DataciteRelatedIdentifierFactory.RAID_RELATION_TYPE_MAP.
+        final var sourceCreateRequest = APIFixtures.newCreateRequest();
+        sourceCreateRequest.getTitle().get(0).setText("RAID-797-source-" + uniqueMarker);
+        sourceCreateRequest.setRelatedRaid(List.of(new RelatedRaid()
+                .id(targetHandle)
+                .type(new RelatedRaidType()
+                        .id(RelatedRaidTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_RAID_TYPE_SCHEMA_204)
+                        .schemaUri(RelatedRaidTypeSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_RAID_TYPE_SCHEMA_367))));
+
+        final var sourceRaid = raidApi.mintRaid(sourceCreateRequest).getBody();
+        assertThat(sourceRaid).isNotNull();
+
+        // 3. Retrieve the DataCite requests MockServer recorded for the /dois route (without
+        // clearing any state) and find this test's own mint by the unique target handle embedded
+        // in its body.
+        final var recordedRequestBodies = retrieveRecordedDoisRequestBodies();
+
+        final var matchingRequestBody = recordedRequestBodies.stream()
+                .filter(body -> body != null && body.toString().contains(targetHandle))
+                .reduce((first, second) -> second) // prefer the most recent matching recorded request
+                .orElse(null);
+
+        assertThat(matchingRequestBody)
+                .as("Expected a recorded DataCite /dois request body referencing target handle %s", targetHandle)
+                .isNotNull();
+
+        final var relatedIdentifiers = matchingRequestBody.path("data").path("attributes").path("relatedIdentifiers");
+        assertThat(relatedIdentifiers.isArray()).isTrue();
+
+        final var candidates = new ArrayList<JsonNode>();
+        relatedIdentifiers.forEach(candidates::add);
+
+        final var raidRelatedIdentifier = candidates.stream()
+                .filter(node -> targetHandle.equals(node.path("relatedIdentifier").asText()))
+                .findFirst()
+                .orElse(null);
+
+        assertThat(raidRelatedIdentifier)
+                .as("Expected a relatedIdentifier entry for the target handle in the recorded DataCite request")
+                .isNotNull();
+        assertThat(raidRelatedIdentifier.path("relatedIdentifierType").asText()).isEqualTo("RAiD");
+        assertThat(raidRelatedIdentifier.path("resourceTypeGeneral").asText()).isEqualTo("Project");
+        assertThat(raidRelatedIdentifier.path("relatedIdentifier").asText()).isEqualTo(targetHandle);
+    }
+
+    private List<JsonNode> retrieveRecordedDoisRequestBodies() {
+        final var matcher = objectMapper.createObjectNode();
+        matcher.put("path", "/dois");
+        matcher.put("method", "POST");
+
+        final var headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        final var entity = new HttpEntity<>(matcher.toString(), headers);
+        final var response = restTemplate.exchange(
+                MOCKSERVER_RETRIEVE_RECORDED_REQUESTS_URL,
+                HttpMethod.PUT,
+                entity,
+                JsonNode.class);
+
+        final var body = response.getBody();
+        if (body == null || !body.isArray()) {
+            return List.of();
+        }
+
+        final var requestBodies = new ArrayList<JsonNode>();
+        body.forEach(recordedRequest -> requestBodies.add(extractJsonBody(recordedRequest)));
+        return requestBodies;
+    }
+
+    private JsonNode extractJsonBody(final JsonNode recordedRequest) {
+        final var bodyNode = recordedRequest.path("body");
+
+        if (bodyNode.isMissingNode() || bodyNode.isNull()) {
+            return null;
+        }
+
+        // MockServer represents a recorded JSON body either as the raw JSON value itself, or
+        // wrapped as {"type":"JSON", "json": {...}} / {"type":"STRING", "string": "..."} depending
+        // on version/content negotiation - handle both shapes defensively.
+        if (bodyNode.has("json")) {
+            return bodyNode.get("json");
+        }
+
+        if (bodyNode.has("string")) {
+            try {
+                return objectMapper.readTree(bodyNode.get("string").asText());
+            } catch (IOException e) {
+                return null;
+            }
+        }
+
+        return bodyNode;
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/factory/datacite/DataciteRelatedIdentifierFactory.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/factory/datacite/DataciteRelatedIdentifierFactory.java
@@ -95,7 +95,7 @@ public class DataciteRelatedIdentifierFactory {
     public DataciteRelatedIdentifier create(final RelatedRaid relatedRaid) {
         return new DataciteRelatedIdentifier()
                 .setRelatedIdentifier(relatedRaid.getId())
-                .setRelatedIdentifierType(RelatedIdentifierType.DOI.getName())
+                .setRelatedIdentifierType(RelatedIdentifierType.RAID.getName())
                 .setRelationType(RAID_RELATION_TYPE_MAP.get(relatedRaid.getType().getId()))
                 .setResourceTypeGeneral(ResourceTypeGeneral.PROJECT.getName());
     }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/vocabularies/datacite/RelatedIdentifierType.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/vocabularies/datacite/RelatedIdentifierType.java
@@ -20,6 +20,7 @@ public enum RelatedIdentifierType {
     LSID("LSID"),
     PMID("PMID"),
     PURL("PURL"),
+    RAID("RAiD"),
     RRID("RRID"),
     UPC("UPC"),
     URL("URL"),

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/datacite/DataciteLiveRelatedRaidIntegrationTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/datacite/DataciteLiveRelatedRaidIntegrationTest.java
@@ -1,0 +1,229 @@
+package au.org.raid.api.datacite;
+
+import au.org.raid.api.factory.HttpEntityFactory;
+import au.org.raid.api.factory.HttpHeadersFactory;
+import au.org.raid.api.factory.datacite.DataciteAlternateIdentifierFactory;
+import au.org.raid.api.factory.datacite.DataciteDateFactory;
+import au.org.raid.api.factory.datacite.DataciteIdentifierFactory;
+import au.org.raid.api.factory.datacite.DataciteRelatedIdentifierFactory;
+import au.org.raid.api.factory.datacite.DataciteTitleFactory;
+import au.org.raid.api.factory.datacite.DataciteTypesFactory;
+import au.org.raid.api.model.datacite.doi.DataciteAttributesDto;
+import au.org.raid.api.model.datacite.doi.DataciteCreator;
+import au.org.raid.api.model.datacite.doi.DataciteDto;
+import au.org.raid.api.model.datacite.doi.DataciteRelatedIdentifier;
+import au.org.raid.api.model.datacite.doi.DataciteRequest;
+import au.org.raid.idl.raidv2.model.Date;
+import au.org.raid.idl.raidv2.model.RelatedRaid;
+import au.org.raid.idl.raidv2.model.RelatedRaidType;
+import au.org.raid.idl.raidv2.model.RelatedRaidTypeIdEnum;
+import au.org.raid.idl.raidv2.model.RelatedRaidTypeSchemaUriEnum;
+import au.org.raid.idl.raidv2.model.Title;
+import au.org.raid.idl.raidv2.model.TitleType;
+import au.org.raid.idl.raidv2.model.TitleTypeIdEnum;
+import au.org.raid.idl.raidv2.model.TitleTypeSchemaURIEnum;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Permanent regression test guarding {@code DataciteRelatedIdentifierFactory.create(RelatedRaid)}
+ * (see RAID-797): DataCite's own {@code relatedIdentifierType} vocabulary (Metadata Schema
+ * 4.6/4.7) includes a native {@code "RAiD"} value, and the production factory now emits that
+ * value (with {@code resourceTypeGeneral = "Project"}) for every {@code relatedRaid} entry on a
+ * minted RAiD, instead of a generic/incorrect type. This test proves the REAL DataCite test API
+ * (https://api.test.datacite.org/dois) accepts that exact payload shape - it is not a stub or a
+ * MockServer expectation.
+ *
+ * <p>It builds the {@code relatedIdentifier} block via the actual, unmodified production classes
+ * ({@link DataciteRelatedIdentifierFactory}), and the surrounding DOI payload via the other
+ * zero-external-dependency Datacite factories/model classes from raid-api's main source set (title,
+ * date, types, identifier). Fields that come from ROR/ORCID/ISNI lookups (publisher, creators,
+ * contributors) are out of scope for this regression - those factories require live external HTTP
+ * clients wired through the full Spring application context - so they are populated directly with
+ * minimal valid values instead of going through {@code DataciteAttributesDtoFactory}'s ROR-backed
+ * collaborators. Only a DRAFT DOI is minted (no {@code event}, so it need not resolve), and it is
+ * deleted again immediately after assertions, leaving no residue in the DataCite test service.
+ *
+ * <p>This lives in the plain unit-test source set (not intTest) because it doesn't extend
+ * {@code AbstractIntegrationTest}, doesn't use Spring, and only needs raid-api's main classes plus
+ * a plain {@link RestTemplate} - the unit-test source set already has {@code src/main} on its
+ * classpath, so no build.gradle classpath changes are needed to exercise the real production
+ * mapping classes.
+ *
+ * <p><b>This test is INERT by default</b> so that {@code ./gradlew test} (and CI) stays green
+ * without DataCite credentials present. To run it against the real DataCite test API, set:
+ * <ul>
+ *   <li>{@code DATACITE_LIVE_TEST=true} - required to enable the test at all</li>
+ *   <li>{@code DATACITE_TEST_REPOSITORY_ID} - the DataCite test repository/client id (HTTP Basic username)</li>
+ *   <li>{@code DATACITE_TEST_PASSWORD} - the repository's password (HTTP Basic password)</li>
+ *   <li>{@code DATACITE_TEST_PREFIX} - the DOI prefix the repository may mint under, e.g. {@code 10.82841}</li>
+ *   <li>{@code DATACITE_TEST_ENDPOINT} - optional, defaults to {@code https://api.test.datacite.org/dois}</li>
+ * </ul>
+ *
+ * <p>Example:
+ * <pre>{@code
+ * DATACITE_LIVE_TEST=true \
+ * DATACITE_TEST_REPOSITORY_ID=XXXX.YYYY \
+ * DATACITE_TEST_PASSWORD=secret \
+ * DATACITE_TEST_PREFIX=10.82841 \
+ * ./gradlew :api-svc:raid-api:test --tests '*DataciteLive*'
+ * }</pre>
+ *
+ * <p>This test does not require the local dev stack (Docker/Postgres/Keycloak/API) - it talks
+ * directly to the real DataCite test API over the network.
+ */
+public class DataciteLiveRelatedRaidIntegrationTest {
+
+    private static final String DEFAULT_ENDPOINT = "https://api.test.datacite.org/dois";
+    private static final String EXPECTED_RELATED_IDENTIFIER_TYPE = "RAiD";
+    private static final String EXPECTED_RESOURCE_TYPE_GENERAL = "Project";
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final HttpEntityFactory httpEntityFactory = new HttpEntityFactory(new HttpHeadersFactory());
+
+    private final DataciteRelatedIdentifierFactory relatedIdentifierFactory = new DataciteRelatedIdentifierFactory();
+    private final DataciteTitleFactory titleFactory = new DataciteTitleFactory();
+    private final DataciteDateFactory dateFactory = new DataciteDateFactory();
+    private final DataciteTypesFactory typesFactory = new DataciteTypesFactory();
+    private final DataciteAlternateIdentifierFactory alternateIdentifierFactory = new DataciteAlternateIdentifierFactory();
+    private final DataciteIdentifierFactory identifierFactory = new DataciteIdentifierFactory();
+
+    private String repositoryId;
+    private String password;
+    private String prefix;
+    private String endpoint;
+
+    private String mintedDoi;
+
+    @BeforeEach
+    void readDataciteTestCredentials() {
+        repositoryId = System.getenv("DATACITE_TEST_REPOSITORY_ID");
+        password = System.getenv("DATACITE_TEST_PASSWORD");
+        prefix = System.getenv("DATACITE_TEST_PREFIX");
+        endpoint = System.getenv().getOrDefault("DATACITE_TEST_ENDPOINT", DEFAULT_ENDPOINT);
+    }
+
+    @AfterEach
+    void deleteDraftDoi() {
+        if (mintedDoi == null) {
+            return;
+        }
+
+        try {
+            final HttpEntity<Void> entity = httpEntityFactory.create(null, repositoryId, password);
+            restTemplate.exchange(endpoint + "/" + mintedDoi, HttpMethod.DELETE, entity, Void.class);
+        } finally {
+            mintedDoi = null;
+        }
+    }
+
+    @Test
+    @DisplayName("DataCite test API accepts a relatedRaid mapped to relatedIdentifierType RAiD")
+    @EnabledIfEnvironmentVariable(named = "DATACITE_LIVE_TEST", matches = "true")
+    void dataciteAcceptsRelatedRaidAsNativeRaidType() {
+        // A RAiD's relatedRaid entry, as it would appear on a RaidCreateRequest.
+        final var relatedRaidHandle = "https://raid.org.au/10.12345/" + UUID.randomUUID();
+
+        final var relatedRaid = new RelatedRaid()
+                .id(relatedRaidHandle)
+                .type(new RelatedRaidType()
+                        .id(RelatedRaidTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_RAID_TYPE_SCHEMA_202)
+                        .schemaUri(RelatedRaidTypeSchemaUriEnum.HTTPS_VOCABULARY_RAID_ORG_RELATED_RAID_TYPE_SCHEMA_367));
+
+        // The exact, unmodified production mapping under test - see DataciteAttributesDtoFactory,
+        // which calls this same factory method for every entry in request.getRelatedRaid().
+        final DataciteRelatedIdentifier relatedIdentifier = relatedIdentifierFactory.create(relatedRaid);
+
+        // Sanity-check our own construction before spending a network round trip on it.
+        assertThat(relatedIdentifier.getRelatedIdentifierType()).isEqualTo(EXPECTED_RELATED_IDENTIFIER_TYPE);
+        assertThat(relatedIdentifier.getResourceTypeGeneral()).isEqualTo(EXPECTED_RESOURCE_TYPE_GENERAL);
+        assertThat(relatedIdentifier.getRelatedIdentifier()).isEqualTo(relatedRaidHandle);
+
+        final var suffix = "raid797-" + UUID.randomUUID();
+        final var doi = prefix + "/" + suffix;
+
+        final var title = new Title()
+                .startDate(LocalDate.now().toString())
+                .text("RAID-797 DataCite live related RAiD regression test")
+                .type(new TitleType()
+                        .id(TitleTypeIdEnum.HTTPS_VOCABULARY_RAID_ORG_TITLE_TYPE_SCHEMA_5)
+                        .schemaUri(TitleTypeSchemaURIEnum.HTTPS_VOCABULARY_RAID_ORG_TITLE_TYPE_SCHEMA_376));
+
+        final var date = new Date(LocalDate.now().toString());
+
+        final var creator = new DataciteCreator()
+                .setName("ARDC")
+                .setNameType("Organizational");
+
+        final var relatedIdentifiers = new ArrayList<DataciteRelatedIdentifier>();
+        relatedIdentifiers.add(relatedIdentifier);
+
+        // Everything below other than relatedIdentifiers is scaffolding to make a minimal valid
+        // DataCite DOI payload - the relatedRaid mapping above is the thing under test.
+        final var attributes = new DataciteAttributesDto()
+                .setPrefix(prefix)
+                .setDoi(doi)
+                .setPublicationYear(String.valueOf(java.time.Year.now()))
+                .setTypes(typesFactory.create())
+                .setTitles(List.of(titleFactory.create(title)))
+                .setCreators(List.of(creator))
+                .setDates(List.of(dateFactory.create(date)))
+                .setContributors(List.of())
+                .setDescriptions(List.of())
+                .setRelatedIdentifiers(relatedIdentifiers)
+                .setAlternateIdentifiers(List.of())
+                .setFundingReferences(List.of())
+                .setUrl("https://raid.org.au/" + doi);
+        // No .setEvent(...) - a draft DOI does not need to resolve and can be deleted afterwards.
+
+        final var dto = new DataciteDto()
+                .setSchemaVersion("http://datacite.org/schema/kernel-4")
+                .setType("dois")
+                .setAttributes(attributes);
+        dto.getDataciteIdentifiers().add(identifierFactory.create(doi, "DOI"));
+
+        final var request = new DataciteRequest().setData(dto);
+
+        final HttpEntity<DataciteRequest> entity = httpEntityFactory.create(request, repositoryId, password);
+
+        final var response = restTemplate.exchange(endpoint, HttpMethod.POST, entity, JsonNode.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        // Remember it so @AfterEach cleans it up even if an assertion below fails.
+        mintedDoi = doi;
+
+        final JsonNode body = response.getBody();
+        assertThat(body).isNotNull();
+
+        final JsonNode createdRelatedIdentifiers = body.path("data").path("attributes").path("relatedIdentifiers");
+        assertThat(createdRelatedIdentifiers.isArray()).isTrue();
+
+        final var matching = new ArrayList<JsonNode>();
+        createdRelatedIdentifiers.forEach(matching::add);
+
+        final var createdRaidRelatedIdentifier = matching.stream()
+                .filter(node -> EXPECTED_RELATED_IDENTIFIER_TYPE.equals(node.path("relatedIdentifierType").asText()))
+                .findFirst()
+                .orElse(null);
+
+        assertThat(createdRaidRelatedIdentifier).as("DataCite should echo back a relatedIdentifier of type RAiD").isNotNull();
+        assertThat(createdRaidRelatedIdentifier.path("resourceTypeGeneral").asText()).isEqualTo(EXPECTED_RESOURCE_TYPE_GENERAL);
+        assertThat(createdRaidRelatedIdentifier.path("relatedIdentifier").asText()).isEqualTo(relatedRaidHandle);
+    }
+}

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/datacite/DataciteLiveRelatedRaidIntegrationTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/datacite/DataciteLiveRelatedRaidIntegrationTest.java
@@ -69,9 +69,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * without DataCite credentials present. To run it against the real DataCite test API, set:
  * <ul>
  *   <li>{@code DATACITE_LIVE_TEST=true} - required to enable the test at all</li>
- *   <li>{@code DATACITE_TEST_REPOSITORY_ID} - the DataCite test repository/client id (HTTP Basic username)</li>
- *   <li>{@code DATACITE_TEST_PASSWORD} - the repository's password (HTTP Basic password)</li>
- *   <li>{@code DATACITE_TEST_PREFIX} - the DOI prefix the repository may mint under, e.g. {@code 10.82841}</li>
+ *   <li>{@code DATACITE_TEST_REPOSITORY_ID} - a service point's DataCite repository/client id (HTTP
+ *       Basic username). DataCite credentials are stored per service point (the same repository id
+ *       and password {@code DataciteService} uses to authenticate to the DOIs API); any test-env
+ *       service point's credentials work here because the test calls the DataCite repository
+ *       directly.</li>
+ *   <li>{@code DATACITE_TEST_PASSWORD} - that service point's DataCite password (HTTP Basic password)</li>
+ *   <li>{@code DATACITE_TEST_PREFIX} - a DOI prefix that repository may mint under, e.g. {@code 10.82841}</li>
  *   <li>{@code DATACITE_TEST_ENDPOINT} - optional, defaults to {@code https://api.test.datacite.org/dois}</li>
  * </ul>
  *

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/factory/datacite/DataciteRelatedIdentifierFactoryTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/factory/datacite/DataciteRelatedIdentifierFactoryTest.java
@@ -595,7 +595,7 @@ public class DataciteRelatedIdentifierFactoryTest {
         final var result = dataciteRelatedIdentifierFactory.create(relatedRaid);
 
         assertThat(result.getRelatedIdentifier(), is(id));
-        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.DOI.getName()));
+        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.RAID.getName()));
         assertThat(result.getRelationType(), is(RelationType.CONTINUES.getName()));
         assertThat(result.getResourceTypeGeneral(), is(ResourceTypeGeneral.PROJECT.getName()));
     }
@@ -612,7 +612,7 @@ public class DataciteRelatedIdentifierFactoryTest {
         final var result = dataciteRelatedIdentifierFactory.create(relatedRaid);
 
         assertThat(result.getRelatedIdentifier(), is(id));
-        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.DOI.getName()));
+        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.RAID.getName()));
         assertThat(result.getRelationType(), is(RelationType.IS_CONTINUED_BY.getName()));
         assertThat(result.getResourceTypeGeneral(), is(ResourceTypeGeneral.PROJECT.getName()));
     }
@@ -629,7 +629,7 @@ public class DataciteRelatedIdentifierFactoryTest {
         final var result = dataciteRelatedIdentifierFactory.create(relatedRaid);
 
         assertThat(result.getRelatedIdentifier(), is(id));
-        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.DOI.getName()));
+        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.RAID.getName()));
         assertThat(result.getRelationType(), is(RelationType.IS_PART_OF.getName()));
         assertThat(result.getResourceTypeGeneral(), is(ResourceTypeGeneral.PROJECT.getName()));
     }
@@ -646,7 +646,7 @@ public class DataciteRelatedIdentifierFactoryTest {
         final var result = dataciteRelatedIdentifierFactory.create(relatedRaid);
 
         assertThat(result.getRelatedIdentifier(), is(id));
-        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.DOI.getName()));
+        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.RAID.getName()));
         assertThat(result.getRelationType(), is(RelationType.HAS_PART.getName()));
         assertThat(result.getResourceTypeGeneral(), is(ResourceTypeGeneral.PROJECT.getName()));
     }
@@ -663,7 +663,7 @@ public class DataciteRelatedIdentifierFactoryTest {
         final var result = dataciteRelatedIdentifierFactory.create(relatedRaid);
 
         assertThat(result.getRelatedIdentifier(), is(id));
-        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.DOI.getName()));
+        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.RAID.getName()));
         assertThat(result.getRelationType(), is(RelationType.IS_DERIVED_FROM.getName()));
         assertThat(result.getResourceTypeGeneral(), is(ResourceTypeGeneral.PROJECT.getName()));
     }
@@ -680,7 +680,7 @@ public class DataciteRelatedIdentifierFactoryTest {
         final var result = dataciteRelatedIdentifierFactory.create(relatedRaid);
 
         assertThat(result.getRelatedIdentifier(), is(id));
-        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.DOI.getName()));
+        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.RAID.getName()));
         assertThat(result.getRelationType(), is(RelationType.IS_SOURCE_OF.getName()));
         assertThat(result.getResourceTypeGeneral(), is(ResourceTypeGeneral.PROJECT.getName()));
     }
@@ -697,7 +697,7 @@ public class DataciteRelatedIdentifierFactoryTest {
         final var result = dataciteRelatedIdentifierFactory.create(relatedRaid);
 
         assertThat(result.getRelatedIdentifier(), is(id));
-        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.DOI.getName()));
+        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.RAID.getName()));
         assertThat(result.getRelationType(), is(RelationType.OBSOLETES.getName()));
         assertThat(result.getResourceTypeGeneral(), is(ResourceTypeGeneral.PROJECT.getName()));
     }
@@ -714,8 +714,14 @@ public class DataciteRelatedIdentifierFactoryTest {
         final var result = dataciteRelatedIdentifierFactory.create(relatedRaid);
 
         assertThat(result.getRelatedIdentifier(), is(id));
-        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.DOI.getName()));
+        assertThat(result.getRelatedIdentifierType(), is(RelatedIdentifierType.RAID.getName()));
         assertThat(result.getRelationType(), is(RelationType.IS_OBSOLETED_BY.getName()));
         assertThat(result.getResourceTypeGeneral(), is(ResourceTypeGeneral.PROJECT.getName()));
+    }
+
+    @Test
+    @DisplayName("RAID related identifier type has the exact DataCite casing 'RAiD'")
+    void raidIdentifierTypeHasExactCasing() {
+        assertThat(RelatedIdentifierType.RAID.getName(), is("RAiD"));
     }
 }

--- a/doc/spike/RAID-797-datacite-backfill-automation.md
+++ b/doc/spike/RAID-797-datacite-backfill-automation.md
@@ -1,0 +1,306 @@
+# DataCite re-sync mechanism
+
+Status: proposal for team discussion (not a decision).
+Related: RAID-797 (the first user of this mechanism), parent RAID-796.
+
+This document proposes a reusable way to re-push already-minted RAiD metadata to DataCite,
+automatically and portably. It began as the RAID-797 backfill, but DataCite backfills have
+recurred on several occasions, so this proposes a general mechanism rather than another
+one-off. It is a starting point for discussion, not a decision.
+
+
+## Summary
+
+We periodically change how RAiD metadata maps to DataCite (RAID-797, which switches related
+RAiDs to DataCite's native "RAiD" relatedIdentifierType, is the latest). Each change leaves
+already-minted records stale until we re-push them. So far we have written a bespoke backfill
+each time, and run it by hand.
+
+This proposes a reusable, in-application "DataCite re-sync" mechanism:
+
+* a flag marks records whose DataCite copy is stale,
+* a background worker re-pushes the flagged records idempotently, and
+* each future correction becomes a one-line migration that flags its affected rows.
+
+Because the worker runs inside the application, it works in any environment and under any
+pipeline, and it contains no manual step. Because it is generic, a future backfill costs
+almost nothing.
+
+
+## Background and problem
+
+A re-push sends a record's full current metadata to DataCite. The `post-to-datacite` path
+already does this as a full-document PUT, so re-pushing is idempotent and creates no duplicate
+identifiers.
+
+The important insight for a reusable design: a record only ever needs to be flagged as "its
+DataCite copy is stale, re-push it", never as "it needs correction X". The worker does not
+need to know the reason. When it re-pushes, it sends the complete current representation,
+which already includes whatever the latest change altered. Several pending corrections on the
+same record simply coalesce into one re-push.
+
+Two requirements shape the mechanism:
+
+* Deployments must contain no manual steps.
+* It must work in environments other than AWS, and under pipelines other than CodeBuild. This
+  is the decisive constraint: it rules out anything that lives in the AWS pipeline, because
+  the automation would then not run elsewhere. The only artifact that runs identically in
+  every environment is the application, so the mechanism lives in the application.
+
+The design must also:
+
+* run once across instances, not once per instance per restart,
+* not block startup or fail the deployment if DataCite is slow or unavailable,
+* be self-terminating, so it stops working once nothing is stale, and
+* be safe in production, so it can never mass-rewrite records unintentionally.
+
+
+## Options considered
+
+* A bespoke backfill per change (the pattern so far), run by hand. Fails the no-manual-step
+  requirement, and repeats effort every time.
+* An AWS pipeline deploy action (CodeBuild) or a one-shot ECS task. Not portable, because they
+  are specific to AWS and CodeBuild.
+* A Flyway migration that calls DataCite. Migrations here are plain SQL. A Java migration could
+  make HTTP calls, but that would block startup and fail the application if DataCite were
+  unavailable. The only suitable use of Flyway is deterministic SQL that flags the records.
+* A reusable in-application re-sync mechanism. Recommended.
+
+
+## Recommended approach
+
+Build a reusable "DataCite re-sync queue" once, then drive each backfill with a small
+migration.
+
+Written once:
+
+* A Flyway migration adds a flag column, `datacite_resync_required` (default false), to the
+  raid table.
+* The write path (mint, update, and `post-to-datacite`) clears the flag on every successful
+  post, so new and edited records are never stale.
+* A background worker drains the flagged records: on a schedule, it takes a Postgres advisory
+  lock so only one instance runs, processes flagged records on a background thread, re-pushes
+  each through the existing `post-to-datacite` path, clears the flag on success, rate-limits,
+  retries, and logs counts. It is self-terminating: once nothing is flagged, every tick is a
+  cheap no-op.
+* A configuration property enables or disables the worker per environment.
+
+Per backfill (including RAID-797), the entire change is a targeting migration:
+
+```sql
+-- RAID-797
+update api_svc.raid r set datacite_resync_required = true
+where exists (select 1 from api_svc.related_raid rr where rr.raid_name = r.handle);
+```
+
+A future correction ships its own one-line migration with its own predicate, and the existing
+worker drains it. No new application code, no manual step, and it runs the same in every
+environment.
+
+Keep `scripts/backfill-datacite-related-raids.sh` as an operator fallback only.
+
+
+## Consequences
+
+Benefits:
+
+* No manual deployment step, and the same behaviour in any environment and under any pipeline.
+* Reusable. A future backfill is a one-line migration, not another bespoke job.
+* Decoupled from startup and serving. A DataCite outage does not fail the deployment or the
+  application; the worker makes no progress that run and retries later.
+* Self-terminating and idempotent.
+* Reuses existing application code and the application's own database for coordination.
+
+Costs and constraints:
+
+* Adds application-lifecycle complexity: a background executor, a Postgres advisory lock, and
+  the flag column plus the write-path change that clears it.
+* Introduces a pattern (application-driven data re-sync) that the team must maintain.
+* The flag is the safety guard. Each backfill's predicate must be correct, especially in
+  production, and the worker must log counts so a run is observable.
+
+
+## Decisions
+
+These are the decisions this proposal puts to the team to confirm.
+
+* Flag shape and row selection. Use a boolean targeting flag, `datacite_resync_required`. Each
+  backfill flags only its affected rows through its own migration predicate, so scope is
+  declared per backfill and DataCite traffic stays minimal. We rejected the global generation
+  counter (which re-pushes every record on each bump) and the `datacite_synced_at` timestamp
+  (whose NULL-means-pending semantics are less clear).
+* Write-path integration. The write path clears the flag on every successful DataCite post in
+  `RaidService` (the mint, update, and `post-to-datacite` paths), so new and edited records are
+  never stale. New mints default the column to false, so this matters most on user edits and on
+  the worker's own re-push.
+* Pacing. The worker drains in capped batches per tick: it processes up to `batchSize` records,
+  releases the advisory lock between ticks, and continues on the schedule until drained. This
+  bounds each tick's duration and DataCite load, and avoids holding the lock through a large
+  backlog.
+* Rate limit. DataCite documents a general limit of 3,000 requests per 5 minutes per IP, but a
+  backfill is DataCite's "large-scale updates" case, for which they recommend 300 to 500
+  requests per 5 minutes, and their test system caps at 750 per 5 minutes. So the default
+  targets roughly 1 request per second (`throttleMillis` around 1000, about 300 per 5 minutes),
+  which sits inside that recommendation and leaves headroom for normal minting traffic sharing
+  the same per-IP budget. The worker handles a 429 by deferring the record to a later tick. The
+  values stay configurable per environment.
+* Status. This remains a spike proposal for now rather than an ADR. We can promote it to an ADR
+  after the team agrees and the mechanism is implemented.
+
+Still to tune (not blockers for the discussion): the exact `batchSize`, `throttleMillis`, and
+`pollDelayMillis` defaults, within the DataCite guidance above.
+
+
+## Links
+
+* RAID-797, DataCite native RAiD relatedIdentifierType, and PR au-research/raid-au#617.
+* RAID-796, parent story.
+* Existing operator-fallback script: `scripts/backfill-datacite-related-raids.sh`.
+* Related ADR: `doc/adr/2026-08-10_resolver-unavailable-503.md`, which follows the same
+  principle of decoupling the application from external-service availability.
+* DataCite API rate limits: https://support.datacite.org/docs/rate-limit and
+  https://support.datacite.org/docs/best-practices-for-integrators.
+
+
+## Appendix: mechanism sketch
+
+This is an illustrative sketch for discussion, using Spring Boot and JOOQ to match the
+api-svc conventions. Class and column names are indicative rather than the exact signatures.
+
+The worker is a scheduled poller rather than a one-shot startup hook, so one mechanism covers
+every case: the first tick fires at startup, later ticks retry failures and catch an instance
+that was already running during a rolling deployment, and once nothing is flagged every tick
+is a cheap no-op.
+
+```java
+@ConfigurationProperties(prefix = "raid.datacite.resync")
+public record DataciteResyncProperties(
+        boolean enabled,
+        int batchSize,          // records per tick, e.g. 50
+        long throttleMillis,    // pause between DataCite calls, e.g. 1000 (~1 req/s, see below)
+        long pollDelayMillis) { // gap between ticks, e.g. 60000
+}
+```
+
+```java
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "raid.datacite.resync", name = "enabled", havingValue = "true")
+public class DataciteResyncWorker {
+
+    private static final Logger log = LoggerFactory.getLogger(DataciteResyncWorker.class);
+    // A fixed key. Every instance uses the same one, so the lock is mutually exclusive.
+    private static final long LOCK_KEY = 0x2126_0797L;
+
+    private final DSLContext db;
+    private final RaidResyncRepository repository;   // JOOQ queries over the flag column
+    private final RaidService raidService;           // reuses the existing post-to-datacite path
+    private final DataciteResyncProperties props;
+
+    // Runs on a scheduler thread, so it never blocks startup or serving traffic.
+    @Scheduled(fixedDelayString = "${raid.datacite.resync.poll-delay-millis:60000}")
+    public void tick() {
+        // Hold ONE connection for the whole tick, so the session advisory lock stays held.
+        db.connection(conn -> {
+            var dsl = DSL.using(conn);
+            if (!tryAdvisoryLock(dsl)) {
+                return; // another instance is already re-syncing; skip this tick
+            }
+            try {
+                runBatch(dsl);
+            } finally {
+                releaseAdvisoryLock(dsl);
+            }
+        });
+    }
+
+    private void runBatch(DSLContext dsl) {
+        var pending = repository.findResyncRequired(dsl, props.batchSize());
+        if (pending.isEmpty()) {
+            return; // self-terminating: nothing flagged, so the tick is a no-op
+        }
+        log.info("DataCite re-sync: re-pushing {} record(s) this tick", pending.size());
+
+        int synced = 0, deferred = 0;
+        for (var handle : pending) {
+            try {
+                raidService.postToDatacite(handle);        // idempotent full-document PUT
+                repository.clearResyncRequired(dsl, handle);// own statement, no long transaction
+                synced++;
+            } catch (Exception e) {
+                deferred++;
+                // Leave the flag set so a later tick retries it. Do not abort the run.
+                log.warn("DataCite re-sync: {} deferred, will retry: {}", handle, e.getMessage());
+            }
+            sleepQuietly(props.throttleMillis());          // rate-limit against the DataCite API
+        }
+        log.info("DataCite re-sync tick done: {} synced, {} deferred", synced, deferred);
+    }
+
+    private boolean tryAdvisoryLock(DSLContext dsl) {
+        return Boolean.TRUE.equals(
+            dsl.select(field("pg_try_advisory_lock({0})", Boolean.class, val(LOCK_KEY)))
+               .fetchOne(0, Boolean.class));
+    }
+
+    private void releaseAdvisoryLock(DSLContext dsl) {
+        dsl.execute("select pg_advisory_unlock({0})", val(LOCK_KEY));
+    }
+
+    private static void sleepQuietly(long millis) {
+        try { Thread.sleep(millis); }
+        catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+    }
+}
+```
+
+The worker is fully generic, because the "which records" decision lives in each backfill's
+migration, not in the worker.
+
+```java
+// JOOQ repository (names indicative)
+List<String> findResyncRequired(DSLContext dsl, int limit) {
+    return dsl.select(RAID.HANDLE).from(RAID)
+        .where(RAID.DATACITE_RESYNC_REQUIRED.isTrue())
+        .orderBy(RAID.HANDLE).limit(limit).fetch(RAID.HANDLE);
+}
+
+void clearResyncRequired(DSLContext dsl, String handle) {
+    dsl.update(RAID).set(RAID.DATACITE_RESYNC_REQUIRED, false)
+       .where(RAID.HANDLE.eq(handle)).execute();
+}
+```
+
+The mechanism is created once by a Flyway migration, and the write path clears the flag on
+every successful post so new and edited records are never stale:
+
+```sql
+-- Vxx__datacite_resync_queue.sql  (the reusable mechanism, added once)
+alter table api_svc.raid add column datacite_resync_required boolean not null default false;
+```
+
+Each backfill is then a targeting migration:
+
+```sql
+-- Vyy__resync_datacite_for_raid_797.sql  (the first user)
+update api_svc.raid r set datacite_resync_required = true
+where exists (select 1 from api_svc.related_raid rr where rr.raid_name = r.handle);
+
+-- A future correction ships its own one-line migration with its own predicate:
+-- update api_svc.raid set datacite_resync_required = true where <predicate>;
+```
+
+Design points worth noting for the discussion:
+
+* The advisory lock on a single held connection (`db.connection(...)`) makes the worker
+  single-runner across instances without any external coordinator. `pg_try_advisory_lock` is
+  non-blocking, so a losing instance skips the tick.
+* DataCite calls sit outside any database transaction. `clearResyncRequired` is its own
+  statement per record, so there is no long-running transaction, and a crash mid-run leaves
+  the remainder flagged for the next tick.
+* Failure is handled per record, never fatal to the run or the application. A record whose
+  flag is still set is retried on a later tick.
+* The write path clears the flag on every successful post, so a record edited by a user before
+  the worker reaches it is not re-pushed redundantly.
+* The toggle (`@ConditionalOnProperty`) keeps the worker off in tests and local runs, and lets
+  us disable it per environment. Scheduling requires `@EnableScheduling` on the application.

--- a/documentation/20260818-raid-797-datacite-raid-related-identifier.md
+++ b/documentation/20260818-raid-797-datacite-raid-related-identifier.md
@@ -25,12 +25,21 @@ Metadata Schema 4.6/4.7, so we now emit the native type instead.
 - Updated the eight `relatedRaid*` cases in `DataciteRelatedIdentifierFactoryTest` to assert the
   `"RAiD"` type, and added a casing-guard test locking `RelatedIdentifierType.RAID.getName()` to
   the exact string `"RAiD"`.
-- Added `DataciteLiveRelatedRaidIntegrationTest` (in the `src/test` source set) — a permanent
-  regression test that runs the **real** `DataciteRelatedIdentifierFactory` output against the live
-  DataCite **test** API, asserts a draft DOI is accepted with `relatedIdentifierType: "RAiD"` /
-  `resourceTypeGeneral: "Project"`, then deletes the draft. It lives in `src/test` (not `intTest`)
-  to keep the deliberately black-box `intTest` source set free of a `src/main` classpath
-  dependency.
+- Added `DataciteRelatedRaidMockIntegrationTest` (black-box `intTest` source set) — the **local,
+  CI-runnable** regression test. It mints a RAiD with a `relatedRaid` through the app, then
+  retrieves the request the DataCite MockServer (localhost:1080) recorded and asserts the outbound
+  DataCite JSON carries a `relatedIdentifier` with `relatedIdentifierType: "RAiD"`,
+  `resourceTypeGeneral: "Project"`, and the unchanged target handle. This exercises the full app
+  path (`DataciteAttributesDtoFactory` + `DataciteService` + `DataciteRelatedIdentifierFactory`),
+  needs no real DataCite credentials, and adds no `build.gradle`/classpath change (it queries
+  MockServer over HTTP). It runs in the normal `intTest` suite.
+- Added `DataciteLiveRelatedRaidIntegrationTest` (in the `src/test` source set) — the **live**
+  regression test, run on demand in the test environment. It runs the **real**
+  `DataciteRelatedIdentifierFactory` output against the live DataCite **test** API, asserts a draft
+  DOI is accepted with `relatedIdentifierType: "RAiD"` / `resourceTypeGeneral: "Project"`, then
+  deletes the draft. It lives in `src/test` (not `intTest`) to keep the deliberately black-box
+  `intTest` source set free of a `src/main` classpath dependency, and is gated by
+  `@EnabledIfEnvironmentVariable("DATACITE_LIVE_TEST")` so it is skipped in CI.
 
 ## How to run the live DataCite test
 
@@ -71,5 +80,8 @@ The client must hold the `RAID_UPGRADER_ROLE` (the same role the `/raid/non-lega
 ## Verification performed
 
 - `./gradlew :api-svc:raid-api:test` — green (updated factory tests + casing guard).
-- `./gradlew :api-svc:raid-api:intTest` — full suite green locally against a branch API on :8080.
-- Live DataCite test confirmed to compile and skip when `DATACITE_LIVE_TEST` is unset.
+- `./gradlew :api-svc:raid-api:intTest` — full suite green locally against a branch API on :8080,
+  including `DataciteRelatedRaidMockIntegrationTest` (the mocked local test asserting the outbound
+  DataCite payload carries `relatedIdentifierType: "RAiD"` via MockServer).
+- Live DataCite test confirmed to compile and skip when `DATACITE_LIVE_TEST` is unset; to be run
+  for real in the test environment with a service point's credentials.

--- a/documentation/20260818-raid-797-datacite-raid-related-identifier.md
+++ b/documentation/20260818-raid-797-datacite-raid-related-identifier.md
@@ -38,13 +38,19 @@ Skipped by default. Enable it by setting the env vars (no secrets are committed)
 
 ```bash
 DATACITE_LIVE_TEST=true \
-DATACITE_TEST_REPOSITORY_ID=<repository/client id> \
-DATACITE_TEST_PASSWORD=<password> \
-DATACITE_TEST_PREFIX=<test DOI prefix, e.g. 10.82841> \
+DATACITE_TEST_REPOSITORY_ID=<service point's DataCite repository id> \
+DATACITE_TEST_PASSWORD=<that service point's DataCite password> \
+DATACITE_TEST_PREFIX=<a DOI prefix that repository may mint under, e.g. 10.82841> \
 ./gradlew :api-svc:raid-api:test --tests '*DataciteLive*'
 ```
 
 `DATACITE_TEST_ENDPOINT` is optional and defaults to `https://api.test.datacite.org/dois`.
+
+The DataCite repository id and password are **properties of a service point** — the same
+credentials `DataciteService` reads off the service point record to authenticate to the DataCite
+DOIs API. Any service point in the **test** environment has working DataCite test-API credentials,
+so its repository id + password can be used here directly (the test calls the DataCite repository
+directly over HTTP Basic, exactly as the app does).
 
 ## Backfill of already-minted RAiDs
 

--- a/documentation/20260818-raid-797-datacite-raid-related-identifier.md
+++ b/documentation/20260818-raid-797-datacite-raid-related-identifier.md
@@ -1,0 +1,69 @@
+# RAID-797: Emit related RAiDs with DataCite's native "RAiD" relatedIdentifierType
+
+- **Date:** 2026-08-18
+- **JIRA:** [RAID-797](https://ardc.atlassian.net/browse/RAID-797) (parent: [RAID-796](https://ardc.atlassian.net/browse/RAID-796))
+- **PR:** [au-research/raid-au#617](https://github.com/au-research/raid-au/pull/617)
+- **Commit:** `7c67b8d7`
+
+## What changed and why
+
+Related RAiDs were emitted to DataCite as generic `"DOI"` citations, which made them
+indistinguishable from real DOI references in downstream harvesters, aggregators and other
+registration agencies. DataCite introduced a dedicated `"RAiD"` `relatedIdentifierType` in
+Metadata Schema 4.6/4.7, so we now emit the native type instead.
+
+### Code
+- Added `RAID("RAiD")` to `RelatedIdentifierType`
+  (`api-svc/raid-api/.../vocabularies/datacite/RelatedIdentifierType.java`). The DataCite string is
+  exactly `"RAiD"` (mixed case).
+- Changed `DataciteRelatedIdentifierFactory.create(RelatedRaid)` to emit
+  `RelatedIdentifierType.RAID` instead of `DOI`. `resourceTypeGeneral` stays `"Project"`, the
+  identifier value stays the related RAiD's handle unchanged, and the `RAID_RELATION_TYPE_MAP`
+  relation-type mapping is untouched.
+
+### Tests
+- Updated the eight `relatedRaid*` cases in `DataciteRelatedIdentifierFactoryTest` to assert the
+  `"RAiD"` type, and added a casing-guard test locking `RelatedIdentifierType.RAID.getName()` to
+  the exact string `"RAiD"`.
+- Added `DataciteLiveRelatedRaidIntegrationTest` (in the `src/test` source set) — a permanent
+  regression test that runs the **real** `DataciteRelatedIdentifierFactory` output against the live
+  DataCite **test** API, asserts a draft DOI is accepted with `relatedIdentifierType: "RAiD"` /
+  `resourceTypeGeneral: "Project"`, then deletes the draft. It lives in `src/test` (not `intTest`)
+  to keep the deliberately black-box `intTest` source set free of a `src/main` classpath
+  dependency.
+
+## How to run the live DataCite test
+
+Skipped by default. Enable it by setting the env vars (no secrets are committed):
+
+```bash
+DATACITE_LIVE_TEST=true \
+DATACITE_TEST_REPOSITORY_ID=<repository/client id> \
+DATACITE_TEST_PASSWORD=<password> \
+DATACITE_TEST_PREFIX=<test DOI prefix, e.g. 10.82841> \
+./gradlew :api-svc:raid-api:test --tests '*DataciteLive*'
+```
+
+`DATACITE_TEST_ENDPOINT` is optional and defaults to `https://api.test.datacite.org/dois`.
+
+## Backfill of already-minted RAiDs
+
+`scripts/backfill-datacite-related-raids.sh` re-pushes corrected metadata to DataCite for existing
+records. It is **targeted** (only RAiDs that have a `relatedRaid` entry are re-posted; others are
+skipped) and **idempotent** (each re-post is a full-document PUT via `/raid/post-to-datacite`, so
+re-running produces the identical record with no duplicate `relatedIdentifier` entries). It is
+rate-limited (0.5s between requests) and logs the posted-vs-skipped counts.
+
+```bash
+# environment is one of: local, test, demo, stage, prod
+scripts/backfill-datacite-related-raids.sh <environment> <clientId> <clientSecret>
+```
+
+The client must hold the `RAID_UPGRADER_ROLE` (the same role the `/raid/non-legacy` and
+`/raid/post-to-datacite` endpoints are gated on).
+
+## Verification performed
+
+- `./gradlew :api-svc:raid-api:test` — green (updated factory tests + casing guard).
+- `./gradlew :api-svc:raid-api:intTest` — full suite green locally against a branch API on :8080.
+- Live DataCite test confirmed to compile and skip when `DATACITE_LIVE_TEST` is unset.

--- a/scripts/backfill-datacite-related-raids.sh
+++ b/scripts/backfill-datacite-related-raids.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# RAID-797: Backfill already-minted RAiDs so their DataCite records emit related
+# RAiDs with the native "RAiD" relatedIdentifierType instead of generic "DOI".
+#
+# Only RAiDs that actually have a relatedRaid entry are re-posted; RAiDs with no
+# relatedRaid are skipped (nothing about their DataCite record changes).
+#
+# Idempotent: post-to-datacite triggers a full-document PUT to DataCite, which
+# replaces the metadata rather than appending, so re-running produces the
+# identical record with no duplicate relatedIdentifier entries.
+
+# Check if exactly 3 arguments are provided
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 <environment> <clientId> <clientSecret>"
+    echo "Environment can be one of: local, test, demo, stage, prod"
+    echo "Example: $0 demo raid-upgrader BEbm73S8lkIWBTcm8TlU4gREmUkLXLr0"
+    exit 1
+fi
+
+# Assign arguments to variables
+ENVIRONMENT="$1"
+CLIENT_ID="$2"
+CLIENT_SECRET="$3"
+
+# Validate environment parameter
+case $ENVIRONMENT in
+    local)
+        TOKEN_URL="http://localhost:8001/realms/raid/protocol/openid-connect/token"
+        GET_URL="http://localhost:8080/raid/non-legacy"
+        POST_URL="http://localhost:8080/raid/post-to-datacite"
+        ;;
+    test)
+        TOKEN_URL="https://iam.test.raid.org.au/realms/raid/protocol/openid-connect/token"
+        GET_URL="https://api.test.raid.org.au/raid/non-legacy"
+        POST_URL="https://api.test.raid.org.au/raid/post-to-datacite"
+        ;;
+    demo)
+        TOKEN_URL="https://iam.demo.raid.org.au/realms/raid/protocol/openid-connect/token"
+        GET_URL="https://api.demo.raid.org.au/raid/non-legacy"
+        POST_URL="https://api.demo.raid.org.au/raid/post-to-datacite"
+        ;;
+    stage)
+        TOKEN_URL="https://iam.stage.raid.org.au/realms/raid/protocol/openid-connect/token"
+        GET_URL="https://api.stage.raid.org.au/raid/non-legacy"
+        POST_URL="https://api.stage.raid.org.au/raid/post-to-datacite"
+        ;;
+    prod)
+        TOKEN_URL="https://iam.prod.raid.org.au/realms/raid/protocol/openid-connect/token"
+        GET_URL="https://api.prod.raid.org.au/raid/non-legacy"
+        POST_URL="https://api.prod.raid.org.au/raid/post-to-datacite"
+        ;;
+    *)
+        echo "Error: Invalid environment '$ENVIRONMENT'"
+        echo "Environment must be one of: local, test, demo, stage, prod"
+        exit 1
+        ;;
+esac
+
+echo "Using environment: $ENVIRONMENT"
+echo "TOKEN_URL: $TOKEN_URL"
+echo "GET_URL: $GET_URL"
+echo "POST_URL: $POST_URL"
+
+# Helper: fetch a fresh client-credentials access token
+get_token() {
+    local token_response
+    token_response=$(curl -s -X POST "$TOKEN_URL" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "grant_type=client_credentials" \
+        -d "client_id=$CLIENT_ID" \
+        -d "client_secret=$CLIENT_SECRET")
+    echo "$token_response" | jq -r '.access_token'
+}
+
+# Get an initial access token for the listing call
+access_token=$(get_token)
+
+if [ -z "$access_token" ] || [ "$access_token" == "null" ]; then
+    echo "Failed to obtain access token"
+    exit 1
+fi
+
+echo
+
+# Fetch all non-legacy RAiDs
+response=$(curl -s "$GET_URL" -H "Authorization: Bearer $access_token")
+
+total_count=$(echo "$response" | jq 'length')
+
+# Keep only RAiDs that have at least one relatedRaid entry. RAiDs with no
+# relatedRaid are skipped entirely (their DataCite record is left untouched).
+related_raids=$(echo "$response" | jq -c '.[] | select(.relatedRaid != null and (.relatedRaid | length) > 0)')
+
+posted_count=$(echo "$related_raids" | grep -c . )
+skipped_count=$((total_count - posted_count))
+
+echo "Fetched $total_count non-legacy RAiDs: $posted_count with a relatedRaid to re-post, $skipped_count skipped (no relatedRaid)."
+echo
+
+# Re-post each RAiD that has a relatedRaid entry
+echo "$related_raids" | while read -r resource; do
+    [ -z "$resource" ] && continue
+
+    handle=$(echo "$resource" | jq -r '.identifier.id // "unknown"')
+    echo "Posting to DataCite: $handle"
+
+    # Refresh the token per iteration (long runs can outlive a single token)
+    access_token=$(get_token)
+    if [ -z "$access_token" ] || [ "$access_token" == "null" ]; then
+        echo "Failed to obtain access token"
+        exit 1
+    fi
+
+    post_response=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $access_token" \
+        -d "$resource" "$POST_URL")
+    echo "  HTTP $post_response"
+
+    # Rate-limit against DataCite's API
+    sleep 0.5
+done
+
+echo
+echo "Backfill complete: attempted $posted_count RAiD(s), skipped $skipped_count with no relatedRaid."


### PR DESCRIPTION
## What
Emit related RAiDs to DataCite using DataCite's native `RAiD` `relatedIdentifierType` (Metadata Schema 4.6/4.7) instead of generic `DOI`, so related RAiDs are distinguishable from real DOI citations in downstream harvesters/aggregators. `resourceTypeGeneral` stays `Project`; the relation-type mapping is unchanged.

## Changes
- `RelatedIdentifierType.RAID("RAiD")` added.
- `DataciteRelatedIdentifierFactory.create(RelatedRaid)` now emits `RelatedIdentifierType.RAID`.
- Eight `relatedRaid*` unit tests updated + a casing-guard test locking the exact `"RAiD"` string.
- `DataciteLiveRelatedRaidIntegrationTest` (unit-test source set): a permanent regression test that runs OUR real factory payload against the live DataCite **test** API and asserts a draft DOI is accepted with `relatedIdentifierType: "RAiD"`, then deletes the draft. Gated by `@EnabledIfEnvironmentVariable("DATACITE_LIVE_TEST")` and env-supplied creds, so it is skipped in CI.
- `scripts/backfill-datacite-related-raids.sh`: targeted, idempotent backfill of already-minted RAiDs — filters `/raid/non-legacy` to only RAiDs with a `relatedRaid`, re-posts via `/raid/post-to-datacite` (full-document PUT, so re-runs create no duplicate relatedIdentifiers), rate-limited.

## Testing
- `./gradlew :api-svc:raid-api:test` — green (incl. updated factory tests + casing guard).
- `./gradlew :api-svc:raid-api:intTest` — full suite green locally against a branch API.
- Live DataCite test verified to compile and skip when `DATACITE_LIVE_TEST` is unset.

## Ticket
https://ardc.atlassian.net/browse/RAID-797 (parent RAID-796)

🤖 Generated with [Claude Code](https://claude.com/claude-code)