### PR TITLE
RAID-849: cap credentials per service point, defer rate limiting

### DIFF
--- a/doc/adr/2026-08-26_scoped-client-credential-quota.md
+++ b/doc/adr/2026-08-26_scoped-client-credential-quota.md
@@ -1,0 +1,154 @@
+### Rate limiting and quota for scoped client credential endpoints
+
+* Status: final
+* Who: proposed and finalised by RL
+* When: 2026-08-26
+* Related: RAID-711 (epic), RAID-827 (story), RAID-849 (this spike),
+  RAID-767 (source investigation), RAID-714 (RAID-827 was split from it)
+
+
+# Context
+
+RAID-827 adds Keycloak SPI endpoints that let a Service Point Admin self-serve
+their own service point's API client credentials: create, list, rotate, revoke
+and get-secret. The story left rate limiting as an explicit open question.
+RAID-849 investigated the current state and decided it.
+
+The investigation established the following, all of which shape the decision.
+
+1. **Nothing throttles anything today.** There is no rate limiting, throttling
+   or backpressure in `api-svc/` or `iam/`: no bucket4j, resilience4j, Guava
+   `RateLimiter`, and no request-counting filter. The only throttle code in the
+   repo is outbound client-side backoff in build tooling
+   (`buildSrc/src/main/java/au/org/raid/api/Utils.java`), used to poll the ARDC
+   SPARQL vocabulary endpoint politely during code generation.
+
+2. **There is no edge layer to lean on.** `raido-v2-aws-private` contains no
+   WAFv2 WebACL, no rate-based rules, no API Gateway throttling or usage plans,
+   and no CloudFront or ALB request limiting. Keycloak is reached at
+   `iam.<zone>` through an internet-facing Application Load Balancer whose only
+   listener filtering is host-header matching
+   (`registration-authority/cdk/lib/raid/stack/api.ts`). CloudFront fronts the
+   SPA and proxies some `api.<zone>` paths, but it does not front `iam.<zone>`,
+   so there is no existing hop where a WebACL could attach.
+
+3. **The `iam` module has no filter infrastructure.** It is a plain library jar
+   dropped into `/opt/keycloak/providers/`, with no `ContainerRequestFilter`,
+   no `ContainerResponseFilter` and no servlet filters of its own. The only
+   extension points in use are `@Provider`-annotated JAX-RS resources reached
+   through `RealmResourceProvider` dispatch.
+
+4. **There is no working per-endpoint SPI configuration mechanism.** All three
+   existing `RealmResourceProviderFactory` implementations have empty
+   `init(Config.Scope)` bodies, and `getResource()` constructs a fresh
+   controller per request, so `Config.Scope` never reaches the resource.
+   `GroupController` works around this by reading
+   `System.getenv("RAID_FLAT_GROUP_ADMIN_FALLBACK")`
+   (`iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java`,
+   around lines 62 to 68). Controller-per-request also means any counter state
+   would have to be static, with its own eviction design.
+
+5. **Keycloak brute-force protection is disabled.** `bruteForceProtected` is
+   `false` in `iam/realms/raid-realm.json` (line 38), which makes the
+   accompanying `failureFactor: 30` and `maxFailureWaitSeconds: 900` inert. It
+   would not have helped these endpoints in any case, because Keycloak's
+   brute-force detection covers login and credential flows, not custom SPI
+   resources.
+
+
+# Decision
+
+**1. No per-request rate limiting on the RAID-827 endpoints.**
+
+Every one of these endpoints requires an authenticated bearer token and is
+scoped to a single service point. There is nothing to guess: a caller either
+holds `service-point-admin:<groupId>` or does not, so `get-secret` is not an
+enumeration target and the brute-force threat that per-request rate limiting
+exists to address is small. Building it would require new filter
+infrastructure, a static counter with an eviction strategy, and an
+environment-variable configuration workaround, for a control that would not be
+a genuine guarantee: in-memory counters are per-node, so with more than one
+Keycloak task the effective limit becomes the configured limit multiplied by
+the task count.
+
+**2. Enforce a per-service-point quota on live credentials instead.**
+
+The material risk for this feature is not request rate, it is realm pollution.
+An authenticated admin, or more likely a runaway script, could create thousands
+of clients and degrade the realm. A quota addresses that directly.
+
+* Cap the number of active, non-revoked credentials per service point at
+  **10**.
+* Enforce the check in application code, alongside the per-service-point
+  isolation checks that RAID-827 already identifies as the real security
+  boundary. This needs no new infrastructure and is deterministic, so it is
+  straightforward to cover in the RAID-848 integration suite.
+* Reject a create that would exceed the cap with **409 Conflict** and an error
+  body naming the limit. Revoking a credential frees a slot.
+
+This lands in RAID-846 (endpoint implementation) with test coverage in
+RAID-848.
+
+**3. Edge rate limiting and realm brute-force protection are separate work.**
+
+Both are real gaps, but neither belongs inside RAID-827, and the second is
+arguably the larger exposure. Each gets its own ticket.
+
+
+# Alternatives considered
+
+* **Per-request rate limiting in a new JAX-RS `ContainerRequestFilter`:**
+  rejected for this story. It is the textbook answer, but here it buys little
+  against an authenticated and scoped surface, while requiring infrastructure
+  the module does not have. Revisit if these endpoints are ever exposed to a
+  broader caller set, or once a shared limiter exists that the SPI can use.
+
+* **Returning 429 for quota exhaustion:** rejected. The quota is a standing
+  limit on stored objects, not a rate. Overloading 429 would make it impossible
+  for a caller to distinguish "slow down and retry" from "delete something
+  first", and would leave no clean status code if a real rate limit is added
+  later.
+
+* **Relying on Keycloak brute-force protection:** rejected as insufficient
+  rather than wrong. It is disabled today, and even when enabled it does not
+  cover custom SPI resources. Enabling it is still worth doing, for the token
+  endpoint rather than for these endpoints, which is why it becomes its own
+  ticket.
+
+* **A WAFv2 rate-based rule as the whole answer:** rejected as the answer to
+  this question, though it should be built. It is coarse, operating on source
+  IP rather than on service point identity, so it cannot express "this admin
+  has created enough clients". It also carries a deployment sharp edge: the
+  WebACL would attach to the regional ALB, and branch environments share both
+  the test listener and the single Keycloak instance, so one WebACL would cover
+  the test environment and every branch environment at once. Useful as a blunt
+  outer layer, not as tenant-aware protection.
+
+* **A global cap on clients per realm:** rejected. It would let one noisy
+  service point exhaust the allowance for everyone, which is the opposite of
+  the per-tenant isolation this feature is built around.
+
+
+# Consequences
+
+* RAID-846 gains the quota check and the 409 response. RAID-848 gains positive
+  and negative coverage for it, including that revoking frees a slot.
+* The cap of 10 is a starting value chosen without production evidence, since
+  no comparable feature exists yet to measure. It is a constant in application
+  code, so raising it is a small change. Expect to revisit it once real usage
+  exists.
+* These endpoints remain without per-request rate limiting. That is an accepted
+  risk, recorded here rather than solved, and it sits alongside the residual
+  risk RAID-827 already accepts (the broker's `manage-clients` role is
+  realm-wide, with isolation enforced only in application code).
+* Two follow-up tickets are raised: a WAFv2 WebACL with a rate-based rule for
+  the ALB, and enabling realm brute-force protection. The second matters
+  because `client_credentials` token attempts against the very credentials this
+  feature mints are currently unthrottled at Keycloak's token endpoint.
+* One item is unverified and should be confirmed before any future in-memory
+  rate limiting is attempted: the Keycloak ECS service's task count. The
+  per-node counter problem described above only bites when more than one task
+  runs.
+* Note the existing Keycloak version skew, unchanged by this decision: the SPI
+  jar is compiled against 26.5.6 (`gradle/libs.versions.toml`) and runs on
+  26.6.2 (`iam/Dockerfile`).

--- a/doc/adr/2026-08-26_scoped-client-credential-quota.md
+++ b/doc/adr/2026-08-26_scoped-client-credential-quota.md
@@ -1,154 +1,165 @@
-### Rate limiting and quota for scoped client credential endpoints
+### Cap client credentials per service point, defer rate limiting
 
 * Status: final
 * Who: proposed and finalised by RL
 * When: 2026-08-26
 * Related: RAID-711 (epic), RAID-827 (story), RAID-849 (this spike),
-  RAID-767 (source investigation), RAID-714 (RAID-827 was split from it)
+  RAID-767 (source investigation), RAID-714 (RAID-827 was split from it),
+  RAID-851 (realm brute-force protection)
 
 
 # Context
 
 RAID-827 adds Keycloak SPI endpoints that let a Service Point Admin self-serve
 their own service point's API client credentials: create, list, rotate, revoke
-and get-secret. The story left rate limiting as an explicit open question.
-RAID-849 investigated the current state and decided it.
+and get-secret. It listed as an open task "decide and document rate-limiting
+behaviour for these endpoints". This ADR is that decision.
 
-The investigation established the following, all of which shape the decision.
+Two facts from the investigation frame it.
 
-1. **Nothing throttles anything today.** There is no rate limiting, throttling
-   or backpressure in `api-svc/` or `iam/`: no bucket4j, resilience4j, Guava
-   `RateLimiter`, and no request-counting filter. The only throttle code in the
-   repo is outbound client-side backoff in build tooling
-   (`buildSrc/src/main/java/au/org/raid/api/Utils.java`), used to poll the ARDC
-   SPARQL vocabulary endpoint politely during code generation.
+**Nothing throttles anything today.** There is no rate limiting, throttling or
+backpressure in `api-svc/` or `iam/`: no bucket4j, resilience4j, Guava
+`RateLimiter`, and no request-counting filter. Keycloak's own brute-force
+protection is disabled (`bruteForceProtected: false` in
+`iam/realms/raid-realm.json`), and in any case it only covers login and
+credential flows, never custom SPI resources.
 
-2. **There is no edge layer to lean on.** `raido-v2-aws-private` contains no
-   WAFv2 WebACL, no rate-based rules, no API Gateway throttling or usage plans,
-   and no CloudFront or ALB request limiting. Keycloak is reached at
-   `iam.<zone>` through an internet-facing Application Load Balancer whose only
-   listener filtering is host-header matching
-   (`registration-authority/cdk/lib/raid/stack/api.ts`). CloudFront fronts the
-   SPA and proxies some `api.<zone>` paths, but it does not front `iam.<zone>`,
-   so there is no existing hop where a WebACL could attach.
+**Building it in the SPI is not cheap.** The `iam` module has no filter
+infrastructure at all: no `ContainerRequestFilter`, no
+`ContainerResponseFilter`, no servlet filters, only `@Provider`-annotated
+JAX-RS resources. There is also no working per-endpoint SPI configuration
+mechanism: every `RealmResourceProviderFactory` has an empty
+`init(Config.Scope)` body and `getResource()` builds a fresh controller per
+request, so `Config.Scope` never reaches the resource and `GroupController`
+resorts to reading `System.getenv("RAID_FLAT_GROUP_ADMIN_FALLBACK")`.
+Controller-per-request also means any counter must be `static`, bringing its own
+eviction design.
 
-3. **The `iam` module has no filter infrastructure.** It is a plain library jar
-   dropped into `/opt/keycloak/providers/`, with no `ContainerRequestFilter`,
-   no `ContainerResponseFilter` and no servlet filters of its own. The only
-   extension points in use are `@Provider`-annotated JAX-RS resources reached
-   through `RealmResourceProvider` dispatch.
+So a rate limiter here is new cross-cutting infrastructure, a configuration
+workaround, and a state-lifecycle problem, built to address a need that has not
+yet been demonstrated.
 
-4. **There is no working per-endpoint SPI configuration mechanism.** All three
-   existing `RealmResourceProviderFactory` implementations have empty
-   `init(Config.Scope)` bodies, and `getResource()` constructs a fresh
-   controller per request, so `Config.Scope` never reaches the resource.
-   `GroupController` works around this by reading
-   `System.getenv("RAID_FLAT_GROUP_ADMIN_FALLBACK")`
-   (`iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java`,
-   around lines 62 to 68). Controller-per-request also means any counter state
-   would have to be static, with its own eviction design.
 
-5. **Keycloak brute-force protection is disabled.** `bruteForceProtected` is
-   `false` in `iam/realms/raid-realm.json` (line 38), which makes the
-   accompanying `failureFactor: 30` and `maxFailureWaitSeconds: 900` inert. It
-   would not have helped these endpoints in any case, because Keycloak's
-   brute-force detection covers login and credential flows, not custom SPI
-   resources.
+# Deployment portability
+
+This constraint shapes everything below and is easy to miss.
+
+**Most RAiD registration agencies are not deployed on AWS.** Only controls that
+live in the application and its shipped configuration travel to every
+deployment. Anything implemented in the AU account's infrastructure protects
+the AU deployment and nothing else.
+
+Concretely, for the AU deployment there is no WAFv2 WebACL anywhere in
+`raido-v2-aws-private`, no rate-based rules, no API Gateway throttling, and no
+CloudFront or ALB request limiting. `iam.<zone>` is reached directly through the
+internet-facing ALB, with no CloudFront hop where a WebACL could attach (unlike
+some `api.<zone>` paths, which CloudFront does proxy). That gap could be closed
+for AU. It cannot be closed for anyone else, so **the RAiD software must not
+depend on an edge layer existing**, and edge protection must not be presented
+as RAiD's answer to this question.
 
 
 # Decision
 
-**1. No per-request rate limiting on the RAID-827 endpoints.**
+**1. Defer rate limiting until there is a demonstrated need.**
 
-Every one of these endpoints requires an authenticated bearer token and is
-scoped to a single service point. There is nothing to guess: a caller either
-holds `service-point-admin:<groupId>` or does not, so `get-secret` is not an
-enumeration target and the brute-force threat that per-request rate limiting
-exists to address is small. Building it would require new filter
-infrastructure, a static counter with an eviction strategy, and an
-environment-variable configuration workaround, for a control that would not be
-a genuine guarantee: in-memory counters are per-node, so with more than one
-Keycloak task the effective limit becomes the configured limit multiplied by
-the task count.
+Not because the risk is zero, but because the cost is real and the need is
+unproven. Push back on building it until evidence says otherwise. The endpoints
+are all authenticated and scoped to a single service point, so there is nothing
+to guess: a caller either holds `service-point-admin:<groupId>` or does not,
+and `get-secret` is not an enumeration target.
 
-**2. Enforce a per-service-point quota on live credentials instead.**
+**2. Cap the number of credentials per service point instead.**
 
-The material risk for this feature is not request rate, it is realm pollution.
-An authenticated admin, or more likely a runaway script, could create thousands
-of clients and degrade the realm. A quota addresses that directly.
+Capping stored objects is markedly cheaper than limiting request rate, and it
+is portable: it is a count check in application code, so it works identically
+in every deployment regardless of hosting.
 
-* Cap the number of active, non-revoked credentials per service point at
-  **10**.
-* Enforce the check in application code, alongside the per-service-point
-  isolation checks that RAID-827 already identifies as the real security
-  boundary. This needs no new infrastructure and is deterministic, so it is
-  straightforward to cover in the RAID-848 integration suite.
+* Cap active, non-revoked credentials per service point at **10**.
+* Enforce it in application code alongside the per-service-point isolation
+  checks that RAID-827 already identifies as the real security boundary.
 * Reject a create that would exceed the cap with **409 Conflict** and an error
   body naming the limit. Revoking a credential frees a slot.
 
-This lands in RAID-846 (endpoint implementation) with test coverage in
-RAID-848.
+This lands in RAID-846, with coverage in RAID-848.
 
-**3. Edge rate limiting and realm brute-force protection are separate work.**
+**3. Do not pursue edge rate limiting as part of this.**
 
-Both are real gaps, but neither belongs inside RAID-827, and the second is
-arguably the larger exposure. Each gets its own ticket.
+An AU-only WAF rule is rate limiting, for the same unproven need, benefiting
+one deployment. It fails the same test as decision 1 and is not being taken
+forward. Recorded here so a future reader does not mistake its absence for an
+oversight.
+
+**4. Enable Keycloak realm brute-force protection (RAID-851).**
+
+This is the exception that survives, because the implementation cost is
+approximately zero: the settings already exist in the realm JSON and are simply
+switched off. It is also portable, since realm configuration ships with the
+software rather than living in one cloud account. It matters because
+`client_credentials` token attempts against the very credentials this feature
+mints are currently unthrottled at Keycloak's token endpoint, which is a larger
+real exposure than the management endpoints themselves.
+
+
+# What would constitute demonstrated need
+
+Recorded so this deferral stays reviewable rather than simply forgotten.
+Revisit decision 1 if any of the following appears:
+
+* Credentials repeatedly hitting the cap at a rate suggesting automation rather
+  than intent, which would show the cap is absorbing abuse rather than
+  preventing sprawl.
+* Rotate or get-secret call volume far above what human self-service explains.
+* An agency operator reporting load or abuse on these endpoints.
+* The endpoints being opened to a broader or less-trusted caller set than
+  Service Point Admins.
+
+The instrument for the first three already exists in this story: the RAID-847
+audit records (who, when, which credential) are the telemetry that would show
+it. No separate monitoring work is needed to keep this decision reviewable.
 
 
 # Alternatives considered
 
 * **Per-request rate limiting in a new JAX-RS `ContainerRequestFilter`:**
-  rejected for this story. It is the textbook answer, but here it buys little
-  against an authenticated and scoped surface, while requiring infrastructure
-  the module does not have. Revisit if these endpoints are ever exposed to a
-  broader caller set, or once a shared limiter exists that the SPI can use.
+  deferred, per decision 1. This is the textbook answer, and the objection is
+  cost against unproven need rather than a claim that it would not work.
 
-* **Returning 429 for quota exhaustion:** rejected. The quota is a standing
-  limit on stored objects, not a rate. Overloading 429 would make it impossible
-  for a caller to distinguish "slow down and retry" from "delete something
-  first", and would leave no clean status code if a real rate limit is added
-  later.
+* **Returning 429 for cap exhaustion:** rejected. The cap is a standing limit
+  on stored objects, not a rate. Overloading 429 would stop a caller
+  distinguishing "slow down and retry" from "delete something first", and would
+  leave no clean status code if a real rate limit is added later.
 
-* **Relying on Keycloak brute-force protection:** rejected as insufficient
-  rather than wrong. It is disabled today, and even when enabled it does not
-  cover custom SPI resources. Enabling it is still worth doing, for the token
-  endpoint rather than for these endpoints, which is why it becomes its own
-  ticket.
+* **A WAFv2 rate-based rule:** rejected, per decision 3. Beyond the portability
+  problem, it is coarse: it aggregates on source IP and cannot parse a JWT, so
+  it cannot see `service_point_group_id` and cannot express "this admin has
+  created enough clients". It also carries a deployment sharp edge for AU,
+  since the WebACL attaches to the whole regional ALB and branch environments
+  share both the test listener and the single Keycloak instance, so one WebACL
+  would cover the test environment and every branch at once.
 
-* **A WAFv2 rate-based rule as the whole answer:** rejected as the answer to
-  this question, though it should be built. It is coarse, operating on source
-  IP rather than on service point identity, so it cannot express "this admin
-  has created enough clients". It also carries a deployment sharp edge: the
-  WebACL would attach to the regional ALB, and branch environments share both
-  the test listener and the single Keycloak instance, so one WebACL would cover
-  the test environment and every branch environment at once. Useful as a blunt
-  outer layer, not as tenant-aware protection.
-
-* **A global cap on clients per realm:** rejected. It would let one noisy
-  service point exhaust the allowance for everyone, which is the opposite of
-  the per-tenant isolation this feature is built around.
+* **A global cap on clients per realm:** rejected. One noisy service point
+  could exhaust the allowance for everyone, the opposite of the per-tenant
+  isolation this feature is built around.
 
 
 # Consequences
 
-* RAID-846 gains the quota check and the 409 response. RAID-848 gains positive
-  and negative coverage for it, including that revoking frees a slot.
+* RAID-846 gains the cap check and the 409 response. RAID-848 gains positive
+  and negative coverage, including that revoking frees a slot.
 * The cap of 10 is a starting value chosen without production evidence, since
   no comparable feature exists yet to measure. It is a constant in application
   code, so raising it is a small change. Expect to revisit it once real usage
   exists.
-* These endpoints remain without per-request rate limiting. That is an accepted
-  risk, recorded here rather than solved, and it sits alongside the residual
-  risk RAID-827 already accepts (the broker's `manage-clients` role is
-  realm-wide, with isolation enforced only in application code).
-* Two follow-up tickets are raised: a WAFv2 WebACL with a rate-based rule for
-  the ALB, and enabling realm brute-force protection. The second matters
-  because `client_credentials` token attempts against the very credentials this
-  feature mints are currently unthrottled at Keycloak's token endpoint.
-* One item is unverified and should be confirmed before any future in-memory
-  rate limiting is attempted: the Keycloak ECS service's task count. The
-  per-node counter problem described above only bites when more than one task
-  runs.
-* Note the existing Keycloak version skew, unchanged by this decision: the SPI
-  jar is compiled against 26.5.6 (`gradle/libs.versions.toml`) and runs on
-  26.6.2 (`iam/Dockerfile`).
+* These endpoints remain without per-request rate limiting, in every
+  deployment. That is an accepted and deliberate deferral, recorded alongside
+  the residual risk RAID-827 already accepts (the broker's `manage-clients`
+  role is realm-wide, with isolation enforced only in application code).
+* Agency operators deploying outside AWS receive no edge protection from us and
+  are responsible for their own. This should be stated in deployment
+  documentation rather than left implicit.
+* One item is unverified, and would need establishing before any future rate
+  limiting is attempted: deployment topology and instance counts, both for AU
+  and for agency deployments. A `static` in-memory counter is sound on a single
+  Keycloak instance and only becomes per-node theatre across several, so the
+  right implementation depends on facts not yet gathered.

--- a/documentation/20260826-raid-849-credential-quota-decision.md
+++ b/documentation/20260826-raid-849-credential-quota-decision.md
@@ -1,0 +1,118 @@
+# RAID-849: Rate limiting decision for scoped client credential endpoints
+
+- Ticket: [RAID-849](https://ardc.atlassian.net/browse/RAID-849) (parent
+  [RAID-827](https://ardc.atlassian.net/browse/RAID-827), epic
+  [RAID-711](https://ardc.atlassian.net/browse/RAID-711))
+- Sibling sub-tasks: [RAID-845](https://ardc.atlassian.net/browse/RAID-845),
+  [RAID-846](https://ardc.atlassian.net/browse/RAID-846),
+  [RAID-847](https://ardc.atlassian.net/browse/RAID-847),
+  [RAID-848](https://ardc.atlassian.net/browse/RAID-848)
+- Follow-up tickets raised: [RAID-850](https://ardc.atlassian.net/browse/RAID-850),
+  [RAID-851](https://ardc.atlassian.net/browse/RAID-851)
+- Source investigation: [RAID-767](https://ardc.atlassian.net/browse/RAID-767)
+- PR: [au-research/raid-au#624](https://github.com/au-research/raid-au/pull/624)
+- ADR: `doc/adr/2026-08-26_scoped-client-credential-quota.md`
+
+## What changed and why
+
+RAID-827 adds Keycloak SPI endpoints letting a Service Point Admin self-serve
+their own service point's API client credentials (create, list, rotate, revoke,
+get-secret) through a broker, since a Service Point Admin's own token carries
+none of the `realm-management` permissions needed to create a Keycloak client.
+The story deliberately left rate limiting undecided. RAID-849 is the spike that
+decided it.
+
+This is a documentation-only change: an ADR recording the decision. No code or
+configuration was touched. The implementation consequences land in RAID-846 and
+RAID-848, whose descriptions were updated accordingly.
+
+### What the investigation found
+
+- **Nothing throttles anything today.** No rate limiting, throttling or
+  backpressure in `api-svc/` or `iam/`: no bucket4j, resilience4j, Guava
+  `RateLimiter`, and no request-counting filter. The only throttle code in the
+  repo is outbound client-side backoff in build tooling
+  (`buildSrc/.../Utils.java`) for polling the ARDC SPARQL vocabulary endpoint.
+- **No edge layer to lean on.** `raido-v2-aws-private` has no WAFv2 WebACL, no
+  rate-based rules, no API Gateway throttling or usage plans, and no CloudFront
+  or ALB request limiting.
+- **Keycloak is ALB-direct.** `iam.<zone>`, and therefore every custom SPI
+  endpoint, is reached straight through the internet-facing ALB, whose only
+  listener filtering is host-header matching. CloudFront fronts the SPA and
+  proxies some `api.<zone>` paths, but it does not front `iam.<zone>`, so there
+  is no existing hop where a WebACL could attach.
+- **The `iam` module has no filter infrastructure**: no
+  `ContainerRequestFilter`, no `ContainerResponseFilter`, no servlet filters,
+  only `@Provider`-annotated JAX-RS resources.
+- **There is no working per-endpoint SPI config mechanism.** All three
+  `RealmResourceProviderFactory` implementations have empty
+  `init(Config.Scope)` bodies, and `getResource()` builds a fresh controller
+  per request, so `Config.Scope` never reaches the resource. `GroupController`
+  works around this by reading `System.getenv("RAID_FLAT_GROUP_ADMIN_FALLBACK")`.
+- **Keycloak brute-force protection is disabled**: `bruteForceProtected: false`
+  in `iam/realms/raid-realm.json` (line 38), making the accompanying
+  `failureFactor` and wait settings inert. It never covered custom SPI
+  resources anyway, only login and credential flows.
+
+### The decision
+
+**No per-request rate limiting on the RAID-827 endpoints.** They are all
+authenticated and scoped to a single service point, so there is nothing to
+guess: a caller either holds `service-point-admin:<groupId>` or does not, and
+`get-secret` is not an enumeration target. Building it would require new filter
+infrastructure, a static counter with an eviction strategy, and an
+environment-variable configuration workaround, for a control that would not be
+a genuine guarantee anyway, because in-memory counters are per-node.
+
+**A per-service-point quota on live credentials instead.** The material risk is
+realm pollution from runaway credential creation, not request rate. Cap active
+non-revoked credentials per service point at 10, enforce it in application code
+beside the isolation checks that RAID-827 already identifies as the real
+security boundary, and reject an excess create with 409 Conflict naming the
+limit. Revoking frees a slot. 409 rather than 429 because the quota is a
+standing limit on stored objects, not a rate, and overloading 429 would leave
+no clean status code if a real rate limit is added later.
+
+The cap of 10 is a starting value chosen without production evidence, since no
+comparable feature exists yet to measure. It is a code constant, so it is cheap
+to revisit.
+
+### Alternatives rejected
+
+Per-request rate limiting in a new `ContainerRequestFilter` (little value
+against an authenticated, scoped surface for significant new infrastructure);
+429 for quota exhaustion; relying on Keycloak brute-force protection
+(disabled, and does not cover SPI resources); a WAFv2 rate-based rule as the
+whole answer (coarse and source-IP based, so it cannot express "this admin has
+created enough clients"); and a global per-realm cap (one noisy service point
+could exhaust everyone's allowance, the opposite of the per-tenant isolation
+this feature is built around).
+
+## Impact on sibling sub-tasks
+
+- **RAID-846** gains the quota check and the 409 response.
+- **RAID-848** gains positive and negative coverage: creating up to the cap
+  succeeds, the create that would exceed it returns 409, and revoking frees a
+  slot so a subsequent create succeeds.
+
+## Follow-up work raised
+
+Two real gaps were found that do not belong inside RAID-827, so each became its
+own ticket rather than scope creep:
+
+- **RAID-850** — add a WAFv2 WebACL with a rate-based rule in front of the ALB.
+  Noted sharp edge: the WebACL attaches to the regional ALB, and branch
+  environments share both the test listener and the single Keycloak instance,
+  so one WebACL would cover the test environment and every branch at once.
+- **RAID-851** (High) — enable Keycloak realm brute-force protection. This is
+  arguably the larger real-world exposure: `client_credentials` token attempts
+  against the very credentials RAID-827 mints are currently unthrottled at
+  Keycloak's token endpoint. Note the realm config is duplicated, with the
+  authority environments' copy in raid-au and the agency deployment shipping
+  its own in raido-v2-aws-private, also with brute-force disabled.
+
+## Left unverified
+
+The Keycloak ECS service's task count was not confirmed. It only matters if
+in-memory rate limiting is ever attempted, since the per-node counter problem
+described above bites only when more than one task runs.

--- a/documentation/20260826-raid-849-credential-quota-decision.md
+++ b/documentation/20260826-raid-849-credential-quota-decision.md
@@ -1,4 +1,4 @@
-# RAID-849: Rate limiting decision for scoped client credential endpoints
+# RAID-849: Cap client credentials per service point, defer rate limiting
 
 - Ticket: [RAID-849](https://ardc.atlassian.net/browse/RAID-849) (parent
   [RAID-827](https://ardc.atlassian.net/browse/RAID-827), epic
@@ -7,8 +7,7 @@
   [RAID-846](https://ardc.atlassian.net/browse/RAID-846),
   [RAID-847](https://ardc.atlassian.net/browse/RAID-847),
   [RAID-848](https://ardc.atlassian.net/browse/RAID-848)
-- Follow-up tickets raised: [RAID-850](https://ardc.atlassian.net/browse/RAID-850),
-  [RAID-851](https://ardc.atlassian.net/browse/RAID-851)
+- Follow-up raised: [RAID-851](https://ardc.atlassian.net/browse/RAID-851)
 - Source investigation: [RAID-767](https://ardc.atlassian.net/browse/RAID-767)
 - PR: [au-research/raid-au#624](https://github.com/au-research/raid-au/pull/624)
 - ADR: `doc/adr/2026-08-26_scoped-client-credential-quota.md`
@@ -19,100 +18,90 @@ RAID-827 adds Keycloak SPI endpoints letting a Service Point Admin self-serve
 their own service point's API client credentials (create, list, rotate, revoke,
 get-secret) through a broker, since a Service Point Admin's own token carries
 none of the `realm-management` permissions needed to create a Keycloak client.
-The story deliberately left rate limiting undecided. RAID-849 is the spike that
-decided it.
+The story listed "decide and document rate-limiting behaviour for these
+endpoints" as an open task. RAID-849 is that decision.
 
-This is a documentation-only change: an ADR recording the decision. No code or
-configuration was touched. The implementation consequences land in RAID-846 and
-RAID-848, whose descriptions were updated accordingly.
+This is a documentation-only change: an ADR. No code or configuration was
+touched. The implementation consequence lands in RAID-846 and RAID-848.
 
-### What the investigation found
+## The decision
 
-- **Nothing throttles anything today.** No rate limiting, throttling or
-  backpressure in `api-svc/` or `iam/`: no bucket4j, resilience4j, Guava
-  `RateLimiter`, and no request-counting filter. The only throttle code in the
-  repo is outbound client-side backoff in build tooling
-  (`buildSrc/.../Utils.java`) for polling the ARDC SPARQL vocabulary endpoint.
-- **No edge layer to lean on.** `raido-v2-aws-private` has no WAFv2 WebACL, no
-  rate-based rules, no API Gateway throttling or usage plans, and no CloudFront
-  or ALB request limiting.
-- **Keycloak is ALB-direct.** `iam.<zone>`, and therefore every custom SPI
-  endpoint, is reached straight through the internet-facing ALB, whose only
-  listener filtering is host-header matching. CloudFront fronts the SPA and
-  proxies some `api.<zone>` paths, but it does not front `iam.<zone>`, so there
-  is no existing hop where a WebACL could attach.
-- **The `iam` module has no filter infrastructure**: no
+**Defer rate limiting until there is a demonstrated need.** Not because the
+risk is nil, but because the cost is real and the need is unproven. Capping the
+number of clients is markedly cheaper than limiting request rate, so do that
+instead: at most 10 active non-revoked credentials per service point, enforced
+in application code beside the isolation checks, rejecting excess creates with
+409 Conflict. Revoking frees a slot.
+
+409 rather than 429 because the cap is a standing limit on stored objects, not
+a rate, and overloading 429 would leave no clean status code if a real rate
+limit is ever added.
+
+The ADR records what would constitute demonstrated need, so the deferral stays
+reviewable: credentials repeatedly hitting the cap at automation-like rates,
+rotate or get-secret volume beyond what human self-service explains, an agency
+operator reporting abuse, or the endpoints being opened to a broader caller
+set. The RAID-847 audit records are already the instrument that would show the
+first three, so no separate monitoring work is needed.
+
+## Deployment portability drove this
+
+Most RAiD registration agencies are not deployed on AWS. Only controls living
+in the application and its shipped configuration reach every deployment;
+anything built in the AU account protects the AU deployment alone.
+
+That is the main argument for putting the cap in application code, and it is
+also why edge rate limiting is explicitly **not** RAiD's answer here. For the
+record, the AU deployment has no WAFv2 WebACL anywhere in
+`raido-v2-aws-private`, no rate-based rules, no API Gateway throttling, and no
+CloudFront or ALB request limiting, with `iam.<zone>` reached directly through
+the internet-facing ALB with no CloudFront hop where a WebACL could attach.
+That gap could be closed for AU but cannot be closed for anyone else, so the
+software must not depend on an edge layer existing.
+
+## Why building it in the SPI is not cheap
+
+- The `iam` module has no filter infrastructure at all: no
   `ContainerRequestFilter`, no `ContainerResponseFilter`, no servlet filters,
   only `@Provider`-annotated JAX-RS resources.
-- **There is no working per-endpoint SPI config mechanism.** All three
-  `RealmResourceProviderFactory` implementations have empty
-  `init(Config.Scope)` bodies, and `getResource()` builds a fresh controller
-  per request, so `Config.Scope` never reaches the resource. `GroupController`
-  works around this by reading `System.getenv("RAID_FLAT_GROUP_ADMIN_FALLBACK")`.
-- **Keycloak brute-force protection is disabled**: `bruteForceProtected: false`
-  in `iam/realms/raid-realm.json` (line 38), making the accompanying
-  `failureFactor` and wait settings inert. It never covered custom SPI
-  resources anyway, only login and credential flows.
-
-### The decision
-
-**No per-request rate limiting on the RAID-827 endpoints.** They are all
-authenticated and scoped to a single service point, so there is nothing to
-guess: a caller either holds `service-point-admin:<groupId>` or does not, and
-`get-secret` is not an enumeration target. Building it would require new filter
-infrastructure, a static counter with an eviction strategy, and an
-environment-variable configuration workaround, for a control that would not be
-a genuine guarantee anyway, because in-memory counters are per-node.
-
-**A per-service-point quota on live credentials instead.** The material risk is
-realm pollution from runaway credential creation, not request rate. Cap active
-non-revoked credentials per service point at 10, enforce it in application code
-beside the isolation checks that RAID-827 already identifies as the real
-security boundary, and reject an excess create with 409 Conflict naming the
-limit. Revoking frees a slot. 409 rather than 429 because the quota is a
-standing limit on stored objects, not a rate, and overloading 429 would leave
-no clean status code if a real rate limit is added later.
-
-The cap of 10 is a starting value chosen without production evidence, since no
-comparable feature exists yet to measure. It is a code constant, so it is cheap
-to revisit.
-
-### Alternatives rejected
-
-Per-request rate limiting in a new `ContainerRequestFilter` (little value
-against an authenticated, scoped surface for significant new infrastructure);
-429 for quota exhaustion; relying on Keycloak brute-force protection
-(disabled, and does not cover SPI resources); a WAFv2 rate-based rule as the
-whole answer (coarse and source-IP based, so it cannot express "this admin has
-created enough clients"); and a global per-realm cap (one noisy service point
-could exhaust everyone's allowance, the opposite of the per-tenant isolation
-this feature is built around).
+- There is no working per-endpoint SPI configuration mechanism. Every
+  `RealmResourceProviderFactory` has an empty `init(Config.Scope)` body and
+  `getResource()` builds a fresh controller per request, so `Config.Scope`
+  never reaches the resource. `GroupController` works around this by reading
+  `System.getenv("RAID_FLAT_GROUP_ADMIN_FALLBACK")`.
+- Controller-per-request means any counter must be `static`, bringing its own
+  eviction design.
 
 ## Impact on sibling sub-tasks
 
-- **RAID-846** gains the quota check and the 409 response.
+- **RAID-846** gains the cap check and the 409 response.
 - **RAID-848** gains positive and negative coverage: creating up to the cap
   succeeds, the create that would exceed it returns 409, and revoking frees a
   slot so a subsequent create succeeds.
 
-## Follow-up work raised
+## Follow-up
 
-Two real gaps were found that do not belong inside RAID-827, so each became its
-own ticket rather than scope creep:
+**[RAID-851](https://ardc.atlassian.net/browse/RAID-851) (High)** — enable
+Keycloak realm brute-force protection. This survives the "defer until
+demonstrated need" test because its implementation cost is approximately zero:
+the settings already exist in the realm JSON and are simply switched off
+(`bruteForceProtected: false`, which makes the accompanying `failureFactor: 30`
+and wait settings inert). It is also portable, since realm configuration ships
+with the software. It matters because `client_credentials` token attempts
+against the very credentials this feature mints are currently unthrottled at
+Keycloak's token endpoint. Note the realm config is duplicated, with the
+authority environments' copy in raid-au and the agency deployment shipping its
+own in raido-v2-aws-private, also with brute-force disabled.
 
-- **RAID-850** — add a WAFv2 WebACL with a rate-based rule in front of the ALB.
-  Noted sharp edge: the WebACL attaches to the regional ALB, and branch
-  environments share both the test listener and the single Keycloak instance,
-  so one WebACL would cover the test environment and every branch at once.
-- **RAID-851** (High) — enable Keycloak realm brute-force protection. This is
-  arguably the larger real-world exposure: `client_credentials` token attempts
-  against the very credentials RAID-827 mints are currently unthrottled at
-  Keycloak's token endpoint. Note the realm config is duplicated, with the
-  authority environments' copy in raid-au and the agency deployment shipping
-  its own in raido-v2-aws-private, also with brute-force disabled.
+RAID-850, originally raised here to add a WAFv2 rate-based rule, was descoped.
+It is rate limiting, for the same unproven need, benefiting one deployment, so
+it fails the same test as the main decision.
 
 ## Left unverified
 
-The Keycloak ECS service's task count was not confirmed. It only matters if
-in-memory rate limiting is ever attempted, since the per-node counter problem
-described above bites only when more than one task runs.
+Deployment topology and instance counts, for AU and for agency deployments.
+This only matters if rate limiting is revisited: a `static` in-memory counter
+is sound on a single Keycloak instance and only becomes per-node theatre across
+several, so the right implementation would depend on facts not yet gathered.
+Also unestablished is how a non-AWS agency deployment picks up realm
+configuration changes, which bears on RAID-851.


### PR DESCRIPTION
## What

An ADR recording the outcome of spike [RAID-849](https://ardc.atlassian.net/browse/RAID-849): whether the [RAID-827](https://ardc.atlassian.net/browse/RAID-827) scoped client credential endpoints (create/list/rotate/revoke/get-secret) need rate limiting. Answering that was an explicit open task on RAID-827.

Documentation only. No code or configuration changes.

> Note for reviewers: the first two commits argued this via a threat analysis. The third replaces that framing after review. Read the final state of the ADR, not the commit-by-commit reasoning.

## Decision

**Rate limiting is deferred until there is a demonstrated need.** Not because the risk is nil, but because the cost is real and the need is unproven. Building it in the SPI means new cross-cutting infrastructure: `iam` has no filter layer at all, `init(Config.Scope)` is dead so config comes from `System.getenv()`, and controller-per-request forces any counter to be `static` with its own eviction design.

**A cap on stored credentials instead**, because capping objects is markedly cheaper than limiting request rate: at most 10 active non-revoked credentials per service point, enforced in application code beside the isolation checks, rejecting excess creates with 409 Conflict. Revoking frees a slot. 409 rather than 429 because a standing limit on stored objects is not a rate, and 429 should stay available if a real rate limit is ever added.

## Why the cap, and not an edge control

**Most RAiD registration agencies are not deployed on AWS.** Only controls living in the application and its shipped configuration reach every deployment; anything built in the AU account protects the AU deployment alone. That is what makes application code the right home for this, and it is why edge rate limiting is explicitly **not** RAiD's answer rather than a gap to fill later.

For the record, the AU deployment has no WAFv2 WebACL anywhere in `raido-v2-aws-private`, no rate-based rules, no API Gateway throttling, and no CloudFront or ALB request limiting, with `iam.<zone>` reached directly through the internet-facing ALB with no CloudFront hop where a WebACL could attach. That gap could be closed for AU but cannot be closed for anyone else.

## Keeping the deferral reviewable

The ADR names what would count as demonstrated need: the cap being hit at automation-like rather than human rates, rotate/get-secret volume beyond what self-service explains, an operator reporting abuse, or the endpoints being opened to a broader caller set. The [RAID-847](https://ardc.atlassian.net/browse/RAID-847) audit records are already the instrument for the first three, so nothing extra needs building.

## Impact on sibling sub-tasks

- [RAID-846](https://ardc.atlassian.net/browse/RAID-846) gains the cap check and the 409 response
- [RAID-848](https://ardc.atlassian.net/browse/RAID-848) gains positive and negative coverage, including that revoking frees a slot

Note the cap is an addition beyond RAID-827's stated acceptance criteria, not one of its requirements.

## Follow-up

[RAID-851](https://ardc.atlassian.net/browse/RAID-851) (High) enables Keycloak realm brute-force protection. It survives the same deferral test because its cost is near zero (the settings exist in the realm JSON and are simply switched off) and it is portable (realm config ships with the software). It matters because `client_credentials` token attempts against the very credentials this feature mints are currently unthrottled at the token endpoint.

RAID-850, originally raised here for a WAFv2 rate-based rule, is **descoped**: it is rate limiting, for the same unproven need, benefiting one deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)