### PR TITLE
RAID-846: add scoped client credential lifecycle SPI

### DIFF
--- a/iam/src/main/java/au/org/raid/iam/provider/credential/ClientCredentialController.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/credential/ClientCredentialController.java
@@ -1,0 +1,468 @@
+package au.org.raid.iam.provider.credential;
+
+import au.org.raid.iam.provider.cors.Cors;
+import au.org.raid.iam.provider.credential.dto.CreateCredentialRequest;
+import au.org.raid.iam.provider.credential.dto.CredentialResponse;
+import au.org.raid.iam.provider.credential.dto.CredentialSecretResponse;
+import au.org.raid.iam.provider.credential.dto.RotateCredentialRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.services.managers.AppAuthManager;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.managers.ClientManager;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Self-service lifecycle for a service point's scoped API client credentials (RAID-846).
+ *
+ * <p>This runs in-process inside Keycloak, so it mutates the realm through the model layer and
+ * needs no service account and no {@code manage-clients} grant: Keycloak enforces
+ * {@code realm-management} roles in its Admin REST endpoints, which an SPI resource never passes
+ * through. See {@code doc/adr/2026-08-27_in-process-spi-credential-lifecycle.md}. Authorisation is
+ * therefore entirely this class's own scoped role check, which makes it the tenant-isolation
+ * security boundary for the feature.
+ *
+ * <p>Unlike {@code GroupController}, there is deliberately <em>no</em> flat {@code group-admin}
+ * fallback here: RAID-827 requires the scoped {@code service-point-admin:<groupId>} role.
+ */
+@Slf4j
+@Provider
+public class ClientCredentialController {
+    private static final String OPERATOR_ROLE_NAME = "operator";
+    private static final String SERVICE_POINT_ADMIN_ROLE_PREFIX = "service-point-admin";
+    private static final String SERVICE_POINT_USER_ROLE_PREFIX = "service-point-user";
+
+    /**
+     * Client scope carrying the {@code service_point_group_id} claim mapper, which reads the
+     * {@code activeGroupId} user attribute. It is not a realm default scope (only the
+     * {@code raid-api} client has it), so it must be attached explicitly to each credential we
+     * create or its tokens will not identify a service point at all.
+     */
+    private static final String SERVICE_POINT_GROUP_ID_CLIENT_SCOPE = "service_point_group_id";
+    private static final String ACTIVE_GROUP_ID_ATTRIBUTE = "activeGroupId";
+
+    /** Marks a client as managed by this feature, so listing never returns the realm's own clients. */
+    private static final String MANAGED_ATTRIBUTE = "raid.credential.managed";
+    private static final String GROUP_ID_ATTRIBUTE = "raid.credential.group-id";
+    private static final String LABEL_ATTRIBUTE = "raid.credential.label";
+    private static final String CREATED_AT_ATTRIBUTE = "raid.credential.created-at";
+    private static final String ROTATED_AT_ATTRIBUTE = "raid.credential.rotated-at";
+
+    private static final String CLIENT_ID_PREFIX = "raid-cred-";
+
+    /**
+     * Maximum active (non-revoked) credentials per service point. Deliberately a constant rather
+     * than configuration so it is cheap to revisit, per RAID-849: rate limiting was deferred until
+     * demonstrated need and this cap ships in its place, addressing realm pollution from runaway
+     * credential creation. See {@code doc/adr/2026-08-26_scoped-client-credential-quota.md}.
+     */
+    static final int MAX_CREDENTIALS_PER_SERVICE_POINT = 10;
+
+    private final AuthenticationManager.AuthResult auth;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final KeycloakSession session;
+    private final Cors cors;
+    private final Clock clock;
+
+    public ClientCredentialController(final KeycloakSession session) {
+        this(session, Clock.systemUTC());
+    }
+
+    // Package-private seam for tests, so timestamps are deterministic without touching the system
+    // clock.
+    ClientCredentialController(final KeycloakSession session, final Clock clock) {
+        this.session = session;
+        this.auth = new AppAuthManager.BearerTokenAuthenticator(session).authenticate();
+        this.cors = new Cors(session, objectMapper);
+        this.clock = clock;
+    }
+
+    @OPTIONS
+    @Path("")
+    public Response preflight() {
+        return cors.buildOptionsResponse("GET", "POST", "DELETE", "OPTIONS");
+    }
+
+    @POST
+    @Path("")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @SneakyThrows
+    public Response create(final CreateCredentialRequest request) {
+        log.debug("Creating client credential for group {}", request == null ? null : request.getGroupId());
+
+        final var user = authenticatedUser();
+        if (user == null) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        if (request == null || isBlank(request.getGroupId())) {
+            return badRequest("groupId is required");
+        }
+        if (isBlank(request.getLabel())) {
+            return badRequest("label is required");
+        }
+
+        final var groupId = request.getGroupId().trim();
+        requireAuthorisedFor(user, groupId);
+
+        final var realm = session.getContext().getRealm();
+        if (session.groups().getGroupById(realm, groupId) == null) {
+            return notFound("Service point not found");
+        }
+
+        if (countActiveCredentials(realm, groupId) >= MAX_CREDENTIALS_PER_SERVICE_POINT) {
+            return conflict("Service point has reached the maximum of "
+                    + MAX_CREDENTIALS_PER_SERVICE_POINT + " active client credentials. "
+                    + "Revoke an existing credential before creating another.");
+        }
+
+        // Every mutation below shares this request's Keycloak transaction, so a failure part-way
+        // through rolls the whole thing back rather than leaving a half-created client.
+        final var now = nowIso();
+        final var client = session.clients().addClient(realm, CLIENT_ID_PREFIX + KeycloakModelUtils.generateId());
+        client.setName(request.getLabel().trim());
+        client.setEnabled(true);
+        client.setPublicClient(false);
+        client.setServiceAccountsEnabled(true);
+        client.setStandardFlowEnabled(false);
+        client.setDirectAccessGrantsEnabled(false);
+        client.setAttribute(MANAGED_ATTRIBUTE, "true");
+        client.setAttribute(GROUP_ID_ATTRIBUTE, groupId);
+        client.setAttribute(LABEL_ATTRIBUTE, request.getLabel().trim());
+        client.setAttribute(CREATED_AT_ATTRIBUTE, now);
+
+        final var secret = KeycloakModelUtils.generateSecret(client);
+
+        attachServicePointGroupIdScope(realm, client);
+
+        new ClientManager().enableServiceAccount(client);
+        final var serviceAccount = session.users().getServiceAccount(client);
+        if (serviceAccount == null) {
+            // Fail closed rather than hand back a credential that cannot identify a service point.
+            throw new InternalServerErrorException("Service account was not created for the new client");
+        }
+        // The service_point_group_id claim mapper reads this attribute, so without it the
+        // credential's token carries no service point at all.
+        serviceAccount.setAttribute(ACTIVE_GROUP_ID_ATTRIBUTE, List.of(groupId));
+        serviceAccount.grantRole(getOrCreateScopedServicePointUserRole(realm, groupId));
+
+        // TODO:RAID-847 add Cache-Control: no-store to this response.
+        final var body = new CredentialSecretResponse(
+                client.getClientId(), request.getLabel().trim(), secret, now, null);
+
+        return cors.buildCorsResponse("POST",
+                Response.status(Response.Status.CREATED)
+                        .entity(objectMapper.writeValueAsString(body)));
+    }
+
+    @GET
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @SneakyThrows
+    public Response list(@QueryParam("groupId") final String groupId) {
+        log.debug("Listing client credentials for group {}", groupId);
+
+        final var user = authenticatedUser();
+        if (user == null) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+        if (isBlank(groupId)) {
+            return badRequest("groupId parameter is required");
+        }
+
+        requireAuthorisedFor(user, groupId.trim());
+
+        final var realm = session.getContext().getRealm();
+        final var credentials = managedCredentials(realm, groupId.trim())
+                .map(this::toResponse)
+                .toList();
+
+        return cors.buildCorsResponse("GET",
+                Response.ok().entity(objectMapper.writeValueAsString(credentials)));
+    }
+
+    @OPTIONS
+    @Path("/rotate")
+    public Response rotatePreflight() {
+        return cors.buildOptionsResponse("POST", "OPTIONS");
+    }
+
+    @POST
+    @Path("/rotate")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @SneakyThrows
+    public Response rotate(final RotateCredentialRequest request) {
+        log.debug("Rotating secret for client credential {}", request == null ? null : request.getClientId());
+
+        final var user = authenticatedUser();
+        if (user == null) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+        if (request == null || isBlank(request.getClientId())) {
+            return badRequest("clientId is required");
+        }
+
+        final var realm = session.getContext().getRealm();
+        final var client = findManagedCredential(realm, request.getClientId().trim());
+        if (client == null) {
+            return notFound("Client credential not found");
+        }
+
+        requireAuthorisedFor(user, ownerGroupId(client));
+
+        if (!client.isEnabled()) {
+            return conflict("Client credential has been revoked and cannot be rotated");
+        }
+
+        final var rotatedAt = nowIso();
+        final var secret = KeycloakModelUtils.generateSecret(client);
+        client.setAttribute(ROTATED_AT_ATTRIBUTE, rotatedAt);
+
+        // TODO:RAID-847 add Cache-Control: no-store to this response.
+        final var body = new CredentialSecretResponse(
+                client.getClientId(),
+                client.getAttribute(LABEL_ATTRIBUTE),
+                secret,
+                client.getAttribute(CREATED_AT_ATTRIBUTE),
+                rotatedAt);
+
+        return cors.buildCorsResponse("POST",
+                Response.ok().entity(objectMapper.writeValueAsString(body)));
+    }
+
+    @OPTIONS
+    @Path("/secret")
+    public Response secretPreflight() {
+        return cors.buildOptionsResponse("GET", "OPTIONS");
+    }
+
+    @GET
+    @Path("/secret")
+    @Produces(MediaType.APPLICATION_JSON)
+    @SneakyThrows
+    public Response getSecret(@QueryParam("clientId") final String clientId) {
+        log.debug("Retrieving secret for client credential {}", clientId);
+
+        final var user = authenticatedUser();
+        if (user == null) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+        if (isBlank(clientId)) {
+            return badRequest("clientId parameter is required");
+        }
+
+        final var realm = session.getContext().getRealm();
+        final var client = findManagedCredential(realm, clientId.trim());
+        if (client == null) {
+            return notFound("Client credential not found");
+        }
+
+        requireAuthorisedFor(user, ownerGroupId(client));
+
+        // TODO:RAID-847 add Cache-Control: no-store, and an audit entry recording caller, clientId
+        // and timestamp - never the secret value.
+        final var body = new CredentialSecretResponse(
+                client.getClientId(),
+                client.getAttribute(LABEL_ATTRIBUTE),
+                client.getSecret(),
+                client.getAttribute(CREATED_AT_ATTRIBUTE),
+                client.getAttribute(ROTATED_AT_ATTRIBUTE));
+
+        return cors.buildCorsResponse("GET",
+                Response.ok().entity(objectMapper.writeValueAsString(body)));
+    }
+
+    /**
+     * Revokes a credential by disabling it. Disabling rather than deleting keeps the audit trail,
+     * makes repeat calls naturally idempotent, and lets rotation of a revoked credential be
+     * rejected rather than silently resurrecting it.
+     */
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @SneakyThrows
+    public Response revoke(@QueryParam("clientId") final String clientId) {
+        log.debug("Revoking client credential {}", clientId);
+
+        final var user = authenticatedUser();
+        if (user == null) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+        if (isBlank(clientId)) {
+            return badRequest("clientId parameter is required");
+        }
+
+        final var realm = session.getContext().getRealm();
+        final var client = findManagedCredential(realm, clientId.trim());
+        if (client == null) {
+            return notFound("Client credential not found");
+        }
+
+        requireAuthorisedFor(user, ownerGroupId(client));
+
+        // Idempotent: revoking an already-revoked credential is a no-op success, not an error.
+        if (client.isEnabled()) {
+            client.setEnabled(false);
+        }
+
+        return cors.buildCorsResponse("DELETE",
+                Response.ok().entity(objectMapper.writeValueAsString(toResponse(client))));
+    }
+
+    private UserModel authenticatedUser() {
+        if (this.auth == null) {
+            return null;
+        }
+        final var user = auth.session().getUser();
+        if (user == null) {
+            throw new NotAuthorizedException("Bearer");
+        }
+        return user;
+    }
+
+    /**
+     * Uniform authorisation for every endpoint: an Operator short-circuit applied first and
+     * independently, then the scoped per-service-point check. RAID-827 requires these be separate
+     * rather than OR-ed into a single condition, so Operator access does not depend on any
+     * service-point reasoning.
+     */
+    private void requireAuthorisedFor(final UserModel user, final String groupId) {
+        if (isOperator(user)) {
+            return;
+        }
+        if (!isServicePointAdminOf(user, groupId)) {
+            throw new NotAuthorizedException("Permission denied - not an admin of this service point");
+        }
+    }
+
+    private boolean isOperator(final UserModel user) {
+        return user.getRoleMappingsStream()
+                .anyMatch(r -> r.getName().equals(OPERATOR_ROLE_NAME));
+    }
+
+    /**
+     * Requires the scoped {@code service-point-admin:<groupId>} realm role. The flat legacy
+     * {@code group-admin} role is deliberately not honoured, and there is no fallback.
+     */
+    private boolean isServicePointAdminOf(final UserModel user, final String groupId) {
+        final var scopedRoleName = SERVICE_POINT_ADMIN_ROLE_PREFIX + ":" + groupId;
+        return user.getRoleMappingsStream()
+                .anyMatch(r -> r.getName().equals(scopedRoleName));
+    }
+
+    private java.util.stream.Stream<ClientModel> managedCredentials(final RealmModel realm, final String groupId) {
+        return session.clients().getClientsStream(realm)
+                .filter(this::isManagedCredential)
+                .filter(c -> groupId.equals(c.getAttribute(GROUP_ID_ATTRIBUTE)));
+    }
+
+    private long countActiveCredentials(final RealmModel realm, final String groupId) {
+        return managedCredentials(realm, groupId)
+                .filter(ClientModel::isEnabled)
+                .count();
+    }
+
+    private ClientModel findManagedCredential(final RealmModel realm, final String clientId) {
+        final var client = session.clients().getClientByClientId(realm, clientId);
+        if (client == null || !isManagedCredential(client)) {
+            // Treat a non-managed client as absent so this endpoint can never be used to probe or
+            // manipulate the realm's own clients.
+            return null;
+        }
+        return client;
+    }
+
+    private boolean isManagedCredential(final ClientModel client) {
+        return "true".equals(client.getAttribute(MANAGED_ATTRIBUTE));
+    }
+
+    private String ownerGroupId(final ClientModel client) {
+        return client.getAttribute(GROUP_ID_ATTRIBUTE);
+    }
+
+    private CredentialResponse toResponse(final ClientModel client) {
+        return new CredentialResponse(
+                client.getClientId(),
+                client.getAttribute(LABEL_ATTRIBUTE),
+                client.getAttribute(CREATED_AT_ATTRIBUTE),
+                client.getAttribute(ROTATED_AT_ATTRIBUTE),
+                client.isEnabled());
+    }
+
+    private void attachServicePointGroupIdScope(final RealmModel realm, final ClientModel client) {
+        final var scope = KeycloakModelUtils.getClientScopeByName(realm, SERVICE_POINT_GROUP_ID_CLIENT_SCOPE);
+        if (scope == null) {
+            // Fail closed. Without this scope the credential authenticates but its token carries no
+            // service_point_group_id claim, so it would silently have no service point.
+            throw new InternalServerErrorException(
+                    "Required client scope '" + SERVICE_POINT_GROUP_ID_CLIENT_SCOPE + "' is missing from the realm");
+        }
+        client.addClientScope(scope, true);
+    }
+
+    /**
+     * Looks up the scoped {@code service-point-user:<groupId>} realm role, creating it if absent,
+     * mirroring {@code GroupController#getOrCreateServicePointAdminRole}.
+     *
+     * <p>Note {@code RoleContainerModel#addRole(String, String)} is (id, name), not
+     * (name, description), so the single-arg overload is used and the description set separately.
+     */
+    private RoleModel getOrCreateScopedServicePointUserRole(final RealmModel realm, final String groupId) {
+        final var roleName = SERVICE_POINT_USER_ROLE_PREFIX + ":" + groupId;
+        final var existingRole = realm.getRole(roleName);
+        if (existingRole != null) {
+            return existingRole;
+        }
+        final var role = realm.addRole(roleName);
+        role.setDescription("Service point user for group " + groupId);
+        return role;
+    }
+
+    private String nowIso() {
+        return DateTimeFormatter.ISO_INSTANT.format(Instant.now(clock).truncatedTo(java.time.temporal.ChronoUnit.SECONDS));
+    }
+
+    private static boolean isBlank(final String value) {
+        return value == null || value.isBlank();
+    }
+
+    @SneakyThrows
+    private Response badRequest(final String message) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(objectMapper.writeValueAsString(new ErrorResponse(message)))
+                .build();
+    }
+
+    @SneakyThrows
+    private Response notFound(final String message) {
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity(objectMapper.writeValueAsString(new ErrorResponse(message)))
+                .build();
+    }
+
+    @SneakyThrows
+    private Response conflict(final String message) {
+        return Response.status(Response.Status.CONFLICT)
+                .entity(objectMapper.writeValueAsString(new ErrorResponse(message)))
+                .build();
+    }
+
+    private record ErrorResponse(String error) {}
+}

--- a/iam/src/main/java/au/org/raid/iam/provider/credential/ClientCredentialControllerResourceProvider.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/credential/ClientCredentialControllerResourceProvider.java
@@ -1,0 +1,24 @@
+package au.org.raid.iam.provider.credential;
+
+import jakarta.ws.rs.ext.Provider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.resource.RealmResourceProvider;
+
+@Provider
+public class ClientCredentialControllerResourceProvider implements RealmResourceProvider {
+    private final KeycloakSession session;
+
+    public ClientCredentialControllerResourceProvider(final KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public Object getResource() {
+        return new ClientCredentialController(session);
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/iam/src/main/java/au/org/raid/iam/provider/credential/ClientCredentialControllerResourceProviderFactory.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/credential/ClientCredentialControllerResourceProviderFactory.java
@@ -1,0 +1,36 @@
+package au.org.raid.iam.provider.credential;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.services.resource.RealmResourceProvider;
+import org.keycloak.services.resource.RealmResourceProviderFactory;
+
+public class ClientCredentialControllerResourceProviderFactory implements RealmResourceProviderFactory {
+    public static final String ID = "client-credential";
+
+    @Override
+    public RealmResourceProvider create(final KeycloakSession session) {
+        return new ClientCredentialControllerResourceProvider(session);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public void init(final Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(final KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/iam/src/main/java/au/org/raid/iam/provider/credential/dto/CreateCredentialRequest.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/credential/dto/CreateCredentialRequest.java
@@ -1,0 +1,9 @@
+package au.org.raid.iam.provider.credential.dto;
+
+import lombok.Data;
+
+@Data
+public class CreateCredentialRequest {
+    private String groupId;
+    private String label;
+}

--- a/iam/src/main/java/au/org/raid/iam/provider/credential/dto/CredentialResponse.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/credential/dto/CredentialResponse.java
@@ -1,0 +1,13 @@
+package au.org.raid.iam.provider.credential.dto;
+
+/**
+ * A scoped client credential without its secret value. Timestamps are ISO 8601 UTC.
+ * {@code lastRotatedAt} is null until the credential has been rotated at least once.
+ */
+public record CredentialResponse(
+        String clientId,
+        String label,
+        String createdAt,
+        String lastRotatedAt,
+        boolean enabled) {
+}

--- a/iam/src/main/java/au/org/raid/iam/provider/credential/dto/CredentialSecretResponse.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/credential/dto/CredentialSecretResponse.java
@@ -1,0 +1,15 @@
+package au.org.raid.iam.provider.credential.dto;
+
+/**
+ * A scoped client credential including its secret value. Returned only by create, rotate and
+ * get-secret.
+ *
+ * <p>Never log an instance of this type. Timestamps are ISO 8601 UTC.
+ */
+public record CredentialSecretResponse(
+        String clientId,
+        String label,
+        String secret,
+        String createdAt,
+        String lastRotatedAt) {
+}

--- a/iam/src/main/java/au/org/raid/iam/provider/credential/dto/RotateCredentialRequest.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/credential/dto/RotateCredentialRequest.java
@@ -1,0 +1,8 @@
+package au.org.raid.iam.provider.credential.dto;
+
+import lombok.Data;
+
+@Data
+public class RotateCredentialRequest {
+    private String clientId;
+}

--- a/iam/src/main/resources/META-INF/services/org.keycloak.services.resource.RealmResourceProviderFactory
+++ b/iam/src/main/resources/META-INF/services/org.keycloak.services.resource.RealmResourceProviderFactory
@@ -1,3 +1,4 @@
 au.org.raid.iam.provider.group.GroupControllerResourceProviderFactory
 au.org.raid.iam.provider.raid.RaidPermissionsControllerResourceProviderFactory
 au.org.raid.iam.provider.localization.LocalizationControllerResourceProviderFactory
+au.org.raid.iam.provider.credential.ClientCredentialControllerResourceProviderFactory

--- a/iam/src/test/java/au/org/raid/iam/provider/credential/ClientCredentialControllerResourceProviderFactoryTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/credential/ClientCredentialControllerResourceProviderFactoryTest.java
@@ -1,0 +1,27 @@
+package au.org.raid.iam.provider.credential;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.KeycloakSession;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+
+class ClientCredentialControllerResourceProviderFactoryTest {
+
+    private final ClientCredentialControllerResourceProviderFactory factory =
+            new ClientCredentialControllerResourceProviderFactory();
+
+    @Test
+    void getId_returnsClientCredential() {
+        // The factory id becomes the URL segment: /realms/raid/client-credential
+        assertThat(factory.getId(), is("client-credential"));
+    }
+
+    @Test
+    void create_returnsResourceProvider() {
+        var session = mock(KeycloakSession.class);
+        var provider = factory.create(session);
+        assertThat(provider, is(notNullValue()));
+    }
+}

--- a/iam/src/test/java/au/org/raid/iam/provider/credential/ClientCredentialControllerTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/credential/ClientCredentialControllerTest.java
@@ -1,0 +1,700 @@
+package au.org.raid.iam.provider.credential;
+
+import au.org.raid.iam.provider.credential.dto.CreateCredentialRequest;
+import au.org.raid.iam.provider.credential.dto.RotateCredentialRequest;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.models.*;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.services.managers.AppAuthManager;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.managers.ClientManager;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ClientCredentialControllerTest {
+
+    private static final String GROUP_A = "group-a-uuid";
+    private static final String GROUP_B = "group-b-uuid";
+    private static final String NEW_SECRET = "generated-secret-value";
+    private static final String FIXED_NOW = "2026-08-27T00:00:00Z";
+
+    private static final String MANAGED_ATTRIBUTE = "raid.credential.managed";
+    private static final String GROUP_ID_ATTRIBUTE = "raid.credential.group-id";
+    private static final String LABEL_ATTRIBUTE = "raid.credential.label";
+    private static final String CREATED_AT_ATTRIBUTE = "raid.credential.created-at";
+    private static final String ROTATED_AT_ATTRIBUTE = "raid.credential.rotated-at";
+
+    @Mock private KeycloakSession session;
+    @Mock private KeycloakContext context;
+    @Mock private RealmModel realm;
+    @Mock private UserModel user;
+    @Mock private UserProvider userProvider;
+    @Mock private GroupProvider groupProvider;
+    @Mock private ClientProvider clientProvider;
+    @Mock private HttpHeaders headers;
+    @Mock private AuthenticationManager.AuthResult authResult;
+    @Mock private UserSessionModel userSession;
+    @Mock private UserModel serviceAccount;
+    @Mock private ClientScopeModel servicePointGroupIdScope;
+
+    private final Clock fixedClock = Clock.fixed(Instant.parse(FIXED_NOW), ZoneOffset.UTC);
+    private final List<ClientModel> realmClients = new ArrayList<>();
+
+    private MockedStatic<KeycloakModelUtils> keycloakModelUtils;
+
+    @BeforeEach
+    void setUp() {
+        when(session.getContext()).thenReturn(context);
+        when(context.getRealm()).thenReturn(realm);
+        when(context.getRequestHeaders()).thenReturn(headers);
+        when(session.clients()).thenReturn(clientProvider);
+        when(session.users()).thenReturn(userProvider);
+        when(session.groups()).thenReturn(groupProvider);
+
+        // Cors derives allowed origins from the realm's clients, so the stream must also carry a
+        // client with web origins. Credential mocks return null web origins and are skipped by Cors,
+        // while this one has no managed attribute and is skipped by the controller.
+        final var corsClient = mock(ClientModel.class);
+        when(corsClient.getWebOrigins()).thenReturn(Set.of("http://localhost:7080"));
+        when(headers.getHeaderString("Origin")).thenReturn("http://localhost:7080");
+
+        // thenAnswer, not thenReturn: a Stream is single-use and this is consumed more than once
+        // per request (Cors plus the controller's own filtering).
+        when(clientProvider.getClientsStream(realm))
+                .thenAnswer(inv -> Stream.concat(Stream.of(corsClient), realmClients.stream()));
+
+        when(groupProvider.getGroupById(eq(realm), anyString())).thenAnswer(inv -> {
+            final var group = mock(GroupModel.class);
+            when(group.getId()).thenReturn(inv.getArgument(1));
+            return group;
+        });
+
+        keycloakModelUtils = mockStatic(KeycloakModelUtils.class);
+        keycloakModelUtils.when(() -> KeycloakModelUtils.generateId()).thenReturn("fixed-id");
+        keycloakModelUtils.when(() -> KeycloakModelUtils.generateSecret(any())).thenReturn(NEW_SECRET);
+        keycloakModelUtils
+                .when(() -> KeycloakModelUtils.getClientScopeByName(realm, "service_point_group_id"))
+                .thenReturn(servicePointGroupIdScope);
+    }
+
+    @AfterEach
+    void tearDown() {
+        keycloakModelUtils.close();
+    }
+
+    // ---------------------------------------------------------------- fixtures
+
+    /**
+     * A ClientModel mock whose attribute map is real, so the controller's setAttribute calls can be
+     * asserted on afterwards.
+     */
+    private ClientModel credentialClient(final String clientId, final String groupId, final boolean enabled) {
+        final var attributes = new HashMap<String, String>();
+        attributes.put(MANAGED_ATTRIBUTE, "true");
+        attributes.put(GROUP_ID_ATTRIBUTE, groupId);
+        attributes.put(LABEL_ATTRIBUTE, "label for " + clientId);
+        attributes.put(CREATED_AT_ATTRIBUTE, "2026-08-01T00:00:00Z");
+        return backedClient(clientId, attributes, enabled);
+    }
+
+    private ClientModel backedClient(final String clientId, final Map<String, String> attributes, final boolean enabled) {
+        final var client = mock(ClientModel.class);
+        final var enabledHolder = new boolean[]{enabled};
+        when(client.getClientId()).thenReturn(clientId);
+        when(client.getAttribute(anyString())).thenAnswer(inv -> attributes.get(inv.<String>getArgument(0)));
+        when(client.getAttributes()).thenReturn(attributes);
+        doAnswer(inv -> {
+            attributes.put(inv.getArgument(0), inv.getArgument(1));
+            return null;
+        }).when(client).setAttribute(anyString(), anyString());
+        when(client.isEnabled()).thenAnswer(inv -> enabledHolder[0]);
+        doAnswer(inv -> {
+            enabledHolder[0] = inv.getArgument(0);
+            return null;
+        }).when(client).setEnabled(anyBoolean());
+        when(client.getSecret()).thenReturn("existing-secret");
+        return client;
+    }
+
+    private ClientModel registerCredential(final String clientId, final String groupId, final boolean enabled) {
+        final var client = credentialClient(clientId, groupId, enabled);
+        realmClients.add(client);
+        when(clientProvider.getClientByClientId(realm, clientId)).thenReturn(client);
+        return client;
+    }
+
+    private ClientModel stubNewClient() {
+        final var created = backedClient("raid-cred-fixed-id", new HashMap<>(), true);
+        when(clientProvider.addClient(eq(realm), anyString())).thenReturn(created);
+        when(userProvider.getServiceAccount(created)).thenReturn(serviceAccount);
+        when(realm.getRole(anyString())).thenReturn(null);
+        final var scopedUserRole = mock(RoleModel.class);
+        when(realm.addRole(anyString())).thenReturn(scopedUserRole);
+        return created;
+    }
+
+    private ClientCredentialController controller() {
+        try (MockedConstruction<AppAuthManager.BearerTokenAuthenticator> ignored =
+                     mockConstruction(AppAuthManager.BearerTokenAuthenticator.class,
+                             (mock, ctx) -> when(mock.authenticate()).thenReturn(authResult))) {
+            when(authResult.session()).thenReturn(userSession);
+            when(userSession.getUser()).thenReturn(user);
+            return new ClientCredentialController(session, fixedClock);
+        }
+    }
+
+    private ClientCredentialController unauthenticatedController() {
+        try (MockedConstruction<AppAuthManager.BearerTokenAuthenticator> ignored =
+                     mockConstruction(AppAuthManager.BearerTokenAuthenticator.class,
+                             (mock, ctx) -> when(mock.authenticate()).thenReturn(null))) {
+            return new ClientCredentialController(session, fixedClock);
+        }
+    }
+
+    private void givenRoles(final String... roleNames) {
+        when(user.getRoleMappingsStream()).thenAnswer(inv -> Stream.of(roleNames).map(name -> {
+            final var role = mock(RoleModel.class);
+            when(role.getName()).thenReturn(name);
+            return role;
+        }));
+    }
+
+    private void givenScopedAdminOf(final String groupId) {
+        givenRoles("service-point-admin:" + groupId);
+    }
+
+    private CreateCredentialRequest createRequest(final String groupId, final String label) {
+        final var request = new CreateCredentialRequest();
+        request.setGroupId(groupId);
+        request.setLabel(label);
+        return request;
+    }
+
+    private RotateCredentialRequest rotateRequest(final String clientId) {
+        final var request = new RotateCredentialRequest();
+        request.setClientId(clientId);
+        return request;
+    }
+
+    // ---------------------------------------------------------------- tests
+
+    @Nested
+    class Authentication {
+
+        @Test
+        void createReturns401WhenUnauthenticated() {
+            final var response = unauthenticatedController().create(createRequest(GROUP_A, "ci"));
+            assertThat(response.getStatus(), is(401));
+        }
+
+        @Test
+        void listReturns401WhenUnauthenticated() {
+            assertThat(unauthenticatedController().list(GROUP_A).getStatus(), is(401));
+        }
+
+        @Test
+        void rotateReturns401WhenUnauthenticated() {
+            assertThat(unauthenticatedController().rotate(rotateRequest("x")).getStatus(), is(401));
+        }
+
+        @Test
+        void revokeReturns401WhenUnauthenticated() {
+            assertThat(unauthenticatedController().revoke("x").getStatus(), is(401));
+        }
+
+        @Test
+        void getSecretReturns401WhenUnauthenticated() {
+            assertThat(unauthenticatedController().getSecret("x").getStatus(), is(401));
+        }
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void scopedAdminCreatesCredentialAndReceivesSecret() {
+            givenScopedAdminOf(GROUP_A);
+            final var created = stubNewClient();
+
+            try (MockedConstruction<ClientManager> clientManager = mockConstruction(ClientManager.class)) {
+                final var response = controller().create(createRequest(GROUP_A, "ci pipeline"));
+
+                assertThat(response.getStatus(), is(201));
+                assertThat(response.getEntity().toString(), containsString(NEW_SECRET));
+                assertThat(response.getEntity().toString(), containsString("ci pipeline"));
+                verify(clientManager.constructed().get(0)).enableServiceAccount(created);
+            }
+
+            assertThat(created.getAttribute(MANAGED_ATTRIBUTE), is("true"));
+            assertThat(created.getAttribute(GROUP_ID_ATTRIBUTE), is(GROUP_A));
+            assertThat(created.getAttribute(LABEL_ATTRIBUTE), is("ci pipeline"));
+            assertThat(created.getAttribute(CREATED_AT_ATTRIBUTE), is(FIXED_NOW));
+        }
+
+        @Test
+        void newCredentialIsConfidentialWithServiceAccountAndNoInteractiveFlows() {
+            givenScopedAdminOf(GROUP_A);
+            final var created = stubNewClient();
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                controller().create(createRequest(GROUP_A, "ci"));
+            }
+
+            verify(created).setPublicClient(false);
+            verify(created).setServiceAccountsEnabled(true);
+            verify(created).setStandardFlowEnabled(false);
+            verify(created).setDirectAccessGrantsEnabled(false);
+        }
+
+        @Test
+        void newCredentialGetsServicePointGroupIdScopeAndActiveGroupIdAttribute() {
+            givenScopedAdminOf(GROUP_A);
+            final var created = stubNewClient();
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                controller().create(createRequest(GROUP_A, "ci"));
+            }
+
+            // Without both of these the token carries no service_point_group_id claim at all.
+            verify(created).addClientScope(servicePointGroupIdScope, true);
+            verify(serviceAccount).setAttribute("activeGroupId", List.of(GROUP_A));
+        }
+
+        @Test
+        void serviceAccountIsGrantedScopedUsageRoleOnly() {
+            givenScopedAdminOf(GROUP_A);
+            stubNewClient();
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                controller().create(createRequest(GROUP_A, "ci"));
+            }
+
+            verify(realm).addRole("service-point-user:" + GROUP_A);
+            verify(serviceAccount).grantRole(any(RoleModel.class));
+            verify(serviceAccount, never()).grantRole(argThat(role ->
+                    role != null && role.getName() != null && role.getName().contains("admin")));
+        }
+
+        @Test
+        void reusesExistingScopedUsageRoleRatherThanRecreatingIt() {
+            givenScopedAdminOf(GROUP_A);
+            stubNewClient();
+            final var existing = mock(RoleModel.class);
+            when(realm.getRole("service-point-user:" + GROUP_A)).thenReturn(existing);
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                controller().create(createRequest(GROUP_A, "ci"));
+            }
+
+            verify(realm, never()).addRole("service-point-user:" + GROUP_A);
+            verify(serviceAccount).grantRole(existing);
+        }
+
+        @Test
+        void operatorCanCreateForAnyServicePoint() {
+            givenRoles("operator");
+            stubNewClient();
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                assertThat(controller().create(createRequest(GROUP_B, "ci")).getStatus(), is(201));
+            }
+        }
+
+        @Test
+        void adminOfOneServicePointCannotCreateForAnother() {
+            givenScopedAdminOf(GROUP_A);
+            stubNewClient();
+
+            final var controller = controller();
+            assertThrows(NotAuthorizedException.class, () -> controller.create(createRequest(GROUP_B, "ci")));
+            verify(clientProvider, never()).addClient(any(), anyString());
+        }
+
+        @Test
+        void flatGroupAdminIsRejectedWithNoFallback() {
+            givenRoles("group-admin", "service-point-user");
+            stubNewClient();
+
+            final var controller = controller();
+            assertThrows(NotAuthorizedException.class, () -> controller.create(createRequest(GROUP_A, "ci")));
+            verify(clientProvider, never()).addClient(any(), anyString());
+        }
+
+        @Test
+        void userWithNoRelevantRolesIsRejected() {
+            givenRoles();
+            final var controller = controller();
+            assertThrows(NotAuthorizedException.class, () -> controller.create(createRequest(GROUP_A, "ci")));
+        }
+
+        @Test
+        void missingGroupIdIsRejected() {
+            givenScopedAdminOf(GROUP_A);
+            assertThat(controller().create(createRequest(null, "ci")).getStatus(), is(400));
+        }
+
+        @Test
+        void missingLabelIsRejected() {
+            givenScopedAdminOf(GROUP_A);
+            assertThat(controller().create(createRequest(GROUP_A, "  ")).getStatus(), is(400));
+        }
+
+        @Test
+        void unknownServicePointIsRejected() {
+            givenScopedAdminOf(GROUP_A);
+            when(groupProvider.getGroupById(realm, GROUP_A)).thenReturn(null);
+            assertThat(controller().create(createRequest(GROUP_A, "ci")).getStatus(), is(404));
+        }
+
+        @Test
+        void missingClientScopeFailsClosed() {
+            givenScopedAdminOf(GROUP_A);
+            stubNewClient();
+            keycloakModelUtils
+                    .when(() -> KeycloakModelUtils.getClientScopeByName(realm, "service_point_group_id"))
+                    .thenReturn(null);
+
+            final var controller = controller();
+            assertThrows(InternalServerErrorException.class,
+                    () -> controller.create(createRequest(GROUP_A, "ci")));
+        }
+
+        @Test
+        void missingServiceAccountFailsClosed() {
+            givenScopedAdminOf(GROUP_A);
+            final var created = stubNewClient();
+            when(userProvider.getServiceAccount(created)).thenReturn(null);
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                final var controller = controller();
+                assertThrows(InternalServerErrorException.class,
+                        () -> controller.create(createRequest(GROUP_A, "ci")));
+            }
+        }
+    }
+
+    @Nested
+    class Cap {
+
+        @Test
+        void creatingAtTheCapIsRejectedWith409() {
+            givenScopedAdminOf(GROUP_A);
+            for (var i = 0; i < ClientCredentialController.MAX_CREDENTIALS_PER_SERVICE_POINT; i++) {
+                registerCredential("raid-cred-" + i, GROUP_A, true);
+            }
+
+            final var response = controller().create(createRequest(GROUP_A, "one too many"));
+
+            assertThat(response.getStatus(), is(409));
+            assertThat(response.getEntity().toString(),
+                    containsString(String.valueOf(ClientCredentialController.MAX_CREDENTIALS_PER_SERVICE_POINT)));
+            verify(clientProvider, never()).addClient(any(), anyString());
+        }
+
+        @Test
+        void creatingJustBelowTheCapSucceeds() {
+            givenScopedAdminOf(GROUP_A);
+            for (var i = 0; i < ClientCredentialController.MAX_CREDENTIALS_PER_SERVICE_POINT - 1; i++) {
+                registerCredential("raid-cred-" + i, GROUP_A, true);
+            }
+            stubNewClient();
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                assertThat(controller().create(createRequest(GROUP_A, "last slot")).getStatus(), is(201));
+            }
+        }
+
+        @Test
+        void revokedCredentialsDoNotCountTowardsTheCap() {
+            givenScopedAdminOf(GROUP_A);
+            for (var i = 0; i < ClientCredentialController.MAX_CREDENTIALS_PER_SERVICE_POINT; i++) {
+                // One of them revoked, so a slot is free.
+                registerCredential("raid-cred-" + i, GROUP_A, i != 0);
+            }
+            stubNewClient();
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                assertThat(controller().create(createRequest(GROUP_A, "reused slot")).getStatus(), is(201));
+            }
+        }
+
+        @Test
+        void anotherServicePointsCredentialsDoNotCountTowardsTheCap() {
+            givenScopedAdminOf(GROUP_A);
+            for (var i = 0; i < ClientCredentialController.MAX_CREDENTIALS_PER_SERVICE_POINT; i++) {
+                registerCredential("raid-cred-b-" + i, GROUP_B, true);
+            }
+            stubNewClient();
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                assertThat(controller().create(createRequest(GROUP_A, "ci")).getStatus(), is(201));
+            }
+        }
+    }
+
+    @Nested
+    class ListCredentials {
+
+        @Test
+        void listsOnlyTheServicePointsOwnCredentials() {
+            givenScopedAdminOf(GROUP_A);
+            registerCredential("raid-cred-a1", GROUP_A, true);
+            registerCredential("raid-cred-a2", GROUP_A, true);
+            registerCredential("raid-cred-b1", GROUP_B, true);
+
+            final var body = controller().list(GROUP_A).getEntity().toString();
+
+            assertThat(body, containsString("raid-cred-a1"));
+            assertThat(body, containsString("raid-cred-a2"));
+            assertThat(body, not(containsString("raid-cred-b1")));
+        }
+
+        @Test
+        void listIncludesRevokedCredentialsFlaggedAsDisabled() {
+            givenScopedAdminOf(GROUP_A);
+            registerCredential("raid-cred-revoked", GROUP_A, false);
+
+            final var body = controller().list(GROUP_A).getEntity().toString();
+
+            assertThat(body, containsString("raid-cred-revoked"));
+            assertThat(body, containsString("\"enabled\":false"));
+        }
+
+        @Test
+        void listNeverIncludesUnmanagedRealmClients() {
+            givenScopedAdminOf(GROUP_A);
+            final var appClient = backedClient("raid-api", new HashMap<>(), true);
+            realmClients.add(appClient);
+
+            final var body = controller().list(GROUP_A).getEntity().toString();
+
+            assertThat(body, not(containsString("raid-api")));
+        }
+
+        @Test
+        void adminOfOneServicePointCannotListAnother() {
+            givenScopedAdminOf(GROUP_A);
+            final var controller = controller();
+            assertThrows(NotAuthorizedException.class, () -> controller.list(GROUP_B));
+        }
+
+        @Test
+        void missingGroupIdIsRejected() {
+            givenScopedAdminOf(GROUP_A);
+            assertThat(controller().list(null).getStatus(), is(400));
+        }
+    }
+
+    @Nested
+    class Rotate {
+
+        @Test
+        void rotateIssuesNewSecretAndRecordsRotationTime() {
+            givenScopedAdminOf(GROUP_A);
+            final var client = registerCredential("raid-cred-a1", GROUP_A, true);
+
+            final var response = controller().rotate(rotateRequest("raid-cred-a1"));
+
+            assertThat(response.getStatus(), is(200));
+            assertThat(response.getEntity().toString(), containsString(NEW_SECRET));
+            assertThat(client.getAttribute(ROTATED_AT_ATTRIBUTE), is(FIXED_NOW));
+        }
+
+        @Test
+        void rotateLeavesLabelAndOwnerUnchanged() {
+            givenScopedAdminOf(GROUP_A);
+            final var client = registerCredential("raid-cred-a1", GROUP_A, true);
+            final var labelBefore = client.getAttribute(LABEL_ATTRIBUTE);
+
+            controller().rotate(rotateRequest("raid-cred-a1"));
+
+            assertThat(client.getAttribute(LABEL_ATTRIBUTE), is(labelBefore));
+            assertThat(client.getAttribute(GROUP_ID_ATTRIBUTE), is(GROUP_A));
+        }
+
+        @Test
+        void rotatingRevokedCredentialIsRejectedWith409() {
+            givenScopedAdminOf(GROUP_A);
+            registerCredential("raid-cred-a1", GROUP_A, false);
+
+            final var response = controller().rotate(rotateRequest("raid-cred-a1"));
+
+            assertThat(response.getStatus(), is(409));
+            keycloakModelUtils.verify(() -> KeycloakModelUtils.generateSecret(any()), never());
+        }
+
+        @Test
+        void adminOfOneServicePointCannotRotateAnothers() {
+            givenScopedAdminOf(GROUP_A);
+            registerCredential("raid-cred-b1", GROUP_B, true);
+
+            final var controller = controller();
+            assertThrows(NotAuthorizedException.class, () -> controller.rotate(rotateRequest("raid-cred-b1")));
+        }
+
+        @Test
+        void unknownCredentialIsNotFound() {
+            givenScopedAdminOf(GROUP_A);
+            assertThat(controller().rotate(rotateRequest("nope")).getStatus(), is(404));
+        }
+
+        @Test
+        void unmanagedClientIsTreatedAsNotFound() {
+            givenScopedAdminOf(GROUP_A);
+            final var appClient = backedClient("raid-api", new HashMap<>(), true);
+            when(clientProvider.getClientByClientId(realm, "raid-api")).thenReturn(appClient);
+
+            // Must not be usable to probe or mutate the realm's own clients.
+            assertThat(controller().rotate(rotateRequest("raid-api")).getStatus(), is(404));
+            verify(appClient, never()).setEnabled(anyBoolean());
+        }
+    }
+
+    @Nested
+    class Revoke {
+
+        @Test
+        void revokeDisablesTheCredential() {
+            givenScopedAdminOf(GROUP_A);
+            final var client = registerCredential("raid-cred-a1", GROUP_A, true);
+
+            final var response = controller().revoke("raid-cred-a1");
+
+            assertThat(response.getStatus(), is(200));
+            verify(client).setEnabled(false);
+            assertThat(client.isEnabled(), is(false));
+        }
+
+        @Test
+        void revokeIsIdempotent() {
+            givenScopedAdminOf(GROUP_A);
+            final var client = registerCredential("raid-cred-a1", GROUP_A, false);
+
+            final var response = controller().revoke("raid-cred-a1");
+
+            assertThat(response.getStatus(), is(200));
+            verify(client, never()).setEnabled(anyBoolean());
+        }
+
+        @Test
+        void revokeNeverDeletesTheClient() {
+            givenScopedAdminOf(GROUP_A);
+            registerCredential("raid-cred-a1", GROUP_A, true);
+
+            controller().revoke("raid-cred-a1");
+
+            verify(clientProvider, never()).removeClient(any(), anyString());
+        }
+
+        @Test
+        void adminOfOneServicePointCannotRevokeAnothers() {
+            givenScopedAdminOf(GROUP_A);
+            registerCredential("raid-cred-b1", GROUP_B, true);
+
+            final var controller = controller();
+            assertThrows(NotAuthorizedException.class, () -> controller.revoke("raid-cred-b1"));
+        }
+
+        @Test
+        void operatorCanRevokeAnyServicePointsCredential() {
+            givenRoles("operator");
+            final var client = registerCredential("raid-cred-b1", GROUP_B, true);
+
+            assertThat(controller().revoke("raid-cred-b1").getStatus(), is(200));
+            verify(client).setEnabled(false);
+        }
+    }
+
+    @Nested
+    class GetSecret {
+
+        @Test
+        void returnsCurrentSecretToOwningServicePointAdmin() {
+            givenScopedAdminOf(GROUP_A);
+            registerCredential("raid-cred-a1", GROUP_A, true);
+
+            final var response = controller().getSecret("raid-cred-a1");
+
+            assertThat(response.getStatus(), is(200));
+            assertThat(response.getEntity().toString(), containsString("existing-secret"));
+        }
+
+        @Test
+        void adminOfOneServicePointCannotReadAnothersSecret() {
+            givenScopedAdminOf(GROUP_A);
+            registerCredential("raid-cred-b1", GROUP_B, true);
+
+            final var controller = controller();
+            assertThrows(NotAuthorizedException.class, () -> controller.getSecret("raid-cred-b1"));
+        }
+
+        @Test
+        void flatGroupAdminCannotReadASecret() {
+            givenRoles("group-admin", "service-point-user");
+            registerCredential("raid-cred-a1", GROUP_A, true);
+
+            final var controller = controller();
+            assertThrows(NotAuthorizedException.class, () -> controller.getSecret("raid-cred-a1"));
+        }
+
+        @Test
+        void unknownCredentialIsNotFound() {
+            givenScopedAdminOf(GROUP_A);
+            assertThat(controller().getSecret("nope").getStatus(), is(404));
+        }
+    }
+
+    @Nested
+    class Preflight {
+
+        @Test
+        void collectionPreflightAdvertisesTheCollectionMethods() {
+            final var response = controller().preflight();
+            final var allowed = response.getHeaderString("Access-Control-Allow-Methods");
+            assertThat(allowed, allOf(containsString("GET"), containsString("POST"), containsString("DELETE")));
+        }
+
+        @Test
+        void rotatePreflightAdvertisesPost() {
+            assertThat(controller().rotatePreflight().getHeaderString("Access-Control-Allow-Methods"),
+                    containsString("POST"));
+        }
+
+        @Test
+        void secretPreflightAdvertisesGet() {
+            assertThat(controller().secretPreflight().getHeaderString("Access-Control-Allow-Methods"),
+                    containsString("GET"));
+        }
+    }
+}


### PR DESCRIPTION
Into `feature/RAID-827` (story integration branch).

Implements the credential lifecycle for [RAID-846](https://ardc.atlassian.net/browse/RAID-846), in-process via the Keycloak model layer per the [RAID-845](https://ardc.atlassian.net/browse/RAID-845) ADR. **No service account and no `manage-clients` grant exists anywhere.**

New resource at `/realms/raid/client-credential`:

| Method | Path | Purpose |
|---|---|---|
| `POST` | `/` | create (returns secret) |
| `GET` | `/?groupId=` | list (no secrets) |
| `POST` | `/rotate` | reissue secret |
| `GET` | `/secret?clientId=` | current secret |
| `DELETE` | `/?clientId=` | revoke |

## Two things the realm made non-obvious

Worth calling out, because either would have been a silent failure:

1. **`service_point_group_id` is not a realm default client scope.** It exists as a dedicated scope attached only to the `raid-api` client. A newly created credential would authenticate fine but its token would carry **no service point at all**. The code attaches the scope explicitly and fails closed if it's missing from the realm.
2. **That scope's mapper is an `oidc-usermodel-attribute-mapper` reading `activeGroupId`.** So the attribute is set on the credential's *service account user*, not just the client. Also fails closed if the service account isn't created.

## Design notes

- **Authorisation** mirrors `GroupController`: bearer auth, then a uniform Operator short-circuit applied *independently* of the scoped `service-point-admin:<groupId>` check, as RAID-827 requires (separate, not OR-ed). Unlike `GroupController` there is deliberately **no flat `group-admin` fallback**.
- **Ownership and metadata are client attributes**, so isolation and listing filter on stored data rather than a naming convention. A `raid.credential.managed` marker means the endpoints can never read or mutate the realm's own clients — an unmanaged clientId is reported as absent rather than 403, so it can't be used to probe.
- **Revoke disables rather than deletes.** That makes it naturally idempotent, keeps the audit trail, lets rotation of a revoked credential be rejected, and means the cap counts only live credentials.
- **Cap of 10** active credentials per service point → 409 Conflict ([RAID-849](https://ardc.atlassian.net/browse/RAID-849)).
- Created clients are confidential, service-accounts-enabled, with standard flow and direct access grants off.

## Verification

**48 new unit tests, 160 total, 0 failures, 0 skipped** (112 pre-existing still green).

**The deny paths were mutation-tested.** Making the scoped isolation check return `true` unconditionally fails exactly 8 tests, covering every endpoint plus the flat-role rejection — so the isolation tests aren't vacuous. Mutation reverted.

**The SPI was verified to actually load and route**, in an isolated Keycloak **26.6.2** container (the production runtime, so this also exercises the 26.5.6-compile/26.6.2-run skew) with the built jar mounted:

```
KC-SERVICES0047: client-credential (...ClientCredentialControllerResourceProviderFactory)
  is implementing the internal SPI realm-restapi-extension
```

| Request | Result |
|---|---|
| `GET /realms/raid/client-credential` (no token) | **401** — routed to our code |
| `GET /realms/raid/group/all` (control) | 401 |
| `OPTIONS /client-credential` | 200, `allow=GET, POST, DELETE, OPTIONS` |
| `OPTIONS /client-credential/rotate` | 200, `allow=POST, OPTIONS` |
| `GET /realms/raid/no-such-provider` (control) | **404** — discriminator sound |

The container was isolated on a spare port and removed afterwards; the shared local stack was not touched.

## Not done here, deliberately

- **`Cache-Control: no-store` and audit logging** belong to [RAID-847](https://ardc.atlassian.net/browse/RAID-847). Marked with `TODO:RAID-847` at each secret-returning endpoint so they can't be missed.
- **Integration tests** belong to [RAID-848](https://ardc.atlassian.net/browse/RAID-848). The `api-svc` intTest suite was **not** run: no `api-svc` code is touched, and the one way this change could break it is Keycloak failing to start, which the container check above directly disproves.
- **The disabled-service-point rejection was dropped.** `service_point.enabled` lives in the API's database and the SPI has no view of it. Separately, that flag appears unenforced anywhere in the API today, which is a wider issue worth its own ticket.
- **Scoped usage role only.** The service account gets `service-point-user:<groupId>`, created on demand, per the AC. Note nothing consumes that role yet, so API-side consumption is still needed before a credential can actually authorise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)