### PR TITLE
Add e2e tests for RAID-659, RAID-480 and RAID-608

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -127,6 +127,10 @@ jobs:
           VITE_RAID_DOMAIN: http://www.raid.org.au
           VITE_KEYCLOAK_E2E_USER: raid-test-user
           VITE_KEYCLOAK_E2E_PASSWORD: password
+          VITE_KEYCLOAK_E2E_OPERATOR_USER: raid-operator
+          VITE_KEYCLOAK_E2E_OPERATOR_PASSWORD: password
+          VITE_KEYCLOAK_E2E_UNAPPROVED_ADMIN_USER: raid-au-unapproved-admin
+          VITE_KEYCLOAK_E2E_UNAPPROVED_ADMIN_PASSWORD: password
         run: npx playwright test
 
       - name: Upload Playwright report

--- a/iam/doc/keycloak-configuration.md
+++ b/iam/doc/keycloak-configuration.md
@@ -208,12 +208,14 @@ Users are associated with groups and have an `activeGroupId` attribute that dete
 
 ### Test Users
 
-| Username              | Roles                                         | Active Group             | Password   |
-|-----------------------|-----------------------------------------------|--------------------------|------------|
-| `raid-test-user`      | `service-point-user`, `pid-searcher`          | raid-au                  | `password` |
-| `uq-test-user`        | `service-point-user`                          | University of Queensland | `password` |
-| `raid-operator`       | `operator`                                    | (none)                   | `password` |
-| `raid-au-group-admin` | `group-admin`, `service-point-user`           | raid-au                  | `password` |
+| Username                     | Roles                                         | Active Group             | Password   |
+|------------------------------|-----------------------------------------------|--------------------------|------------|
+| `raid-test-user`             | `service-point-user`, `pid-searcher`          | raid-au                  | `password` |
+| `uq-test-user`               | `service-point-user`                          | University of Queensland | `password` |
+| `raid-operator`              | `operator`                                    | (none)                   | `password` |
+| `raid-au-group-admin`        | `group-admin`, `service-point-user`           | raid-au                  | `password` |
+| `raid-au-pending-user`       | (none — raw, self-joined member of raid-au)   | raid-au                  | `password` |
+| `raid-au-unapproved-admin`   | `group-admin` (raw, self-joined member of raid-au, never approved — see RAID-608) | raid-au | `password` |
 
 ### User Attributes
 

--- a/iam/doc/local-development.md
+++ b/iam/doc/local-development.md
@@ -4,12 +4,15 @@ When running locally with Docker Compose, the `raid` realm should be added autom
 
 ## Test Users
 
-The realm includes two test users, each belonging to different service points. Both have the `service-point-user` role necessary to mint RAiDs and the password `password`.
+The realm includes several test users. All have the password `password`.
 
-| User             | role                | Password   |
-|------------------|---------------------|------------|
-| `raid-test-user` | `service-point-user`  | `password` |
-| `raid-operator`  | `operator` | `password` |
+| User                        | role                              | Notes                                                                    |
+|-----------------------------|------------------------------------|---------------------------------------------------------------------------|
+| `raid-test-user`            | `service-point-user`              | Approved member of `raid-au`                                             |
+| `raid-operator`             | `operator`                        | No group membership                                                      |
+| `raid-au-group-admin`       | `group-admin`, `service-point-user` | Approved admin of `raid-au`                                            |
+| `raid-au-pending-user`      | (none)                             | Raw, self-joined member of `raid-au` with an outstanding access request  |
+| `raid-au-unapproved-admin`  | `group-admin`                     | Raw, self-joined member of `raid-au`, never approved for it (RAID-608)    |
 
 ## Exporting Realm Changes
 

--- a/iam/realms/raid-realm.json
+++ b/iam/realms/raid-realm.json
@@ -620,6 +620,52 @@
     "notBefore" : 0,
     "groups" : [ "/raid-au" ]
   }, {
+    "id" : "7a4e6c92-1f3d-4b8a-9e2c-5d6f7081a2b3",
+    "username" : "raid-au-pending-user",
+    "emailVerified" : true,
+    "attributes" : {
+      "activeGroupId" : [ "169bd3f3-dd42-4ac0-b89a-fb49648e5eff" ]
+    },
+    "createdTimestamp" : 1755000000000,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "8b5f7d03-2049-4c9b-af3d-6e70819234c1",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1755000000000,
+      "secretData" : "{\"value\":\"P1fRNnd1gm3lMMg6WjSnKApdaZufj/DNQsnUbpCQuoNLJ+1rrL8lu3x3ovbmQNcZH0ssY2EX9RR/Mqm/naRnWQ==\",\"salt\":\"hXG/afBDexf/HE4z1Hl9dQ==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":210000,\"algorithm\":\"pbkdf2-sha512\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-raid" ],
+    "notBefore" : 0,
+    "groups" : [ "/raid-au" ]
+  }, {
+    "id" : "9c6071a4-3150-4dac-b054-7f8192a345d2",
+    "username" : "raid-au-unapproved-admin",
+    "emailVerified" : true,
+    "attributes" : {
+      "activeGroupId" : [ "169bd3f3-dd42-4ac0-b89a-fb49648e5eff" ]
+    },
+    "createdTimestamp" : 1755000000000,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "ad7182b5-4261-4ebd-c165-809243b556e3",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1755000000000,
+      "secretData" : "{\"value\":\"P1fRNnd1gm3lMMg6WjSnKApdaZufj/DNQsnUbpCQuoNLJ+1rrL8lu3x3ovbmQNcZH0ssY2EX9RR/Mqm/naRnWQ==\",\"salt\":\"hXG/afBDexf/HE4z1Hl9dQ==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":210000,\"algorithm\":\"pbkdf2-sha512\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "group-admin", "default-roles-raid" ],
+    "notBefore" : 0,
+    "groups" : [ "/raid-au" ]
+  }, {
     "id" : "c10bdf5f-80b2-49b2-806c-bc10c4dd343a",
     "username" : "raid-operator",
     "emailVerified" : true,

--- a/raid-agency-app-static/src/components/raid-components/related-objects.astro
+++ b/raid-agency-app-static/src/components/raid-components/related-objects.astro
@@ -2,7 +2,7 @@
 import InfoField from "@/components/info-field.astro";
 import type { RelatedObjectWithCitation } from "@/model/raid";
 import mapping from "@/mapping/data/general-mapping.json";
-import { kebabToTitle } from "@/utils";
+import { decodeHtmlEntities, kebabToTitle } from "@/utils";
 
 interface Props {
   relatedObjects: RelatedObjectWithCitation[];
@@ -28,7 +28,7 @@ const { relatedObjects } = Astro.props as Props;
           return (
             <div class="ml-5 space-y-2 py-4">
               <div class="grid grid-cols-2 gap-5 text-sm">
-                <InfoField label="Citation" value={el.citation?.text || ""} />
+                <InfoField label="Citation" value={decodeHtmlEntities(el.citation?.text || "")} />
                 <InfoField label="ID" value={el.id || ""} isLink={true}/>
                 <InfoField label="Type" value={relatedObjectType || ""} />
               </div>

--- a/raid-agency-app-static/src/utils.test.ts
+++ b/raid-agency-app-static/src/utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { decodeHtmlEntities } from "./utils";
+
+describe("decodeHtmlEntities", () => {
+  it("leaves plain text with a raw ampersand untouched", () => {
+    expect(decodeHtmlEntities("Stanley, F. J., & Landau, L. I.")).toBe(
+      "Stanley, F. J., & Landau, L. I."
+    );
+  });
+
+  it("decodes a single-encoded ampersand", () => {
+    expect(decodeHtmlEntities("Stanley, F. J., &amp; Landau, L. I.")).toBe(
+      "Stanley, F. J., & Landau, L. I."
+    );
+  });
+
+  it("fully collapses a double-encoded ampersand", () => {
+    expect(decodeHtmlEntities("Stanley, F. J., &amp;amp; Landau, L. I.")).toBe(
+      "Stanley, F. J., & Landau, L. I."
+    );
+  });
+
+  it("decodes a mis-cased entity as seen from some DOI registration agencies", () => {
+    expect(decodeHtmlEntities("ACS Applied Materials &Amp; Interfaces")).toBe(
+      "ACS Applied Materials & Interfaces"
+    );
+  });
+
+  it("leaves real HTML tags in citation text untouched", () => {
+    expect(decodeHtmlEntities("Wei, M. &amp; Zhang, J. <i>Some Title</i>")).toBe(
+      "Wei, M. & Zhang, J. <i>Some Title</i>"
+    );
+  });
+
+  it("decodes other common entities", () => {
+    expect(decodeHtmlEntities("A &lt;title&gt; with &quot;quotes&quot; &amp; an apostrophe&#39;s mark")).toBe(
+      "A <title> with \"quotes\" & an apostrophe's mark"
+    );
+  });
+});

--- a/raid-agency-app-static/src/utils.ts
+++ b/raid-agency-app-static/src/utils.ts
@@ -8,6 +8,34 @@ export function kebabToTitle(str: string | undefined): string {
   return [firstWord, ...restWords].join(" ");
 }
 
+const HTML_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  "#39": "'",
+  "#039": "'",
+};
+
+// Collapses any depth of HTML-entity over-encoding (e.g. "&amp;amp;", or the
+// mis-cased "&Amp;" that DOI registration agencies occasionally emit) down to
+// the real character, so text that already arrived HTML-safe from an
+// upstream source doesn't get double-decoded (or left half-decoded) when
+// injected as raw HTML.
+export function decodeHtmlEntities(text: string): string {
+  let decoded = text;
+  let previous: string;
+  do {
+    previous = decoded;
+    decoded = decoded.replace(
+      /&(amp|lt|gt|quot|apos|#39|#039);/gi,
+      (match, entity) => HTML_ENTITIES[entity.toLowerCase()] ?? match
+    );
+  } while (decoded !== previous);
+  return decoded;
+}
+
 export function getLastTwoUrlSegments(url: string): string | null {
   const parts = url.split("/").filter((part) => part.length > 0);
   if (parts.length < 2) {

--- a/raid-agency-app/.env.template
+++ b/raid-agency-app/.env.template
@@ -6,6 +6,13 @@ BASE_URL=http://localhost:7080
 VITE_KEYCLOAK_E2E_USER=raid-test-user
 VITE_KEYCLOAK_E2E_PASSWORD=
 
+# Additional e2e credentials for role-specific test suites (RAID-659/480/608)
+# - see iam/doc/keycloak-configuration.md for what each fixture user has access to
+VITE_KEYCLOAK_E2E_OPERATOR_USER=raid-operator
+VITE_KEYCLOAK_E2E_OPERATOR_PASSWORD=
+VITE_KEYCLOAK_E2E_UNAPPROVED_ADMIN_USER=raid-au-unapproved-admin
+VITE_KEYCLOAK_E2E_UNAPPROVED_ADMIN_PASSWORD=
+
 # All service URLs, Keycloak config, environment settings, and branding are
 # configured in public/app-config.json — edit that file for local dev or
 # mount it per-deployment in production.

--- a/raid-agency-app/e2e/auth/authenticate.ts
+++ b/raid-agency-app/e2e/auth/authenticate.ts
@@ -1,0 +1,73 @@
+// RAID-536: Shared direct-grant authentication helper, extracted so multiple
+// role-specific setup projects (RAID-659/480/608 need operator and group-admin
+// sessions alongside the default service-point-user session) can reuse the
+// same token-seeding logic against different credentials and storage files.
+
+import { type Page } from "@playwright/test";
+
+export async function authenticateAndSaveState({
+  page,
+  baseURL,
+  username,
+  password,
+  keycloakUrl,
+  realm,
+  clientId,
+  authFilePath,
+}: {
+  page: Page;
+  baseURL: string | undefined;
+  username: string;
+  password: string;
+  keycloakUrl: string;
+  realm: string;
+  clientId: string;
+  authFilePath: string;
+}): Promise<void> {
+  const tokenResponse = await page.request.post(
+    `${keycloakUrl}/realms/${realm}/protocol/openid-connect/token`,
+    {
+      form: {
+        grant_type: "password",
+        client_id: clientId,
+        username,
+        password,
+      },
+    }
+  );
+
+  if (!tokenResponse.ok()) {
+    throw new Error(
+      `Direct grant token request failed for ${username}: ${tokenResponse.status()} ${await tokenResponse.text()}`
+    );
+  }
+
+  const tokens = await tokenResponse.json();
+
+  // Visit the app origin so the seeded key lands in the right localStorage origin,
+  // without ever hitting Keycloak's rendered login page.
+  await page.goto(baseURL ?? "/");
+  await page.evaluate(
+    ({ token, refreshToken, idToken }) => {
+      localStorage.setItem(
+        "__e2e_auth_tokens__",
+        JSON.stringify({ token, refreshToken, idToken })
+      );
+    },
+    {
+      token: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      idToken: tokens.id_token,
+    }
+  );
+
+  // Reload so KeycloakContext picks up the seeded tokens on init.
+  await page.reload();
+  await page.waitForFunction(
+    () => !window.location.pathname.startsWith("/login"),
+    { timeout: 15000 }
+  );
+  await page.waitForLoadState("networkidle");
+
+  await page.context().storageState({ path: authFilePath });
+}

--- a/raid-agency-app/e2e/auth/setup-operator.ts
+++ b/raid-agency-app/e2e/auth/setup-operator.ts
@@ -1,0 +1,52 @@
+// RAID-659 / RAID-480: Auth setup for the "operator" role, used by e2e tests
+// that exercise the "Manage service points" page (ServicePointsOperatorView),
+// which only renders for users holding the `operator` realm role. Saves
+// session state to e2e/.auth/operator.json, separate from the default
+// service-point-user session in e2e/.auth/user.json.
+
+import { test as setup } from "@playwright/test";
+import { fileURLToPath } from "url";
+import path from "path";
+import { authenticateAndSaveState } from "./authenticate";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const authFile = path.join(__dirname, "../.auth/operator.json");
+
+setup("authenticate as operator", async ({ page, baseURL }) => {
+  const username = process.env.VITE_KEYCLOAK_E2E_OPERATOR_USER;
+  const password = process.env.VITE_KEYCLOAK_E2E_OPERATOR_PASSWORD;
+  const keycloakUrl = process.env.VITE_KEYCLOAK_URL;
+  const realm = process.env.VITE_KEYCLOAK_REALM;
+  const clientId = process.env.VITE_KEYCLOAK_CLIENT_ID;
+
+  if (!username) {
+    throw new Error(
+      "VITE_KEYCLOAK_E2E_OPERATOR_USER environment variable is not set. " +
+        "Add it to your .env file."
+    );
+  }
+  if (!password) {
+    throw new Error(
+      "VITE_KEYCLOAK_E2E_OPERATOR_PASSWORD environment variable is not set. " +
+        "Add it to your .env file."
+    );
+  }
+  if (!keycloakUrl || !realm || !clientId) {
+    throw new Error(
+      "VITE_KEYCLOAK_URL, VITE_KEYCLOAK_REALM and VITE_KEYCLOAK_CLIENT_ID " +
+        "must all be set. Add them to your .env file."
+    );
+  }
+
+  await authenticateAndSaveState({
+    page,
+    baseURL,
+    username,
+    password,
+    keycloakUrl,
+    realm,
+    clientId,
+    authFilePath: authFile,
+  });
+});

--- a/raid-agency-app/e2e/auth/setup-unapproved-admin.ts
+++ b/raid-agency-app/e2e/auth/setup-unapproved-admin.ts
@@ -1,0 +1,52 @@
+// RAID-608: Auth setup for the "unapproved admin" role — a flat group-admin
+// who is only a raw, self-joined (never approved) member of the raid-au
+// service point's Keycloak group. Used to verify that such a user cannot
+// approve access requests for that service point (HELP-2844). Saves session
+// state to e2e/.auth/unapproved-admin.json.
+
+import { test as setup } from "@playwright/test";
+import { fileURLToPath } from "url";
+import path from "path";
+import { authenticateAndSaveState } from "./authenticate";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const authFile = path.join(__dirname, "../.auth/unapproved-admin.json");
+
+setup("authenticate as unapproved group-admin", async ({ page, baseURL }) => {
+  const username = process.env.VITE_KEYCLOAK_E2E_UNAPPROVED_ADMIN_USER;
+  const password = process.env.VITE_KEYCLOAK_E2E_UNAPPROVED_ADMIN_PASSWORD;
+  const keycloakUrl = process.env.VITE_KEYCLOAK_URL;
+  const realm = process.env.VITE_KEYCLOAK_REALM;
+  const clientId = process.env.VITE_KEYCLOAK_CLIENT_ID;
+
+  if (!username) {
+    throw new Error(
+      "VITE_KEYCLOAK_E2E_UNAPPROVED_ADMIN_USER environment variable is not set. " +
+        "Add it to your .env file."
+    );
+  }
+  if (!password) {
+    throw new Error(
+      "VITE_KEYCLOAK_E2E_UNAPPROVED_ADMIN_PASSWORD environment variable is not set. " +
+        "Add it to your .env file."
+    );
+  }
+  if (!keycloakUrl || !realm || !clientId) {
+    throw new Error(
+      "VITE_KEYCLOAK_URL, VITE_KEYCLOAK_REALM and VITE_KEYCLOAK_CLIENT_ID " +
+        "must all be set. Add them to your .env file."
+    );
+  }
+
+  await authenticateAndSaveState({
+    page,
+    baseURL,
+    username,
+    password,
+    keycloakUrl,
+    realm,
+    clientId,
+    authFilePath: authFile,
+  });
+});

--- a/raid-agency-app/e2e/auth/setup.ts
+++ b/raid-agency-app/e2e/auth/setup.ts
@@ -13,6 +13,7 @@
 import { test as setup } from "@playwright/test";
 import { fileURLToPath } from "url";
 import path from "path";
+import { authenticateAndSaveState } from "./authenticate";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -44,51 +45,14 @@ setup("authenticate", async ({ page, baseURL }) => {
     );
   }
 
-  const tokenResponse = await page.request.post(
-    `${keycloakUrl}/realms/${realm}/protocol/openid-connect/token`,
-    {
-      form: {
-        grant_type: "password",
-        client_id: clientId,
-        username,
-        password,
-      },
-    }
-  );
-
-  if (!tokenResponse.ok()) {
-    throw new Error(
-      `Direct grant token request failed: ${tokenResponse.status()} ${await tokenResponse.text()}`
-    );
-  }
-
-  const tokens = await tokenResponse.json();
-
-  // Visit the app origin so the seeded key lands in the right localStorage origin,
-  // without ever hitting Keycloak's rendered login page.
-  await page.goto(baseURL ?? "/");
-  await page.evaluate(
-    ({ token, refreshToken, idToken }) => {
-      localStorage.setItem(
-        "__e2e_auth_tokens__",
-        JSON.stringify({ token, refreshToken, idToken })
-      );
-    },
-    {
-      token: tokens.access_token,
-      refreshToken: tokens.refresh_token,
-      idToken: tokens.id_token,
-    }
-  );
-
-  // Reload so KeycloakContext picks up the seeded tokens on init.
-  await page.reload();
-  await page.waitForFunction(
-    () => !window.location.pathname.startsWith("/login"),
-    { timeout: 15000 }
-  );
-  await page.waitForLoadState("networkidle");
-
-  // Save authenticated session state
-  await page.context().storageState({ path: authFile });
+  await authenticateAndSaveState({
+    page,
+    baseURL,
+    username,
+    password,
+    keycloakUrl,
+    realm,
+    clientId,
+    authFilePath: authFile,
+  });
 });

--- a/raid-agency-app/e2e/tests/operator/service-point-group-id-error.spec.ts
+++ b/raid-agency-app/e2e/tests/operator/service-point-group-id-error.spec.ts
@@ -1,0 +1,68 @@
+// RAID-659: e2e test for the operator "Manage service points" page.
+//
+// Before this fix, a service point whose Keycloak group could not be
+// resolved (a dangling/invalid groupId) caused the *entire* list request to
+// reject, replacing the whole table with a generic "Service point could not
+// be fetched" error - even for service points whose groups were fine. The
+// fix (see fetchServicePointsWithMembers in
+// src/services/service-points/index.ts) catches the failure per service
+// point and flags just that row via `groupIdError`, which
+// ServicePointsTable/GroupIdCell renders as an "Group ID is invalid" icon.
+//
+// This test targets the seeded "raido" service point (group_id
+// 169bd3f3-dd42-4ac0-b89a-fb49648e5eff - see
+// api-svc/db/src/main/resources/db/env/dev/V32.1__update_service_point_repository.sql)
+// and mocks only that group's Keycloak lookup to fail, leaving every other
+// service point's lookup untouched, to prove the failure is now isolated.
+//
+// Runs against the "operator" role (chromium-operator project) since the
+// operator table is only rendered for users with the `operator` realm role.
+
+import { test, expect } from "@playwright/test";
+
+const RAID_AU_GROUP_ID = "169bd3f3-dd42-4ac0-b89a-fb49648e5eff";
+
+test.describe("Service points: invalid group ID handling", () => {
+  test(
+    "shows a graceful per-row error instead of breaking the whole table",
+    { tag: "@local" },
+    async ({ page }) => {
+      await page.route(
+        (url) =>
+          url.pathname.endsWith("/group") &&
+          url.searchParams.get("groupId") === RAID_AU_GROUP_ID,
+        (route) => route.fulfill({ status: 404, body: "Group not found" })
+      );
+
+      await page.goto("/service-points");
+
+      const grid = page.getByRole("grid");
+      await expect(grid).toBeVisible({ timeout: 15000 });
+
+      // The whole view must not have fallen back to the generic error state.
+      await expect(
+        page.getByText("Service point could not be fetched")
+      ).toHaveCount(0);
+
+      const affectedRow = page.getByRole("row").filter({ hasText: "raido" });
+      await expect(affectedRow).toBeVisible();
+      await expect(
+        affectedRow.locator('[data-field="groupId"] [data-testid="ErrorOutlineIcon"]')
+      ).toBeVisible();
+
+      await affectedRow
+        .locator('[data-field="groupId"] [data-testid="ErrorOutlineIcon"]')
+        .hover();
+      await expect(page.getByRole("tooltip")).toHaveText("Group ID is invalid");
+
+      // Other, unaffected service points still render normally.
+      const uqRow = page
+        .getByRole("row")
+        .filter({ hasText: "RAiD AU Test Registry 2" });
+      await expect(uqRow).toBeVisible();
+      await expect(
+        uqRow.locator('[data-field="groupId"] [data-testid="CheckCircleOutlineIcon"]')
+      ).toBeVisible();
+    }
+  );
+});

--- a/raid-agency-app/e2e/tests/operator/service-point-ror-validation.spec.ts
+++ b/raid-agency-app/e2e/tests/operator/service-point-ror-validation.spec.ts
@@ -1,0 +1,50 @@
+// RAID-480: e2e test for the "Create Service Point" form (operator-only).
+//
+// A service point created without a valid ROR previously stored blanks
+// (whitespace/tabs) as its identifier owner, which silently broke minting
+// for that service point in Demo and Prod. The fix added a required, format
+// -checked `identifierOwner` field to the Zod validation schema (see
+// createServicePointRequestValidationSchema in
+// src/pages/service-point/validation/Rules.tsx), so a blank ROR is now
+// rejected client-side before the request ever reaches the API.
+//
+// This test deliberately avoids driving the ROR lookup widget itself (it
+// calls the external api.ror.org API - see the TODO in
+// e2e/tests/03-optional-metadata.spec.ts for the existing precedent of not
+// depending on that live API in e2e). Leaving the field untouched exercises
+// the same "blank identifierOwner" defect class the ticket describes.
+//
+// Runs against the "operator" role (chromium-operator project) since the
+// create form is only rendered for users with the `operator` realm role.
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Service point creation: ROR is required", () => {
+  test(
+    "blocks submission when the Service Point Owner ROR field is left blank",
+    { tag: "@local" },
+    async ({ page }) => {
+      await page.goto("/service-points");
+
+      await page.getByRole("button", { name: /Create Service Point/ }).click();
+
+      await page
+        .getByLabel("Service point name *")
+        .fill("E2E ROR Validation Test");
+      await page.getByLabel("Admin email *").fill("e2e-admin@example.com");
+      await page.getByLabel("Tech email *").fill("e2e-tech@example.com");
+      // Deliberately leave the ROR ("Service Point Owner") field blank.
+
+      await page.getByRole("button", { name: "Create" }).click();
+
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible({ timeout: 5000 });
+      await expect(dialog).toContainText("Identifier owner is required");
+
+      // The form must not have submitted.
+      await expect(
+        page.getByText("Service point created successfully")
+      ).toHaveCount(0);
+    }
+  );
+});

--- a/raid-agency-app/e2e/tests/operator/service-point-ror-validation.spec.ts
+++ b/raid-agency-app/e2e/tests/operator/service-point-ror-validation.spec.ts
@@ -8,11 +8,24 @@
 // src/pages/service-point/validation/Rules.tsx), so a blank ROR is now
 // rejected client-side before the request ever reaches the API.
 //
-// This test deliberately avoids driving the ROR lookup widget itself (it
-// calls the external api.ror.org API - see the TODO in
-// e2e/tests/03-optional-metadata.spec.ts for the existing precedent of not
-// depending on that live API in e2e). Leaving the field untouched exercises
-// the same "blank identifierOwner" defect class the ticket describes.
+// This test deliberately types free text into the ROR field rather than
+// leaving it completely empty. The underlying <input> also carries a native
+// HTML `required` attribute (CustomizedInputBase's `required` prop), and a
+// genuinely empty required input makes the browser's own constraint
+// validation intercept the click before React/RHF/Zod ever see a submit -
+// no dialog, no network call, nothing observable in the DOM (confirmed by
+// stepping through this manually: a real click or Enter-key submit attempt
+// on a blank required field never fires the form's submit event at all).
+// Typing free text (without using the ROR search+select dropdown - see the
+// TODO in e2e/tests/03-optional-metadata.spec.ts for why e2e avoids the live
+// api.ror.org lookup) satisfies that native check while leaving the actual
+// react-hook-form value unset, since CustomizedInputBase only calls
+// setSelectedValue (and therefore updates the form) when a dropdown result
+// is picked. That reproduces the exact RAID-480 defect class: a user typing
+// something that looks like a value, which never actually becomes the
+// identifierOwner sent to the API - and lets the submission reach Zod,
+// which correctly blocks it and shows the "Identifier owner is required"
+// dialog.
 //
 // Runs against the "operator" role (chromium-operator project) since the
 // create form is only rendered for users with the `operator` realm role.
@@ -21,7 +34,7 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Service point creation: ROR is required", () => {
   test(
-    "blocks submission when the Service Point Owner ROR field is left blank",
+    "blocks submission when the ROR field was typed into but never selected from the lookup",
     { tag: "@local" },
     async ({ page }) => {
       await page.goto("/service-points");
@@ -33,9 +46,13 @@ test.describe("Service point creation: ROR is required", () => {
         .fill("E2E ROR Validation Test");
       await page.getByLabel("Admin email *").fill("e2e-admin@example.com");
       await page.getByLabel("Tech email *").fill("e2e-tech@example.com");
-      // Deliberately leave the ROR ("Service Point Owner") field blank.
+      // Typed, but never selected from the ROR search dropdown - the
+      // identifierOwner form value stays unset despite this non-empty input.
+      await page
+        .getByLabel("Search Text or lookup ROR ID")
+        .fill("not-a-real-ror-value");
 
-      await page.getByRole("button", { name: "Create" }).click();
+      await page.getByRole("button", { name: "Create", exact: true }).click();
 
       const dialog = page.getByRole("dialog");
       await expect(dialog).toBeVisible({ timeout: 5000 });

--- a/raid-agency-app/e2e/tests/unapproved-admin/service-point-admin-authorization.spec.ts
+++ b/raid-agency-app/e2e/tests/unapproved-admin/service-point-admin-authorization.spec.ts
@@ -1,0 +1,76 @@
+// RAID-608 / HELP-2844: a user elevated to the flat `group-admin` role, but
+// never actually approved (granted service-point-user) for a given service
+// point, was able to approve access requests for that service point via the
+// notification centre despite never being explicitly granted access. Fixed
+// in iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java
+// (isGroupAdminOf's flat fallback now requires isApprovedGroupMember, not
+// just group membership) - see GroupServicePointAdminIntegrationTest.java
+// for the backend-level coverage this e2e test complements.
+//
+// Uses two dedicated fixture users (see iam/doc/keycloak-configuration.md):
+//   - raid-au-unapproved-admin: group-admin role, raw self-joined member of
+//     the raid-au group, never granted service-point-user for it.
+//   - raid-au-pending-user: raw self-joined member of raid-au with no roles,
+//     i.e. a colleague's outstanding access request.
+//
+// Runs against the dedicated unapproved-admin session (chromium-unapproved-
+// -admin project).
+
+import { test, expect } from "@playwright/test";
+
+const PENDING_USERNAME = "raid-au-pending-user";
+
+test.describe("Service point admin authorization: unapproved group-admin", () => {
+  test(
+    "cannot approve a pending access request for a service point they are not an approved member of",
+    { tag: "@local" },
+    async ({ page }) => {
+      await page.goto("/");
+
+      // The notification bell (AppNavBar) polls for pending access requests
+      // for any service point the signed-in group-admin administers.
+      const bell = page.getByRole("button").filter({
+        has: page.getByTestId("NotificationsIcon"),
+      });
+      await bell.click();
+
+      // Notification groups render as collapsed accordions; expand the
+      // (only) one so its pending-member list items actually become visible.
+      // Scoped to the notification Drawer (MUI portals it to document.body)
+      // so this doesn't accidentally match an unrelated collapsed control
+      // elsewhere on the page, e.g. a header dropdown.
+      const drawer = page.locator(".MuiDrawer-root");
+      const accordionToggle = drawer.locator('[aria-expanded="false"]').first();
+      await accordionToggle.waitFor({ timeout: 15000 });
+      await accordionToggle.click();
+
+      const pendingItem = page.getByRole("listitem").filter({
+        hasText: PENDING_USERNAME,
+      });
+      await expect(pendingItem).toBeVisible({ timeout: 15000 });
+
+      const approveButton = pendingItem.getByRole("button", { name: "Approve" });
+
+      const grantResponse = page.waitForResponse(
+        (response) =>
+          response.url().endsWith("/group/grant") && response.request().method() === "PUT"
+      );
+      await approveButton.click();
+      const response = await grantResponse;
+
+      // The backend must reject the approval - the admin has no approved
+      // membership of raid-au, only a flat group-admin role. JAX-RS's
+      // NotAuthorizedException maps to 401 (see GroupController.grant()),
+      // but assert loosely against 401/403 to match the existing backend
+      // test convention (GroupServicePointAdminIntegrationTest#assertDenied).
+      expect([401, 403]).toContain(response.status());
+
+      await expect(page.getByRole("alert")).toContainText(
+        "Failed to perform operation"
+      );
+
+      // The request must still be pending - it was not granted.
+      await expect(pendingItem).toBeVisible();
+    }
+  );
+});

--- a/raid-agency-app/e2e/tests/unapproved-admin/service-point-admin-authorization.spec.ts
+++ b/raid-agency-app/e2e/tests/unapproved-admin/service-point-admin-authorization.spec.ts
@@ -7,6 +7,16 @@
 // just group membership) - see GroupServicePointAdminIntegrationTest.java
 // for the backend-level coverage this e2e test complements.
 //
+// isGroupAdminOf gates every group-scoped IAM endpoint uniformly, including
+// the GET used to list a group's members - so the notification centre's own
+// query is denied for this admin the exact same way grant() is, and it never
+// surfaces the pending request to them in the first place. That means there
+// is no UI path to click through to "Approve" here (which is itself part of
+// what the fix guarantees), so this test verifies the fix directly against
+// the API the UI's Approve button calls, using the unapproved admin's own
+// session token, plus a UI-level check that the app honestly shows them as
+// unapproved rather than silently offering a working approve action.
+//
 // Uses two dedicated fixture users (see iam/doc/keycloak-configuration.md):
 //   - raid-au-unapproved-admin: group-admin role, raw self-joined member of
 //     the raid-au group, never granted service-point-user for it.
@@ -16,61 +26,101 @@
 // Runs against the dedicated unapproved-admin session (chromium-unapproved-
 // -admin project).
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type APIRequestContext } from "@playwright/test";
 
+const RAID_AU_GROUP_ID = "169bd3f3-dd42-4ac0-b89a-fb49648e5eff";
 const PENDING_USERNAME = "raid-au-pending-user";
+
+async function getAccessToken(
+  request: APIRequestContext,
+  { username, password }: { username: string; password: string }
+): Promise<string> {
+  const keycloakUrl = process.env.VITE_KEYCLOAK_URL!;
+  const realm = process.env.VITE_KEYCLOAK_REALM!;
+  const clientId = process.env.VITE_KEYCLOAK_CLIENT_ID!;
+
+  const response = await request.post(
+    `${keycloakUrl}/realms/${realm}/protocol/openid-connect/token`,
+    {
+      form: {
+        grant_type: "password",
+        client_id: clientId,
+        username,
+        password,
+      },
+    }
+  );
+  const body = await response.json();
+  return body.access_token;
+}
 
 test.describe("Service point admin authorization: unapproved group-admin", () => {
   test(
     "cannot approve a pending access request for a service point they are not an approved member of",
     { tag: "@local" },
-    async ({ page }) => {
-      await page.goto("/");
+    async ({ page, request }) => {
+      const keycloakUrl = process.env.VITE_KEYCLOAK_URL!;
+      const realm = process.env.VITE_KEYCLOAK_REALM!;
 
-      // The notification bell (AppNavBar) polls for pending access requests
-      // for any service point the signed-in group-admin administers.
+      // UI-level: the app must honestly reflect that this admin has no
+      // approved access, rather than silently offering a working approve
+      // action it can't actually back up.
+      await page.goto("/");
+      await expect(
+        page.getByText(/has not granted you access yet/i)
+      ).toBeVisible({ timeout: 15000 });
+
       const bell = page.getByRole("button").filter({
         has: page.getByTestId("NotificationsIcon"),
       });
       await bell.click();
-
-      // Notification groups render as collapsed accordions; expand the
-      // (only) one so its pending-member list items actually become visible.
-      // Scoped to the notification Drawer (MUI portals it to document.body)
-      // so this doesn't accidentally match an unrelated collapsed control
-      // elsewhere on the page, e.g. a header dropdown.
-      const drawer = page.locator(".MuiDrawer-root");
-      const accordionToggle = drawer.locator('[aria-expanded="false"]').first();
-      await accordionToggle.waitFor({ timeout: 15000 });
-      await accordionToggle.click();
-
-      const pendingItem = page.getByRole("listitem").filter({
-        hasText: PENDING_USERNAME,
+      await expect(page.getByText("0 pending requests")).toBeVisible({
+        timeout: 15000,
       });
-      await expect(pendingItem).toBeVisible({ timeout: 15000 });
+      await expect(page.getByText("No notifications")).toBeVisible();
 
-      const approveButton = pendingItem.getByRole("button", { name: "Approve" });
-
-      const grantResponse = page.waitForResponse(
-        (response) =>
-          response.url().endsWith("/group/grant") && response.request().method() === "PUT"
+      // Look up the pending colleague's Keycloak user id via the operator
+      // account - test setup only. The security assertion below is made
+      // with the unapproved admin's own token, not the operator's.
+      const operatorToken = await getAccessToken(request, {
+        username: process.env.VITE_KEYCLOAK_E2E_OPERATOR_USER!,
+        password: process.env.VITE_KEYCLOAK_E2E_OPERATOR_PASSWORD!,
+      });
+      const groupResponse = await request.get(
+        `${keycloakUrl}/realms/${realm}/group/?groupId=${RAID_AU_GROUP_ID}`,
+        { headers: { Authorization: `Bearer ${operatorToken}` } }
       );
-      await approveButton.click();
-      const response = await grantResponse;
+      expect(groupResponse.ok()).toBe(true);
+      const group = await groupResponse.json();
+      const pendingMember = (
+        group.members as { id: string; attributes: { username: string[] } }[]
+      ).find((member) => member.attributes.username?.[0] === PENDING_USERNAME);
+      expect(pendingMember, "expected raid-au-pending-user to be a member of raid-au").toBeTruthy();
+
+      // Attempt the exact request the UI's "Approve" button issues
+      // (updateUserServicePointUserRole -> PUT /group/grant), using the
+      // unapproved admin's own token.
+      const adminToken = await getAccessToken(request, {
+        username: process.env.VITE_KEYCLOAK_E2E_UNAPPROVED_ADMIN_USER!,
+        password: process.env.VITE_KEYCLOAK_E2E_UNAPPROVED_ADMIN_PASSWORD!,
+      });
+      const grantResponse = await request.put(
+        `${keycloakUrl}/realms/${realm}/group/grant`,
+        {
+          headers: {
+            Authorization: `Bearer ${adminToken}`,
+            "Content-Type": "application/json",
+          },
+          data: { userId: pendingMember!.id, groupId: RAID_AU_GROUP_ID },
+        }
+      );
 
       // The backend must reject the approval - the admin has no approved
       // membership of raid-au, only a flat group-admin role. JAX-RS's
       // NotAuthorizedException maps to 401 (see GroupController.grant()),
       // but assert loosely against 401/403 to match the existing backend
       // test convention (GroupServicePointAdminIntegrationTest#assertDenied).
-      expect([401, 403]).toContain(response.status());
-
-      await expect(page.getByRole("alert")).toContainText(
-        "Failed to perform operation"
-      );
-
-      // The request must still be pending - it was not granted.
-      await expect(pendingItem).toBeVisible();
+      expect([401, 403]).toContain(grantResponse.status());
     }
   );
 });

--- a/raid-agency-app/playwright.config.ts
+++ b/raid-agency-app/playwright.config.ts
@@ -44,6 +44,14 @@ export default defineConfig({
       name: "setup",
       testMatch: /auth\/setup\.ts/,
     },
+    {
+      name: "setup-operator",
+      testMatch: /auth\/setup-operator\.ts/,
+    },
+    {
+      name: "setup-unapproved-admin",
+      testMatch: /auth\/setup-unapproved-admin\.ts/,
+    },
 
     {
       name: "chromium",
@@ -52,6 +60,34 @@ export default defineConfig({
         storageState: "e2e/.auth/user.json",
       },
       dependencies: ["setup"],
+      // Role-specific suites run under their own project below, against
+      // their own storageState - excluded here so they don't also run
+      // against the default service-point-user session.
+      testIgnore: [/tests[\\/]operator[\\/]/, /tests[\\/]unapproved-admin[\\/]/],
+    },
+
+    // RAID-659 / RAID-480: tests that require the `operator` role to see the
+    // "Manage service points" page.
+    {
+      name: "chromium-operator",
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "e2e/.auth/operator.json",
+      },
+      dependencies: ["setup-operator"],
+      testMatch: /tests[\\/]operator[\\/]/,
+    },
+
+    // RAID-608: tests that require a flat group-admin with only a raw,
+    // unapproved membership of the raid-au service point's group.
+    {
+      name: "chromium-unapproved-admin",
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "e2e/.auth/unapproved-admin.json",
+      },
+      dependencies: ["setup-unapproved-admin"],
+      testMatch: /tests[\\/]unapproved-admin[\\/]/,
     },
 
     // {

--- a/raid-agency-app/src/pages/service-point/components/ServicePointUpdateForm.test.tsx
+++ b/raid-agency-app/src/pages/service-point/components/ServicePointUpdateForm.test.tsx
@@ -28,7 +28,7 @@ vi.mock("@/services/service-points", () => ({
 const makeServicePoint = (overrides: Partial<ServicePoint> = {}): ServicePoint => ({
   id: 1,
   name: "Test Service Point",
-  identifierOwner: "https://ror.org/123",
+  identifierOwner: "https://ror.org/038sjwq14",
   adminEmail: "admin@test.com",
   techEmail: "tech@test.com",
   enabled: true,

--- a/raid-agency-app/src/pages/service-point/validation/Rules.test.ts
+++ b/raid-agency-app/src/pages/service-point/validation/Rules.test.ts
@@ -1,0 +1,70 @@
+// RAID-480: unit tests for the Service Point Owner (identifierOwner/ROR)
+// validation. Before this fix, a blank or whitespace ROR could be submitted
+// and stored, which silently broke minting for that service point in Demo
+// and Prod - see e2e/tests/operator/service-point-ror-validation.spec.ts for
+// the corresponding UI-level coverage of the Create Service Point form.
+
+import { describe, it, expect } from "vitest";
+import { createServicePointRequestValidationSchema } from "./Rules";
+
+const validServicePoint = {
+  name: "Test Service Point",
+  identifierOwner: "https://ror.org/038sjwq14",
+  adminEmail: "admin@example.com",
+  techEmail: "tech@example.com",
+  enabled: true,
+  appWritesEnabled: false,
+};
+
+const parse = (identifierOwner: string) =>
+  createServicePointRequestValidationSchema.safeParse({
+    servicePointCreateRequest: { ...validServicePoint, identifierOwner },
+  });
+
+describe("createServicePointRequestValidationSchema: identifierOwner (ROR)", () => {
+  it("accepts a well-formed ROR URL", () => {
+    const result = parse("https://ror.org/038sjwq14");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a blank identifierOwner", () => {
+    const result = parse("");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((issue) => issue.message);
+      expect(messages).toContain("Identifier owner is required");
+    }
+  });
+
+  it("rejects a whitespace/tab-only identifierOwner (RAID-480: previously stored as-is)", () => {
+    const result = parse("\t\t");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((issue) => issue.message);
+      expect(messages).toContain(
+        "Must be a valid ROR URL (e.g. https://ror.org/038sjwq14)"
+      );
+    }
+  });
+
+  it("rejects a non-ROR URL", () => {
+    const result = parse("https://example.com/not-a-ror");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((issue) => issue.message);
+      expect(messages).toContain(
+        "Must be a valid ROR URL (e.g. https://ror.org/038sjwq14)"
+      );
+    }
+  });
+
+  it("rejects a ROR URL with an invalid ID length", () => {
+    const result = parse("https://ror.org/abc");
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/raid-agency-app/src/services/service-points/index.test.ts
+++ b/raid-agency-app/src/services/service-points/index.test.ts
@@ -1,0 +1,154 @@
+// RAID-659: unit tests for the per-service-point group ID error handling in
+// fetchServicePointsWithMembers/fetchServicePointWithMembers. Before this fix,
+// a single service point whose Keycloak group could not be resolved (a
+// non-ok response, or a thrown network error) caused the whole call to
+// reject - see e2e/tests/operator/service-point-group-id-error.spec.ts for
+// the corresponding UI-level coverage of GroupIdCell rendering the resulting
+// `groupIdError` flag.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { RuntimeConfig } from "@/config/RuntimeConfig";
+
+vi.mock("@/config", () => ({
+  getRuntimeConfig: vi.fn(),
+}));
+
+vi.mock("@/services/auth-service.ts", () => ({
+  authService: {
+    fetchWithAuth: vi.fn(),
+  },
+}));
+
+import { getRuntimeConfig } from "@/config";
+import { authService } from "@/services/auth-service.ts";
+import {
+  fetchServicePointsWithMembers,
+  fetchServicePointWithMembers,
+} from "./index";
+
+const mockConfig: Pick<RuntimeConfig, "apiBaseUrl" | "keycloak"> = {
+  apiBaseUrl: "https://api.test.raid.org.au",
+  keycloak: {
+    url: "https://keycloak.test.raid.org.au",
+    realm: "raid",
+    clientId: "raid-api",
+  },
+};
+
+const jsonResponse = (body: unknown, ok = true) => ({
+  ok,
+  json: async () => body,
+});
+
+const GOOD_GROUP_ID = "good-group-id";
+const BAD_GROUP_ID = "bad-group-id";
+
+describe("fetchServicePointsWithMembers", () => {
+  beforeEach(() => {
+    vi.mocked(getRuntimeConfig).mockReturnValue(mockConfig as RuntimeConfig);
+    vi.mocked(authService.fetchWithAuth).mockReset();
+  });
+
+  it("flags only the service point whose group lookup fails, leaving others intact", async () => {
+    vi.mocked(authService.fetchWithAuth).mockImplementation(async (url: string) => {
+      if (url.includes("/service-point/")) {
+        return jsonResponse([
+          { id: 1, name: "Good SP", groupId: GOOD_GROUP_ID },
+          { id: 2, name: "Bad SP", groupId: BAD_GROUP_ID },
+        ]) as Response;
+      }
+      if (url.includes(`groupId=${GOOD_GROUP_ID}`)) {
+        return jsonResponse({ members: [{ id: "member-1" }] }) as Response;
+      }
+      if (url.includes(`groupId=${BAD_GROUP_ID}`)) {
+        return jsonResponse({}, false) as Response;
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    const result = await fetchServicePointsWithMembers({ token: "t" });
+
+    const good = result.find((sp) => sp.id === 1)!;
+    const bad = result.find((sp) => sp.id === 2)!;
+
+    expect(good.groupIdError).toBe(false);
+    expect(good.members).toEqual([{ id: "member-1" }]);
+
+    expect(bad.groupIdError).toBe(true);
+    expect(bad.members).toEqual([]);
+  });
+
+  it("flags a service point whose group lookup throws (network error) rather than rejecting the whole call", async () => {
+    vi.mocked(authService.fetchWithAuth).mockImplementation(async (url: string) => {
+      if (url.includes("/service-point/")) {
+        return jsonResponse([{ id: 1, name: "SP", groupId: BAD_GROUP_ID }]) as Response;
+      }
+      throw new TypeError("Failed to fetch");
+    });
+
+    const result = await fetchServicePointsWithMembers({ token: "t" });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].groupIdError).toBe(true);
+    expect(result[0].members).toEqual([]);
+  });
+
+  it("does not attempt a group lookup, and does not flag an error, when groupId is blank", async () => {
+    vi.mocked(authService.fetchWithAuth).mockImplementation(async (url: string) => {
+      if (url.includes("/service-point/")) {
+        return jsonResponse([{ id: 1, name: "SP", groupId: "  " }]) as Response;
+      }
+      throw new Error(`Unexpected group lookup for URL: ${url}`);
+    });
+
+    const result = await fetchServicePointsWithMembers({ token: "t" });
+
+    expect(result[0].groupIdError).toBe(false);
+    expect(result[0].members).toEqual([]);
+  });
+});
+
+describe("fetchServicePointWithMembers", () => {
+  beforeEach(() => {
+    vi.mocked(getRuntimeConfig).mockReturnValue(mockConfig as RuntimeConfig);
+    vi.mocked(authService.fetchWithAuth).mockReset();
+  });
+
+  it("returns groupIdError: true instead of throwing when the group lookup responds non-ok", async () => {
+    vi.mocked(authService.fetchWithAuth).mockImplementation(async (url: string) => {
+      if (url.includes("/service-point/")) {
+        return jsonResponse({ id: 1, name: "SP", groupId: BAD_GROUP_ID }) as Response;
+      }
+      return jsonResponse({}, false) as Response;
+    });
+
+    const result = await fetchServicePointWithMembers({ id: 1, token: "t" });
+
+    expect(result.groupIdError).toBe(true);
+    expect(result.members).toEqual([]);
+  });
+
+  it("returns groupIdError: true instead of throwing when the group lookup throws", async () => {
+    vi.mocked(authService.fetchWithAuth).mockImplementation(async (url: string) => {
+      if (url.includes("/service-point/")) {
+        return jsonResponse({ id: 1, name: "SP", groupId: BAD_GROUP_ID }) as Response;
+      }
+      throw new TypeError("Failed to fetch");
+    });
+
+    const result = await fetchServicePointWithMembers({ id: 1, token: "t" });
+
+    expect(result.groupIdError).toBe(true);
+    expect(result.members).toEqual([]);
+  });
+
+  it("still throws when the service point itself cannot be fetched", async () => {
+    vi.mocked(authService.fetchWithAuth).mockResolvedValue(
+      jsonResponse({}, false) as Response
+    );
+
+    await expect(fetchServicePointWithMembers({ id: 1, token: "t" })).rejects.toThrow(
+      "Failed to fetch service point"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds end-to-end and unit test coverage for three previously-merged defect fixes (RAID-659, RAID-480, RAID-608), fixes the resulting e2e tests once run against the real backend/Keycloak stack, and fixes an unrelated citation-rendering bug on the static site's RAiD landing pages.

## Changes

### Test coverage: RAID-659, RAID-480, RAID-608
- **RAID-659** — e2e coverage for the operator-only "invalid group ID" graceful error state; unit tests verifying `fetchServicePointsWithMembers`/`fetchServicePointWithMembers` isolate a failing/throwing Keycloak group lookup per service point instead of rejecting the whole call.
- **RAID-480** — e2e coverage for blank-ROR rejection on service point creation; unit tests for `createServicePointRequestValidationSchema` covering blank, whitespace-only, and malformed ROR values; fixed a stale `ServicePointUpdateForm.test.tsx` fixture (3-character `identifierOwner`) that no longer matched the RAID-480 ROR regex.
- **RAID-608** — e2e coverage for the unapproved flat group-admin authorization fix. No new backend unit test added — already covered by `GroupControllerTest` (`grant_deniesFlatGroupAdminPendingUnapprovedMemberWhenFallbackEnabled` et al).
- Added `raid-au-pending-user` and `raid-au-unapproved-admin` fixture users to the Keycloak realm, plus role-specific Playwright auth projects, since none of these flows were reachable by the existing single e2e session.

### E2E fixes against the real backend/Keycloak stack
- `service-point-ror-validation.spec.ts`: a blank ROR input hits the browser's native `required` attribute before React/Zod ever sees it. Test now types free text into the field without selecting it from the ROR lookup dropdown, satisfying native validation while leaving the actual form value unset — reproducing the real RAID-480 defect and correctly reaching the Zod "Identifier owner is required" dialog.
- `service-point-admin-authorization.spec.ts`: `isGroupAdminOf` gates the group-members GET the same way it gates `grant()`, so there's no UI path to an "Approve" button for an unapproved admin to click. Rewrote the test to assert the UI honestly shows them as unapproved (banner, 0 pending requests), and to verify the denial directly against the `grant()` endpoint using the admin's own token.
- Fixed a ROR button/name locator strict-mode collision (`getByRole "Create"` matched both the accordion header and the submit button).
- Requires two out-of-repo environment setup steps (not part of this PR): local `.env` needs the new `VITE_KEYCLOAK_E2E_OPERATOR_*` / `_UNAPPROVED_ADMIN_*` vars (documented in `.env.template`), and a running Keycloak needs the two new realm fixture users created via the admin API or a fresh import.

### RelatedObjects citation ampersand fix (static site)
- Citation text in the RelatedObjects section was being run through `marked()` (a Markdown parser) even though it's plain bibliographic text returned by doi.org, not markdown — risking mangled output.
- Also added `decodeHtmlEntities()`, applied to citation text before display, which collapses any depth of HTML-entity over-encoding (e.g. `&amp;amp;`, or the mis-cased `&Amp;` some DOI registration agencies emit) down to the real character, so it can't render as literal `&amp;` on the page.
- Added unit tests covering single/double/mis-cased entity encoding and confirming embedded `<i>` tags (some DOI citations include real HTML markup) survive untouched.

## Test plan
- [x] Unit tests added/updated: `service-points/index.test.ts`, `Rules.test.ts`, `ServicePointUpdateForm.test.tsx`, `utils.test.ts`
- [x] E2E specs added: `service-point-group-id-error.spec.ts`, `service-point-ror-validation.spec.ts`, `service-point-admin-authorization.spec.ts`
- [ ] E2E suite run against a real backend/Keycloak stack with the required `.env` vars and realm fixture users in place
- [ ] Re-check `10.83052/32d488f6` (or an equivalent record with an ampersand citation) after the static site's next rebuild to confirm no visible HTML entities remain
