### PR TITLE
RAID-847: harden secret handling and add credential audit trail

### DIFF
--- a/iam/src/main/java/au/org/raid/iam/provider/cors/Cors.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/cors/Cors.java
@@ -44,9 +44,24 @@ public class Cors {
         responseBuilder.header("Access-Control-Max-Age", "3600");
 
         final var response = responseBuilder.build();
-        log.debug("Returning response {}", objectMapper.writeValueAsString(response));
+        log.debug("Returning {}", debugPayload(response));
         return response;
 
+    }
+
+    /**
+     * The payload logged at debug level. Deliberately status and headers only.
+     *
+     * <p>This previously logged {@code objectMapper.writeValueAsString(response)}, and Jackson
+     * serialises {@code Response.getEntity()}, so every response body from every SPI controller was
+     * written into the application log - including the client secrets returned by the credential
+     * endpoints. It must never include the entity (RAID-847).
+     *
+     * <p>Package-private so the guarantee can be asserted directly in tests.
+     */
+    @SneakyThrows
+    String debugPayload(final Response response) {
+        return response.getStatus() + " headers=" + objectMapper.writeValueAsString(response.getStringHeaders());
     }
 
     private List<String> getAllowedOrigins() {

--- a/iam/src/main/java/au/org/raid/iam/provider/credential/ClientCredentialController.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/credential/ClientCredentialController.java
@@ -7,6 +7,7 @@ import au.org.raid.iam.provider.credential.dto.CredentialSecretResponse;
 import au.org.raid.iam.provider.credential.dto.RotateCredentialRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
@@ -65,6 +66,9 @@ public class ClientCredentialController {
 
     private static final String CLIENT_ID_PREFIX = "raid-cred-";
 
+    /** Applied to every response carrying a secret value, so it is never cached anywhere. */
+    private static final String NO_STORE = "no-store";
+
     /**
      * Maximum active (non-revoked) credentials per service point. Deliberately a constant rather
      * than configuration so it is cheap to revisit, per RAID-849: rate limiting was deferred until
@@ -78,6 +82,7 @@ public class ClientCredentialController {
     private final KeycloakSession session;
     private final Cors cors;
     private final Clock clock;
+    private final CredentialAuditLogger auditLogger;
 
     public ClientCredentialController(final KeycloakSession session) {
         this(session, Clock.systemUTC());
@@ -86,10 +91,17 @@ public class ClientCredentialController {
     // Package-private seam for tests, so timestamps are deterministic without touching the system
     // clock.
     ClientCredentialController(final KeycloakSession session, final Clock clock) {
+        this(session, clock, new CredentialAuditLogger(clock));
+    }
+
+    // Package-private seam for tests, so audit output can be captured directly.
+    ClientCredentialController(final KeycloakSession session, final Clock clock,
+                              final CredentialAuditLogger auditLogger) {
         this.session = session;
         this.auth = new AppAuthManager.BearerTokenAuthenticator(session).authenticate();
         this.cors = new Cors(session, objectMapper);
         this.clock = clock;
+        this.auditLogger = auditLogger;
     }
 
     @OPTIONS
@@ -162,12 +174,14 @@ public class ClientCredentialController {
         serviceAccount.setAttribute(ACTIVE_GROUP_ID_ATTRIBUTE, List.of(groupId));
         serviceAccount.grantRole(getOrCreateScopedServicePointUserRole(realm, groupId));
 
-        // TODO:RAID-847 add Cache-Control: no-store to this response.
         final var body = new CredentialSecretResponse(
                 client.getClientId(), request.getLabel().trim(), secret, now, null);
 
+        auditLogger.record(CredentialAuditLogger.ACTION_CREATE, user, client.getClientId(), groupId);
+
         return cors.buildCorsResponse("POST",
                 Response.status(Response.Status.CREATED)
+                        .header(HttpHeaders.CACHE_CONTROL, NO_STORE)
                         .entity(objectMapper.writeValueAsString(body)));
     }
 
@@ -192,6 +206,8 @@ public class ClientCredentialController {
         final var credentials = managedCredentials(realm, groupId.trim())
                 .map(this::toResponse)
                 .toList();
+
+        auditLogger.record(CredentialAuditLogger.ACTION_LIST, user, null, groupId.trim());
 
         return cors.buildCorsResponse("GET",
                 Response.ok().entity(objectMapper.writeValueAsString(credentials)));
@@ -235,7 +251,6 @@ public class ClientCredentialController {
         final var secret = KeycloakModelUtils.generateSecret(client);
         client.setAttribute(ROTATED_AT_ATTRIBUTE, rotatedAt);
 
-        // TODO:RAID-847 add Cache-Control: no-store to this response.
         final var body = new CredentialSecretResponse(
                 client.getClientId(),
                 client.getAttribute(LABEL_ATTRIBUTE),
@@ -243,8 +258,12 @@ public class ClientCredentialController {
                 client.getAttribute(CREATED_AT_ATTRIBUTE),
                 rotatedAt);
 
+        auditLogger.record(CredentialAuditLogger.ACTION_ROTATE, user, client.getClientId(), ownerGroupId(client));
+
         return cors.buildCorsResponse("POST",
-                Response.ok().entity(objectMapper.writeValueAsString(body)));
+                Response.ok()
+                        .header(HttpHeaders.CACHE_CONTROL, NO_STORE)
+                        .entity(objectMapper.writeValueAsString(body)));
     }
 
     @OPTIONS
@@ -276,8 +295,6 @@ public class ClientCredentialController {
 
         requireAuthorisedFor(user, ownerGroupId(client));
 
-        // TODO:RAID-847 add Cache-Control: no-store, and an audit entry recording caller, clientId
-        // and timestamp - never the secret value.
         final var body = new CredentialSecretResponse(
                 client.getClientId(),
                 client.getAttribute(LABEL_ATTRIBUTE),
@@ -285,8 +302,13 @@ public class ClientCredentialController {
                 client.getAttribute(CREATED_AT_ATTRIBUTE),
                 client.getAttribute(ROTATED_AT_ATTRIBUTE));
 
+        auditLogger.record(
+                CredentialAuditLogger.ACTION_REVEAL_SECRET, user, client.getClientId(), ownerGroupId(client));
+
         return cors.buildCorsResponse("GET",
-                Response.ok().entity(objectMapper.writeValueAsString(body)));
+                Response.ok()
+                        .header(HttpHeaders.CACHE_CONTROL, NO_STORE)
+                        .entity(objectMapper.writeValueAsString(body)));
     }
 
     /**
@@ -321,6 +343,8 @@ public class ClientCredentialController {
         if (client.isEnabled()) {
             client.setEnabled(false);
         }
+
+        auditLogger.record(CredentialAuditLogger.ACTION_REVOKE, user, client.getClientId(), ownerGroupId(client));
 
         return cors.buildCorsResponse("DELETE",
                 Response.ok().entity(objectMapper.writeValueAsString(toResponse(client))));

--- a/iam/src/main/java/au/org/raid/iam/provider/credential/CredentialAuditLogger.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/credential/CredentialAuditLogger.java
@@ -1,0 +1,60 @@
+package au.org.raid.iam.provider.credential;
+
+import org.keycloak.models.UserModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Audit trail for client credential lifecycle actions (RAID-847).
+ *
+ * <p>Records who did what, when, and to which credential. It deliberately has no parameter capable
+ * of carrying a secret value, so the type itself guarantees a secret cannot be audited by mistake.
+ *
+ * <p>Entries are written at INFO under the dedicated logger name {@value #AUDIT_LOGGER_NAME} rather
+ * than this class's own name, so deployments can route or retain the audit trail independently of
+ * ordinary application logging.
+ */
+public class CredentialAuditLogger {
+    static final String AUDIT_LOGGER_NAME = "au.org.raid.iam.audit";
+
+    public static final String ACTION_CREATE = "credential.create";
+    public static final String ACTION_LIST = "credential.list";
+    public static final String ACTION_ROTATE = "credential.rotate";
+    public static final String ACTION_REVOKE = "credential.revoke";
+    public static final String ACTION_REVEAL_SECRET = "credential.reveal-secret";
+
+    private final Logger auditLog;
+    private final Clock clock;
+
+    public CredentialAuditLogger(final Clock clock) {
+        this(clock, LoggerFactory.getLogger(AUDIT_LOGGER_NAME));
+    }
+
+    // Package-private seam for tests, so the audit output can be captured without a logging appender.
+    CredentialAuditLogger(final Clock clock, final Logger auditLog) {
+        this.clock = clock;
+        this.auditLog = auditLog;
+    }
+
+    /**
+     * @param action   one of the {@code ACTION_*} constants
+     * @param actor    the authenticated caller
+     * @param clientId the credential acted on, or null where the action is not specific to one
+     *                 (a list, for instance)
+     * @param groupId  the owning service point group
+     */
+    public void record(final String action, final UserModel actor, final String clientId, final String groupId) {
+        auditLog.info("action={} at={} actorId={} actor={} clientId={} servicePointGroupId={}",
+                action,
+                DateTimeFormatter.ISO_INSTANT.format(Instant.now(clock).truncatedTo(ChronoUnit.SECONDS)),
+                actor == null ? null : actor.getId(),
+                actor == null ? null : actor.getUsername(),
+                clientId,
+                groupId);
+    }
+}

--- a/iam/src/main/java/au/org/raid/iam/provider/credential/dto/CredentialSecretResponse.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/credential/dto/CredentialSecretResponse.java
@@ -12,4 +12,18 @@ public record CredentialSecretResponse(
         String secret,
         String createdAt,
         String lastRotatedAt) {
+
+    /**
+     * Redacts the secret. A record's generated {@code toString} includes every component, so
+     * without this any accidental log statement or exception message mentioning this object would
+     * write the secret into the log (RAID-847).
+     */
+    @Override
+    public String toString() {
+        return "CredentialSecretResponse[clientId=" + clientId
+                + ", label=" + label
+                + ", secret=***REDACTED***"
+                + ", createdAt=" + createdAt
+                + ", lastRotatedAt=" + lastRotatedAt + "]";
+    }
 }

--- a/iam/src/test/java/au/org/raid/iam/provider/cors/CorsDebugPayloadTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/cors/CorsDebugPayloadTest.java
@@ -1,0 +1,55 @@
+package au.org.raid.iam.provider.cors;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.KeycloakSession;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * RAID-847 regression guard.
+ *
+ * <p>{@code Cors} used to log {@code objectMapper.writeValueAsString(response)} at debug level.
+ * Jackson serialises {@code Response.getEntity()}, so that wrote every response body from every SPI
+ * controller into the application log, including the client secrets returned by the credential
+ * endpoints. The debug payload must never include the entity.
+ */
+class CorsDebugPayloadTest {
+
+    private final Cors cors = new Cors(mock(KeycloakSession.class), new ObjectMapper());
+
+    private Response responseCarryingASecret() {
+        return Response.ok()
+                .entity("{\"clientId\":\"raid-cred-a1\",\"secret\":\"SUPER_SECRET\"}")
+                .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                .build();
+    }
+
+    @Test
+    void neverIncludesTheResponseEntity() {
+        final var payload = cors.debugPayload(responseCarryingASecret());
+
+        assertThat(payload, not(containsString("SUPER_SECRET")));
+        assertThat(payload, not(containsString("clientId")));
+        assertThat(payload, not(containsStringIgnoringCase("entity")));
+    }
+
+    @Test
+    void stillReportsStatusAndHeadersSoItRemainsUsefulForDebugging() {
+        final var payload = cors.debugPayload(responseCarryingASecret());
+
+        assertThat(payload, containsString("200"));
+        assertThat(payload, containsString("Cache-Control"));
+    }
+
+    @Test
+    void handlesAResponseWithNoEntity() {
+        final var payload = cors.debugPayload(Response.noContent().build());
+
+        assertThat(payload, containsString("204"));
+    }
+}

--- a/iam/src/test/java/au/org/raid/iam/provider/credential/CredentialAuditLoggerTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/credential/CredentialAuditLoggerTest.java
@@ -1,0 +1,94 @@
+package au.org.raid.iam.provider.credential;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.models.UserModel;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.slf4j.Logger;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CredentialAuditLoggerTest {
+
+    private static final String FIXED_NOW = "2026-08-27T00:00:00Z";
+
+    @Mock private Logger auditLog;
+    @Mock private UserModel actor;
+
+    private CredentialAuditLogger auditLogger;
+
+    @BeforeEach
+    void setUp() {
+        when(actor.getId()).thenReturn("user-uuid");
+        when(actor.getUsername()).thenReturn("sp-admin");
+        auditLogger = new CredentialAuditLogger(
+                Clock.fixed(Instant.parse(FIXED_NOW), ZoneOffset.UTC), auditLog);
+    }
+
+    private Object[] captureArgs() {
+        final var args = ArgumentCaptor.forClass(Object[].class);
+        verify(auditLog).info(org.mockito.ArgumentMatchers.anyString(), args.capture());
+        return args.getValue();
+    }
+
+    @Test
+    void recordsActorCredentialAndServicePoint() {
+        auditLogger.record(CredentialAuditLogger.ACTION_REVEAL_SECRET, actor, "raid-cred-x", "group-a");
+
+        final var args = captureArgs();
+        assertThat(args, hasItemInArray("credential.reveal-secret"));
+        assertThat(args, hasItemInArray("user-uuid"));
+        assertThat(args, hasItemInArray("sp-admin"));
+        assertThat(args, hasItemInArray("raid-cred-x"));
+        assertThat(args, hasItemInArray("group-a"));
+    }
+
+    @Test
+    void recordsTimestampAsIso8601Utc() {
+        auditLogger.record(CredentialAuditLogger.ACTION_CREATE, actor, "raid-cred-x", "group-a");
+
+        assertThat(captureArgs(), hasItemInArray(FIXED_NOW));
+    }
+
+    @Test
+    void toleratesANullClientIdForActionsNotSpecificToOneCredential() {
+        auditLogger.record(CredentialAuditLogger.ACTION_LIST, actor, null, "group-a");
+
+        final var args = captureArgs();
+        assertThat(args, hasItemInArray("credential.list"));
+        assertThat(args, hasItemInArray("group-a"));
+    }
+
+    @Test
+    void writesToTheDedicatedAuditLoggerName() {
+        // Deployments route and retain the audit trail separately from application logging, so the
+        // logger name is part of the contract.
+        assertThat(CredentialAuditLogger.AUDIT_LOGGER_NAME, is("au.org.raid.iam.audit"));
+    }
+
+    @Test
+    void recordsAtInfoAndNowhereElse() {
+        // An audit trail suppressed by a production log level would be worthless, so it must be
+        // INFO. captureArgs() verifies the info(..) call; verifyNoMoreInteractions then proves
+        // nothing was written at debug or any other level instead.
+        auditLogger.record(CredentialAuditLogger.ACTION_CREATE, actor, "raid-cred-x", "group-a");
+
+        captureArgs();
+        verifyNoMoreInteractions(auditLog);
+    }
+}

--- a/iam/src/test/java/au/org/raid/iam/provider/credential/CredentialSecretHandlingTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/credential/CredentialSecretHandlingTest.java
@@ -1,0 +1,289 @@
+package au.org.raid.iam.provider.credential;
+
+import au.org.raid.iam.provider.cors.Cors;
+import au.org.raid.iam.provider.credential.dto.CreateCredentialRequest;
+import au.org.raid.iam.provider.credential.dto.CredentialSecretResponse;
+import au.org.raid.iam.provider.credential.dto.RotateCredentialRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.models.*;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.services.managers.AppAuthManager;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.managers.ClientManager;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * RAID-847: secret-handling hardening and the audit trail.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CredentialSecretHandlingTest {
+
+    private static final String GROUP_A = "group-a-uuid";
+    private static final String SECRET = "generated-secret-value";
+
+    @Mock private KeycloakSession session;
+    @Mock private KeycloakContext context;
+    @Mock private RealmModel realm;
+    @Mock private UserModel user;
+    @Mock private UserProvider userProvider;
+    @Mock private GroupProvider groupProvider;
+    @Mock private ClientProvider clientProvider;
+    @Mock private HttpHeaders headers;
+    @Mock private AuthenticationManager.AuthResult authResult;
+    @Mock private UserSessionModel userSession;
+    @Mock private UserModel serviceAccount;
+    @Mock private ClientScopeModel scope;
+    @Mock private CredentialAuditLogger auditLogger;
+
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-08-27T00:00:00Z"), ZoneOffset.UTC);
+    private MockedStatic<KeycloakModelUtils> keycloakModelUtils;
+
+    @BeforeEach
+    void setUp() {
+        when(session.getContext()).thenReturn(context);
+        when(context.getRealm()).thenReturn(realm);
+        when(context.getRequestHeaders()).thenReturn(headers);
+        when(session.clients()).thenReturn(clientProvider);
+        when(session.users()).thenReturn(userProvider);
+        when(session.groups()).thenReturn(groupProvider);
+
+        final var corsClient = mock(ClientModel.class);
+        when(corsClient.getWebOrigins()).thenReturn(Set.of("http://localhost:7080"));
+        when(clientProvider.getClientsStream(realm)).thenAnswer(inv -> Stream.of(corsClient));
+        when(headers.getHeaderString("Origin")).thenReturn("http://localhost:7080");
+
+        when(groupProvider.getGroupById(eq(realm), anyString())).thenAnswer(inv -> mock(GroupModel.class));
+
+        final var scopedRole = mock(RoleModel.class);
+        when(scopedRole.getName()).thenReturn("service-point-admin:" + GROUP_A);
+        when(user.getRoleMappingsStream()).thenAnswer(inv -> Stream.of(scopedRole));
+
+        keycloakModelUtils = mockStatic(KeycloakModelUtils.class);
+        keycloakModelUtils.when(KeycloakModelUtils::generateId).thenReturn("fixed-id");
+        keycloakModelUtils.when(() -> KeycloakModelUtils.generateSecret(any())).thenReturn(SECRET);
+        keycloakModelUtils.when(() -> KeycloakModelUtils.getClientScopeByName(realm, "service_point_group_id"))
+                .thenReturn(scope);
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    void tearDown() {
+        keycloakModelUtils.close();
+    }
+
+    private ClientModel backedClient(final String clientId, final Map<String, String> attributes) {
+        final var client = mock(ClientModel.class);
+        final var enabled = new boolean[]{true};
+        when(client.getClientId()).thenReturn(clientId);
+        when(client.getAttribute(anyString())).thenAnswer(inv -> attributes.get(inv.<String>getArgument(0)));
+        doAnswer(inv -> {
+            attributes.put(inv.getArgument(0), inv.getArgument(1));
+            return null;
+        }).when(client).setAttribute(anyString(), anyString());
+        when(client.isEnabled()).thenAnswer(inv -> enabled[0]);
+        doAnswer(inv -> {
+            enabled[0] = inv.getArgument(0);
+            return null;
+        }).when(client).setEnabled(anyBoolean());
+        when(client.getSecret()).thenReturn("existing-secret");
+        return client;
+    }
+
+    private ClientModel existingCredential() {
+        final var attributes = new HashMap<String, String>();
+        attributes.put("raid.credential.managed", "true");
+        attributes.put("raid.credential.group-id", GROUP_A);
+        attributes.put("raid.credential.label", "ci");
+        attributes.put("raid.credential.created-at", "2026-08-01T00:00:00Z");
+        final var client = backedClient("raid-cred-a1", attributes);
+        when(clientProvider.getClientByClientId(realm, "raid-cred-a1")).thenReturn(client);
+        return client;
+    }
+
+    private ClientModel stubNewClient() {
+        final var created = backedClient("raid-cred-fixed-id", new HashMap<>());
+        when(clientProvider.addClient(eq(realm), anyString())).thenReturn(created);
+        when(userProvider.getServiceAccount(created)).thenReturn(serviceAccount);
+        when(realm.addRole(anyString())).thenReturn(mock(RoleModel.class));
+        return created;
+    }
+
+    private ClientCredentialController controller() {
+        try (MockedConstruction<AppAuthManager.BearerTokenAuthenticator> ignored =
+                     mockConstruction(AppAuthManager.BearerTokenAuthenticator.class,
+                             (mock, ctx) -> when(mock.authenticate()).thenReturn(authResult))) {
+            when(authResult.session()).thenReturn(userSession);
+            when(userSession.getUser()).thenReturn(user);
+            return new ClientCredentialController(session, fixedClock, auditLogger);
+        }
+    }
+
+    private CreateCredentialRequest createRequest() {
+        final var request = new CreateCredentialRequest();
+        request.setGroupId(GROUP_A);
+        request.setLabel("ci");
+        return request;
+    }
+
+    private RotateCredentialRequest rotateRequest() {
+        final var request = new RotateCredentialRequest();
+        request.setClientId("raid-cred-a1");
+        return request;
+    }
+
+    @Nested
+    class CacheControl {
+
+        @Test
+        void createSetsNoStore() {
+            stubNewClient();
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                final var response = controller().create(createRequest());
+                assertThat(response.getHeaderString(HttpHeaders.CACHE_CONTROL), is("no-store"));
+            }
+        }
+
+        @Test
+        void rotateSetsNoStore() {
+            existingCredential();
+            assertThat(controller().rotate(rotateRequest()).getHeaderString(HttpHeaders.CACHE_CONTROL),
+                    is("no-store"));
+        }
+
+        @Test
+        void getSecretSetsNoStore() {
+            existingCredential();
+            assertThat(controller().getSecret("raid-cred-a1").getHeaderString(HttpHeaders.CACHE_CONTROL),
+                    is("no-store"));
+        }
+
+        @Test
+        void everyResponseCarryingASecretSetsNoStore() {
+            // The three secret-bearing endpoints, asserted together so a new one cannot be added
+            // without noticing this list.
+            existingCredential();
+            stubNewClient();
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                assertThat(controller().create(createRequest()).getHeaderString(HttpHeaders.CACHE_CONTROL),
+                        is("no-store"));
+            }
+            assertThat(controller().rotate(rotateRequest()).getHeaderString(HttpHeaders.CACHE_CONTROL),
+                    is("no-store"));
+            assertThat(controller().getSecret("raid-cred-a1").getHeaderString(HttpHeaders.CACHE_CONTROL),
+                    is("no-store"));
+        }
+    }
+
+    @Nested
+    class AuditTrail {
+
+        @Test
+        void createIsAudited() {
+            stubNewClient();
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                controller().create(createRequest());
+            }
+            verify(auditLogger).record(CredentialAuditLogger.ACTION_CREATE, user, "raid-cred-fixed-id", GROUP_A);
+        }
+
+        @Test
+        void listIsAudited() {
+            controller().list(GROUP_A);
+            verify(auditLogger).record(CredentialAuditLogger.ACTION_LIST, user, null, GROUP_A);
+        }
+
+        @Test
+        void rotateIsAudited() {
+            existingCredential();
+            controller().rotate(rotateRequest());
+            verify(auditLogger).record(CredentialAuditLogger.ACTION_ROTATE, user, "raid-cred-a1", GROUP_A);
+        }
+
+        @Test
+        void revokeIsAudited() {
+            existingCredential();
+            controller().revoke("raid-cred-a1");
+            verify(auditLogger).record(CredentialAuditLogger.ACTION_REVOKE, user, "raid-cred-a1", GROUP_A);
+        }
+
+        @Test
+        void secretRevealIsAudited() {
+            existingCredential();
+            controller().getSecret("raid-cred-a1");
+            verify(auditLogger)
+                    .record(CredentialAuditLogger.ACTION_REVEAL_SECRET, user, "raid-cred-a1", GROUP_A);
+        }
+
+        @Test
+        void deniedActionsAreNotAudited() {
+            // Documents current behaviour rather than endorsing it: only successful actions are
+            // recorded. Auditing denials would be a useful follow-up, but is outside RAID-847.
+            existingCredential();
+            final var otherGroupRole = mock(RoleModel.class);
+            when(otherGroupRole.getName()).thenReturn("service-point-admin:some-other-group");
+            when(user.getRoleMappingsStream()).thenAnswer(inv -> Stream.of(otherGroupRole));
+
+            final var controller = controller();
+            try {
+                controller.getSecret("raid-cred-a1");
+            } catch (RuntimeException expected) {
+                // denied
+            }
+            verifyNoInteractions(auditLogger);
+        }
+    }
+
+    @Nested
+    class SecretNeverLeaks {
+
+        @Test
+        void secretResponseToStringIsRedacted() {
+            final var body = new CredentialSecretResponse(
+                    "raid-cred-a1", "ci", "SUPER_SECRET", "2026-08-01T00:00:00Z", null);
+
+            assertThat(body.toString(), not(containsString("SUPER_SECRET")));
+            assertThat(body.toString(), containsString("REDACTED"));
+            // Non-sensitive fields stay visible so the value is still useful in a log.
+            assertThat(body.toString(), containsString("raid-cred-a1"));
+        }
+
+        @Test
+        void secretIsStillPresentInTheSerialisedBody() {
+            // Redaction must apply to toString only, never to the JSON the caller receives.
+            final var body = new CredentialSecretResponse(
+                    "raid-cred-a1", "ci", "SUPER_SECRET", "2026-08-01T00:00:00Z", null);
+
+            assertThat(body.secret(), is("SUPER_SECRET"));
+        }
+
+        // The Cors debug-logging leak guard lives in CorsDebugPayloadTest, since debugPayload is
+        // package-private to the cors package.
+    }
+}


### PR DESCRIPTION
Into `feature/RAID-827` (story integration branch).

## What

[RAID-847](https://ardc.atlassian.net/browse/RAID-847): `Cache-Control: no-store` on the three secret-returning endpoints, plus an audit trail for all five lifecycle actions. The `TODO:RAID-847` markers left in RAID-846 are now resolved and gone.

## A real leak, found while verifying the requirement

RAID-847 asks that secret values never appear in application logs. Checking that turned up an actual leak, and it wasn't credential-specific.

`Cors` logged `objectMapper.writeValueAsString(response)` at debug level. Jackson serialises `Response.getEntity()`, so **every response body from every SPI controller** was written into the application log. Confirmed with a throwaway probe before changing anything:

```
{"entity":"{\"clientId\":\"raid-cred-x\",\"secret\":\"SUPER_SECRET_VALUE\"}", ...}
CONTAINS SECRET: true
```

Now logs status and headers only. The payload construction is extracted into a package-private `debugPayload(...)` so the guarantee is directly assertable rather than resting on a comment, and `CorsDebugPayloadTest` asserts the entity never appears.

This is a pre-existing bug affecting all controllers, not something RAID-846 introduced. Whether it has ever been triggered depends on deployed log level, which is exactly why it shouldn't rely on one.

## Also hardened

**`CredentialSecretResponse.toString()` now redacts the secret.** A record's generated `toString` includes every component, so any accidental log statement or exception message mentioning the object would have exposed it. The serialised JSON the caller receives is unaffected, and there's a test for each half of that.

## Audit trail

New `CredentialAuditLogger`, writing at INFO under a dedicated `au.org.raid.iam.audit` logger name so deployments can route and retain the audit trail independently of ordinary application logging.

Records action, ISO 8601 UTC timestamp, actor id, actor username, clientId and owning service point. **It has no parameter capable of carrying a secret**, so the type signature itself prevents auditing one by mistake.

Wired into all five actions: create, list, rotate, revoke, reveal-secret.

## Verification

**20 new tests; 180 total, 0 failures, 0 skipped.**

**The leak guard was mutation-tested.** Restoring the old `Cors` behaviour fails `neverIncludesTheResponseEntity`, so the guard genuinely catches the original bug. Mutation reverted, and the tree is confirmed free of both mutations and `TODO:RAID-847` markers.

**Blast radius smoke-tested.** The `Cors` change touches every SPI controller, so I ran an isolated Keycloak 26.6.2 with the built jar. All four providers registered, and `OPTIONS /realms/raid/group/all` returned `allow=GET, PUT, OPTIONS` — an *existing* controller's preflight going through the modified `Cors` and producing correct headers. Container was on a spare port and removed afterwards; the shared local stack was untouched.

## Deliberately out of scope

- **Denied actions are not audited.** Only successful ones are, per the ticket. There's a test documenting this rather than leaving it ambiguous, since auditing denied cross-tenant secret reads would be genuinely useful and is worth a follow-up.
- **End-to-end proof that `no-store` reaches a real client** needs an authenticated call, which is [RAID-848](https://ardc.atlassian.net/browse/RAID-848). Header presence is asserted at unit level here.
- **Whether the audit entry actually lands in a deployed log** depends on log configuration for the `au.org.raid.iam.audit` logger, which is not set anywhere yet. Worth confirming before relying on the trail in test/stage/prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)