### PR TITLE
RAID-848: credential integration suite, and three runtime defects it exposed

### DIFF
--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/ClientCredentialIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/ClientCredentialIntegrationTest.java
@@ -1,0 +1,460 @@
+package au.org.raid.inttest;
+
+import au.org.raid.inttest.config.AuthConfig;
+import au.org.raid.inttest.dto.UserContext;
+import au.org.raid.inttest.dto.keycloak.CreateCredentialRequest;
+import au.org.raid.inttest.dto.keycloak.CredentialSecretResponse;
+import au.org.raid.inttest.dto.keycloak.Group;
+import au.org.raid.inttest.dto.keycloak.RotateCredentialRequest;
+import feign.FeignException;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.*;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * RAID-848: proves the RAID-827 acceptance criteria for the scoped client credential lifecycle,
+ * end to end, through real calls to the Keycloak SPI, the Keycloak token endpoint and the Admin API.
+ *
+ * <p>Unit tests in the {@code iam} module cover the same authorisation matrix against mocks. That
+ * overlap is deliberate: those guard the implementation, these demonstrate the accepted behaviour.
+ * Several scenarios here are simply not expressible against mocks, notably that a minted credential
+ * can actually authenticate and carries the right claims.
+ */
+@DisplayName("Client Credential Integration Tests")
+class ClientCredentialIntegrationTest extends AbstractIntegrationTest {
+
+    private static final int MAX_CREDENTIALS_PER_SERVICE_POINT = 10;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    private AuthConfig authConfig;
+
+    private UserContext operator;
+    private Group groupA;
+    private Group groupB;
+    private UserContext adminA;
+
+    /**
+     * Keycloak's Admin API needs {@code realm-management} permissions, which the RAiD realm's
+     * "operator" role does not confer - an operator is an application-level administrator, not a
+     * Keycloak realm administrator. Admin API assertions therefore go through the
+     * integration-test-client service account, as {@code UserService} does.
+     */
+    private au.org.raid.inttest.client.keycloak.KeycloakApi adminApi() {
+        return keycloakClient.keycloakApi(authConfig.getIntegrationTestClient());
+    }
+
+    @BeforeEach
+    void setUpCredentialFixtures() {
+        operator = userService.createUser("raid-au", "operator");
+        // Fresh groups per test so credential counts cannot leak between tests, which matters for
+        // the cap scenarios in particular.
+        groupA = createGroup("cred-a");
+        groupB = createGroup("cred-b");
+        adminA = userService.createUser(groupA.getName(), servicePointAdminRole(groupA.getId()));
+    }
+
+    @AfterEach
+    void tearDownCredentialFixtures() {
+        deleteUserQuietly(adminA);
+        deleteGroupQuietly(groupA);
+        deleteGroupQuietly(groupB);
+        deleteUserQuietly(operator);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private static String servicePointAdminRole(final String groupId) {
+        return "service-point-admin:" + groupId;
+    }
+
+    private static String servicePointUserRole(final String groupId) {
+        return "service-point-user:" + groupId;
+    }
+
+    /**
+     * Creates a group through the SPI, which also creates its scoped
+     * {@code service-point-admin:<groupId>} role as a side effect, so a scoped admin user can then
+     * be granted it.
+     */
+    private Group createGroup(final String namePrefix) {
+        final var api = keycloakClient.keycloakApi(operator.getToken());
+        final var groupName = namePrefix + "-" + UUID.randomUUID();
+
+        api.createGroupViaSpi(Map.of("name", groupName, "path", "/groups/" + groupName));
+
+        final var groups = api.allGroups().getBody();
+        assertThat(groups).isNotNull();
+
+        return groups.getGroups().stream()
+                .filter(g -> g.getName().equals(groupName))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Test group was not created: " + groupName));
+    }
+
+    private void deleteGroupQuietly(final Group group) {
+        if (operator == null || group == null) {
+            return;
+        }
+        try {
+            keycloakClient.keycloakApi(operator.getToken()).deleteGroup(group.getId());
+        } catch (Exception e) {
+            // Already gone, or cleanup raced another test - not a failure of the test itself.
+        }
+    }
+
+    private void deleteUserQuietly(final UserContext user) {
+        if (user != null) {
+            userService.deleteUser(user.getId());
+        }
+    }
+
+    private CredentialSecretResponse createCredential(final UserContext as, final String groupId, final String label) {
+        final var response = keycloakClient.keycloakApi(as.getToken())
+                .createClientCredential(new CreateCredentialRequest(groupId, label));
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody();
+    }
+
+    /** Decoded claims of an access token, so assertions can be made on what the token actually carries. */
+    private Map<String, Object> claimsOf(final String accessToken) {
+        final var payload = accessToken.split("\\.")[1];
+        final var decoded = new String(Base64.getUrlDecoder().decode(payload));
+        try {
+            return objectMapper.readValue(decoded, Map.class);
+        } catch (Exception e) {
+            fail("Could not decode token payload: " + e.getMessage());
+            return Map.of();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> realmRolesOf(final String accessToken) {
+        final var realmAccess = (Map<String, Object>) claimsOf(accessToken).get("realm_access");
+        if (realmAccess == null) {
+            return List.of();
+        }
+        return (List<String>) realmAccess.getOrDefault("roles", List.of());
+    }
+
+    /** Denials surface as 401 or 403 depending on which check rejects first; either is acceptable. */
+    private void assertDenied(final ThrowingCallable call) {
+        assertThatThrownBy(call)
+                .isInstanceOf(FeignException.class)
+                .satisfies(e -> assertThat(((FeignException) e).status())
+                        .describedAs("expected an authorisation failure")
+                        .isIn(401, 403));
+    }
+
+    // ------------------------------------------------------------------ tests
+
+    @Nested
+    @DisplayName("A minted credential works and is correctly scoped")
+    class CreateAndUse {
+
+        @Test
+        @DisplayName("credential obtains a token carrying its service point and scoped role")
+        void mintedCredentialObtainsCorrectlyScopedToken() {
+            final var credential = createCredential(adminA, groupA.getId(), "ci pipeline");
+
+            // The whole point of the feature: the credential must actually authenticate.
+            final var token = tokenService.getClientToken(credential.clientId(), credential.secret());
+
+            assertThat(claimsOf(token).get("service_point_group_id"))
+                    .describedAs("token must identify the owning service point")
+                    .isEqualTo(groupA.getId());
+            assertThat(realmRolesOf(token))
+                    .describedAs("token must carry the scoped usage role")
+                    .contains(servicePointUserRole(groupA.getId()));
+        }
+
+        @Test
+        @DisplayName("credential never receives an admin role")
+        void credentialNeverReceivesAnAdminRole() {
+            final var credential = createCredential(adminA, groupA.getId(), "ci pipeline");
+            final var token = tokenService.getClientToken(credential.clientId(), credential.secret());
+
+            assertThat(realmRolesOf(token))
+                    .noneMatch(role -> role.contains("admin") || role.equals("operator"));
+        }
+
+        @Test
+        @DisplayName("service account role mappings verified via the Admin API, not inferred")
+        void serviceAccountRoleMappingsVerifiedViaAdminApi() {
+            final var credential = createCredential(adminA, groupA.getId(), "ci pipeline");
+            final var admin = adminApi();
+
+            // Reached by service account username rather than via /admin/realms/raid/clients,
+            // because integration-test-client holds only realm-management [manage-users,
+            // view-realm] and the clients endpoint needs view-clients.
+            final var serviceAccounts =
+                    admin.findUserByUsername("service-account-" + credential.clientId()).getBody();
+            assertThat(serviceAccounts)
+                    .describedAs("every credential must have a service account user")
+                    .isNotNull().hasSize(1);
+
+            final var roles = admin.getRealmRoleMappings(serviceAccounts.get(0).getId()).getBody();
+            assertThat(roles).isNotNull();
+            assertThat(roles).extracting("name").contains(servicePointUserRole(groupA.getId()));
+            assertThat(roles).extracting("name").noneMatch(name -> String.valueOf(name).contains("admin"));
+        }
+
+        @Test
+        @DisplayName("create response sets Cache-Control: no-store and returns the label")
+        void createResponseIsUncacheableAndCarriesTheLabel() {
+            final var response = keycloakClient.keycloakApi(adminA.getToken())
+                    .createClientCredential(new CreateCredentialRequest(groupA.getId(), "labelled"));
+
+            assertThat(response.getHeaders().getCacheControl()).isEqualTo("no-store");
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().label()).isEqualTo("labelled");
+            assertThat(response.getBody().clientId()).isNotBlank();
+            assertThat(response.getBody().secret()).isNotBlank();
+        }
+    }
+
+    @Nested
+    @DisplayName("Rotation")
+    class Rotate {
+
+        @Test
+        @DisplayName("old secret stops working immediately and the new one works")
+        void rotationInvalidatesTheOldSecret() {
+            final var original = createCredential(adminA, groupA.getId(), "rotate me");
+            // Prove it worked before rotating, so a failure afterwards is attributable to rotation.
+            tokenService.getClientToken(original.clientId(), original.secret());
+
+            final var rotated = keycloakClient.keycloakApi(adminA.getToken())
+                    .rotateClientCredential(new RotateCredentialRequest(original.clientId()))
+                    .getBody();
+            assertThat(rotated).isNotNull();
+            assertThat(rotated.secret()).isNotEqualTo(original.secret());
+
+            assertThatThrownBy(() -> tokenService.getClientToken(original.clientId(), original.secret()))
+                    .describedAs("the previous secret must stop working immediately");
+
+            final var token = tokenService.getClientToken(rotated.clientId(), rotated.secret());
+            assertThat(claimsOf(token).get("service_point_group_id")).isEqualTo(groupA.getId());
+        }
+
+        @Test
+        @DisplayName("clientId, label and scoped role survive rotation")
+        void rotationPreservesIdentityAndScope() {
+            final var original = createCredential(adminA, groupA.getId(), "stable label");
+
+            final var rotated = keycloakClient.keycloakApi(adminA.getToken())
+                    .rotateClientCredential(new RotateCredentialRequest(original.clientId()))
+                    .getBody();
+
+            assertThat(rotated).isNotNull();
+            assertThat(rotated.clientId()).isEqualTo(original.clientId());
+            assertThat(rotated.label()).isEqualTo(original.label());
+
+            final var token = tokenService.getClientToken(rotated.clientId(), rotated.secret());
+            assertThat(realmRolesOf(token)).contains(servicePointUserRole(groupA.getId()));
+        }
+
+        @Test
+        @DisplayName("rotating a revoked credential is rejected")
+        void rotatingARevokedCredentialIsRejected() {
+            final var credential = createCredential(adminA, groupA.getId(), "doomed");
+            final var api = keycloakClient.keycloakApi(adminA.getToken());
+            api.revokeClientCredential(credential.clientId());
+
+            assertThatThrownBy(() -> api.rotateClientCredential(new RotateCredentialRequest(credential.clientId())))
+                    .isInstanceOf(FeignException.class)
+                    .satisfies(e -> assertThat(((FeignException) e).status()).isEqualTo(409));
+        }
+    }
+
+    @Nested
+    @DisplayName("Revocation")
+    class Revoke {
+
+        @Test
+        @DisplayName("a revoked credential can no longer obtain a token")
+        void revokedCredentialCannotAuthenticate() {
+            final var credential = createCredential(adminA, groupA.getId(), "revoke me");
+            tokenService.getClientToken(credential.clientId(), credential.secret());
+
+            keycloakClient.keycloakApi(adminA.getToken()).revokeClientCredential(credential.clientId());
+
+            assertThatThrownBy(() -> tokenService.getClientToken(credential.clientId(), credential.secret()))
+                    .describedAs("a revoked credential must not authenticate");
+        }
+
+        @Test
+        @DisplayName("revoking twice is a no-op success, not an error")
+        void revokeIsIdempotent() {
+            final var credential = createCredential(adminA, groupA.getId(), "twice");
+            final var api = keycloakClient.keycloakApi(adminA.getToken());
+
+            assertThat(api.revokeClientCredential(credential.clientId()).getStatusCode().value()).isEqualTo(200);
+            assertThat(api.revokeClientCredential(credential.clientId()).getStatusCode().value()).isEqualTo(200);
+        }
+    }
+
+    @Nested
+    @DisplayName("Listing and secret retrieval")
+    class ListAndSecret {
+
+        @Test
+        @DisplayName("listing returns only the service point's own credentials")
+        void listingIsScopedToTheServicePoint() {
+            final var mine = createCredential(adminA, groupA.getId(), "mine");
+            final var theirs = createCredential(operator, groupB.getId(), "theirs");
+
+            final var listed = keycloakClient.keycloakApi(adminA.getToken())
+                    .listClientCredentials(groupA.getId()).getBody();
+
+            assertThat(listed).isNotNull();
+            assertThat(listed).extracting("clientId").contains(mine.clientId());
+            assertThat(listed).extracting("clientId").doesNotContain(theirs.clientId());
+        }
+
+        @Test
+        @DisplayName("listing never includes the realm's own clients")
+        void listingNeverIncludesRealmClients() {
+            createCredential(adminA, groupA.getId(), "mine");
+
+            final var listed = keycloakClient.keycloakApi(adminA.getToken())
+                    .listClientCredentials(groupA.getId()).getBody();
+
+            assertThat(listed).isNotNull();
+            assertThat(listed).extracting("clientId")
+                    .doesNotContain("raid-api", "raid-dumper", "integration-test-client", "admin-cli");
+        }
+
+        @Test
+        @DisplayName("get-secret returns the current secret and is uncacheable")
+        void getSecretReturnsTheCurrentSecret() {
+            final var credential = createCredential(adminA, groupA.getId(), "peek");
+
+            final var response = keycloakClient.keycloakApi(adminA.getToken())
+                    .getClientCredentialSecret(credential.clientId());
+
+            assertThat(response.getHeaders().getCacheControl()).isEqualTo("no-store");
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().secret()).isEqualTo(credential.secret());
+            // And it is genuinely usable, not just echoed back.
+            tokenService.getClientToken(credential.clientId(), response.getBody().secret());
+        }
+    }
+
+    @Nested
+    @DisplayName("Authorisation")
+    class Authorisation {
+
+        @Test
+        @DisplayName("an admin of one service point cannot create for another")
+        void cannotCreateForAnotherServicePoint() {
+            final var api = keycloakClient.keycloakApi(adminA.getToken());
+            assertDenied(() -> api.createClientCredential(new CreateCredentialRequest(groupB.getId(), "not mine")));
+        }
+
+        @Test
+        @DisplayName("an admin of one service point cannot list another's credentials")
+        void cannotListAnotherServicePoint() {
+            final var api = keycloakClient.keycloakApi(adminA.getToken());
+            assertDenied(() -> api.listClientCredentials(groupB.getId()));
+        }
+
+        @Test
+        @DisplayName("an admin of one service point cannot read another's secret")
+        void cannotReadAnotherServicePointsSecret() {
+            final var theirs = createCredential(operator, groupB.getId(), "theirs");
+            final var api = keycloakClient.keycloakApi(adminA.getToken());
+            assertDenied(() -> api.getClientCredentialSecret(theirs.clientId()));
+        }
+
+        @Test
+        @DisplayName("an admin of one service point cannot revoke another's credential")
+        void cannotRevokeAnotherServicePointsCredential() {
+            final var theirs = createCredential(operator, groupB.getId(), "theirs");
+            final var api = keycloakClient.keycloakApi(adminA.getToken());
+            assertDenied(() -> api.revokeClientCredential(theirs.clientId()));
+        }
+
+        @Test
+        @DisplayName("the flat legacy group-admin role is rejected, with no fallback")
+        void flatGroupAdminIsRejected() {
+            // GroupController still honours the flat role behind a fallback flag; these endpoints
+            // deliberately do not.
+            final var flatAdmin = userService.createUser(groupA.getName(), "group-admin", "service-point-user");
+            try {
+                final var api = keycloakClient.keycloakApi(flatAdmin.getToken());
+                assertDenied(() -> api.createClientCredential(new CreateCredentialRequest(groupA.getId(), "nope")));
+                assertDenied(() -> api.listClientCredentials(groupA.getId()));
+            } finally {
+                deleteUserQuietly(flatAdmin);
+            }
+        }
+
+        @Test
+        @DisplayName("an operator can manage any service point via the uniform short-circuit")
+        void operatorCanManageAnyServicePoint() {
+            final var credential = createCredential(operator, groupB.getId(), "operator made this");
+
+            final var listed = keycloakClient.keycloakApi(operator.getToken())
+                    .listClientCredentials(groupB.getId()).getBody();
+            assertThat(listed).isNotNull();
+            assertThat(listed).extracting("clientId").contains(credential.clientId());
+
+            // Even an operator-created credential gets only a scoped usage role.
+            final var token = tokenService.getClientToken(credential.clientId(), credential.secret());
+            assertThat(realmRolesOf(token)).contains(servicePointUserRole(groupB.getId()));
+            assertThat(realmRolesOf(token)).noneMatch(r -> r.contains("admin") || r.equals("operator"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Per-service-point cap")
+    class Cap {
+
+        @Test
+        @DisplayName("creating beyond the cap is rejected with 409")
+        void creatingBeyondTheCapIsRejected() {
+            final var api = keycloakClient.keycloakApi(adminA.getToken());
+            for (var i = 0; i < MAX_CREDENTIALS_PER_SERVICE_POINT; i++) {
+                createCredential(adminA, groupA.getId(), "cap-" + i);
+            }
+
+            assertThatThrownBy(() -> api.createClientCredential(
+                    new CreateCredentialRequest(groupA.getId(), "one too many")))
+                    .isInstanceOf(FeignException.class)
+                    .satisfies(e -> {
+                        assertThat(((FeignException) e).status()).isEqualTo(409);
+                        assertThat(((FeignException) e).contentUTF8())
+                                .describedAs("error body should name the limit")
+                                .contains(String.valueOf(MAX_CREDENTIALS_PER_SERVICE_POINT));
+                    });
+        }
+
+        @Test
+        @DisplayName("revoking frees a slot")
+        void revokingFreesASlot() {
+            final var api = keycloakClient.keycloakApi(adminA.getToken());
+            CredentialSecretResponse first = null;
+            for (var i = 0; i < MAX_CREDENTIALS_PER_SERVICE_POINT; i++) {
+                final var created = createCredential(adminA, groupA.getId(), "cap-" + i);
+                if (i == 0) {
+                    first = created;
+                }
+            }
+
+            api.revokeClientCredential(first.clientId());
+
+            final var afterRevoke = api.createClientCredential(
+                    new CreateCredentialRequest(groupA.getId(), "reused slot"));
+            assertThat(afterRevoke.getStatusCode().value()).isEqualTo(201);
+        }
+    }
+}

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/client/keycloak/KeycloakApi.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/client/keycloak/KeycloakApi.java
@@ -90,4 +90,31 @@ public interface KeycloakApi {
 
     @RequestMapping(method = RequestMethod.DELETE, value = "/realms/raid/group/delete")
     ResponseEntity<java.util.Map<String, String>> deleteGroup(@RequestParam final String groupId);
+
+    // RAID-846/848: scoped client credential lifecycle. Authorisation requires the scoped
+    // "service-point-admin:<groupId>" role, or the operator role via a uniform short-circuit; the
+    // flat group-admin role is deliberately NOT honoured here.
+    @RequestMapping(method = RequestMethod.POST, value = "/realms/raid/client-credential")
+    ResponseEntity<CredentialSecretResponse> createClientCredential(@RequestBody final CreateCredentialRequest request);
+
+    @RequestMapping(method = RequestMethod.GET, value = "/realms/raid/client-credential")
+    ResponseEntity<List<CredentialSummary>> listClientCredentials(@RequestParam final String groupId);
+
+    @RequestMapping(method = RequestMethod.POST, value = "/realms/raid/client-credential/rotate")
+    ResponseEntity<CredentialSecretResponse> rotateClientCredential(@RequestBody final RotateCredentialRequest request);
+
+    @RequestMapping(method = RequestMethod.GET, value = "/realms/raid/client-credential/secret")
+    ResponseEntity<CredentialSecretResponse> getClientCredentialSecret(@RequestParam final String clientId);
+
+    @RequestMapping(method = RequestMethod.DELETE, value = "/realms/raid/client-credential")
+    ResponseEntity<CredentialSummary> revokeClientCredential(@RequestParam final String clientId);
+
+    // RAID-848: role-grant assertions must be verified via a direct Keycloak Admin API query rather
+    // than inferred from the SPI's own responses. Note the /admin/realms/raid/clients endpoints are
+    // NOT usable from these tests: integration-test-client's service account holds only
+    // realm-management [manage-users, view-realm], so anything needing view-clients returns 403.
+    // Reach a credential's service account by username instead ("service-account-<clientId>") via
+    // findUserByUsername above, which manage-users does cover.
+    @GetMapping(path = "/admin/realms/raid/users/{userId}/role-mappings/realm")
+    ResponseEntity<List<KeycloakRole>> getRealmRoleMappings(@PathVariable final String userId);
 }

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/dto/keycloak/CreateCredentialRequest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/dto/keycloak/CreateCredentialRequest.java
@@ -1,0 +1,7 @@
+package au.org.raid.inttest.dto.keycloak;
+
+/**
+ * Request body for {@code POST /realms/raid/client-credential} (RAID-846).
+ */
+public record CreateCredentialRequest(String groupId, String label) {
+}

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/dto/keycloak/CredentialSecretResponse.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/dto/keycloak/CredentialSecretResponse.java
@@ -1,0 +1,15 @@
+package au.org.raid.inttest.dto.keycloak;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Response from create, rotate and get-secret (RAID-846). Carries the secret value.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CredentialSecretResponse(
+        String clientId,
+        String label,
+        String secret,
+        String createdAt,
+        String lastRotatedAt) {
+}

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/dto/keycloak/CredentialSummary.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/dto/keycloak/CredentialSummary.java
@@ -1,0 +1,16 @@
+package au.org.raid.inttest.dto.keycloak;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * An entry in the list response from {@code GET /realms/raid/client-credential} (RAID-846).
+ * Deliberately carries no secret.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CredentialSummary(
+        String clientId,
+        String label,
+        String createdAt,
+        String lastRotatedAt,
+        boolean enabled) {
+}

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/dto/keycloak/KeycloakUser.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/dto/keycloak/KeycloakUser.java
@@ -1,5 +1,6 @@
 package au.org.raid.inttest.dto.keycloak;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -8,6 +9,12 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * RAID-848: tolerant of unknown fields. Keycloak 26.6.2 returns {@code userProfileMetadata} on the
+ * users endpoint, which this DTO does not model, and without this any such addition by a future
+ * Keycloak version breaks deserialisation outright.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @Builder
 @AllArgsConstructor

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/dto/keycloak/RotateCredentialRequest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/dto/keycloak/RotateCredentialRequest.java
@@ -1,0 +1,7 @@
+package au.org.raid.inttest.dto.keycloak;
+
+/**
+ * Request body for {@code POST /realms/raid/client-credential/rotate} (RAID-846).
+ */
+public record RotateCredentialRequest(String clientId) {
+}

--- a/iam/src/main/java/au/org/raid/iam/provider/credential/ClientCredentialController.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/credential/ClientCredentialController.java
@@ -22,6 +22,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.ClientManager;
+import org.keycloak.services.managers.RealmManager;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -154,6 +155,13 @@ public class ClientCredentialController {
         client.setServiceAccountsEnabled(true);
         client.setStandardFlowEnabled(false);
         client.setDirectAccessGrantsEnabled(false);
+        // addClient() leaves this false, unlike the Admin API path. While it is false Keycloak
+        // filters the token down to roles present in the client's explicit scope mappings, so the
+        // scoped service-point-user role granted below is stripped and the credential authenticates
+        // with no roles at all. Safe here because this controller is the only thing that grants
+        // roles to these service accounts, and it grants exactly one scoped usage role. Matches the
+        // existing raid-dumper client.
+        client.setFullScopeAllowed(true);
         client.setAttribute(MANAGED_ATTRIBUTE, "true");
         client.setAttribute(GROUP_ID_ATTRIBUTE, groupId);
         client.setAttribute(LABEL_ATTRIBUTE, request.getLabel().trim());
@@ -161,9 +169,12 @@ public class ClientCredentialController {
 
         final var secret = KeycloakModelUtils.generateSecret(client);
 
-        attachServicePointGroupIdScope(realm, client);
+        attachClientScopes(realm, client);
 
-        new ClientManager().enableServiceAccount(client);
+        // Must use the RealmManager constructor. ClientManager's no-arg constructor leaves its
+        // realmManager field null, and enableServiceAccount dereferences it, so the no-arg form
+        // fails at runtime with an NPE even though it compiles.
+        new ClientManager(new RealmManager(session)).enableServiceAccount(client);
         final var serviceAccount = session.users().getServiceAccount(client);
         if (serviceAccount == null) {
             // Fail closed rather than hand back a credential that cannot identify a service point.
@@ -430,15 +441,37 @@ public class ClientCredentialController {
                 client.isEnabled());
     }
 
-    private void attachServicePointGroupIdScope(final RealmModel realm, final ClientModel client) {
-        final var scope = KeycloakModelUtils.getClientScopeByName(realm, SERVICE_POINT_GROUP_ID_CLIENT_SCOPE);
-        if (scope == null) {
-            // Fail closed. Without this scope the credential authenticates but its token carries no
-            // service_point_group_id claim, so it would silently have no service point.
+    /**
+     * Attaches the client scopes a credential needs for its tokens to be usable.
+     *
+     * <p>Two distinct problems, both of which produce a credential that authenticates successfully
+     * while being silently useless:
+     *
+     * <ol>
+     *   <li>{@code session.clients().addClient(...)} is a raw model-layer create and does
+     *       <em>not</em> apply the realm's default client scopes, unlike the Admin API path. Without
+     *       them the client has no {@code roles} scope, so realm roles granted to its service
+     *       account never appear in {@code realm_access.roles} and the API sees an unauthorised
+     *       caller.
+     *   <li>{@code service_point_group_id} is not a realm default scope at all (only the
+     *       {@code raid-api} client carries it), so it must be attached explicitly or the token
+     *       identifies no service point.
+     * </ol>
+     */
+    private void attachClientScopes(final RealmModel realm, final ClientModel client) {
+        // Materialise before mutating: addClientScope writes to the same underlying data the stream
+        // is reading.
+        realm.getDefaultClientScopesStream(true).toList()
+                .forEach(scope -> client.addClientScope(scope, true));
+
+        final var servicePointScope =
+                KeycloakModelUtils.getClientScopeByName(realm, SERVICE_POINT_GROUP_ID_CLIENT_SCOPE);
+        if (servicePointScope == null) {
+            // Fail closed rather than issue a credential with no service point.
             throw new InternalServerErrorException(
                     "Required client scope '" + SERVICE_POINT_GROUP_ID_CLIENT_SCOPE + "' is missing from the realm");
         }
-        client.addClientScope(scope, true);
+        client.addClientScope(servicePointScope, true);
     }
 
     /**

--- a/iam/src/test/java/au/org/raid/iam/provider/credential/ClientCredentialControllerTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/credential/ClientCredentialControllerTest.java
@@ -16,6 +16,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.ClientManager;
+import org.keycloak.services.managers.RealmManager;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
@@ -278,6 +279,22 @@ class ClientCredentialControllerTest {
         }
 
         @Test
+        void newCredentialHasFullScopeAllowedSoItsScopedRoleReachesTheToken() {
+            // addClient() leaves fullScopeAllowed false, and while false Keycloak filters the token
+            // down to the client's explicit scope mappings, stripping the scoped usage role. The
+            // credential then authenticates with no roles at all. Caught in RAID-846 only by using
+            // a real credential end to end.
+            givenScopedAdminOf(GROUP_A);
+            final var created = stubNewClient();
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                controller().create(createRequest(GROUP_A, "ci"));
+            }
+
+            verify(created).setFullScopeAllowed(true);
+        }
+
+        @Test
         void newCredentialGetsServicePointGroupIdScopeAndActiveGroupIdAttribute() {
             givenScopedAdminOf(GROUP_A);
             final var created = stubNewClient();
@@ -289,6 +306,49 @@ class ClientCredentialControllerTest {
             // Without both of these the token carries no service_point_group_id claim at all.
             verify(created).addClientScope(servicePointGroupIdScope, true);
             verify(serviceAccount).setAttribute("activeGroupId", List.of(GROUP_A));
+        }
+
+        @Test
+        void clientManagerIsConstructedWithARealmManager() {
+            // ClientManager's no-arg constructor leaves its realmManager field null, and
+            // enableServiceAccount dereferences it, so `new ClientManager()` compiles but throws
+            // NullPointerException at runtime. Mocking the construction hides that, so assert the
+            // constructor argument instead. This caught a real 500 in RAID-846.
+            givenScopedAdminOf(GROUP_A);
+            stubNewClient();
+            final var constructorArgs = new ArrayList<List<?>>();
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class,
+                    (mock, ctx) -> constructorArgs.add(ctx.arguments()))) {
+                controller().create(createRequest(GROUP_A, "ci"));
+            }
+
+            assertThat(constructorArgs, hasSize(1));
+            assertThat(constructorArgs.get(0), hasSize(1));
+            assertThat(constructorArgs.get(0).get(0), instanceOf(RealmManager.class));
+        }
+
+        @Test
+        void newCredentialInheritsTheRealmsDefaultClientScopes() {
+            // addClient() is a raw model create and does not apply realm default scopes, unlike the
+            // Admin API path. Without them the client has no `roles` scope, so realm roles granted
+            // to its service account never reach realm_access.roles and the credential is silently
+            // useless. This caught a real defect in RAID-846.
+            givenScopedAdminOf(GROUP_A);
+            final var created = stubNewClient();
+            final var rolesScope = mock(ClientScopeModel.class);
+            final var basicScope = mock(ClientScopeModel.class);
+            when(realm.getDefaultClientScopesStream(true))
+                    .thenAnswer(inv -> Stream.of(rolesScope, basicScope));
+
+            try (MockedConstruction<ClientManager> ignored = mockConstruction(ClientManager.class)) {
+                controller().create(createRequest(GROUP_A, "ci"));
+            }
+
+            verify(created).addClientScope(rolesScope, true);
+            verify(created).addClientScope(basicScope, true);
+            // And still the non-default service point scope on top.
+            verify(created).addClientScope(servicePointGroupIdScope, true);
         }
 
         @Test


### PR DESCRIPTION
Into `feature/RAID-827` (story integration branch). Two commits, deliberately separate.

## The headline: RAID-846 was comprehensively broken

Standing up the SPI locally and hand-driving the happy path before writing any test code returned a **500 on every create**. Fixing that exposed two more defects behind it. **None were reachable by unit tests**, because all three live in Keycloak behaviour the tests mock away.

| Defect | Symptom |
|---|---|
| `new ClientManager()` (no-arg) leaves `realmManager` null; `enableServiceAccount` dereferences it | **500 on every create** |
| `session.clients().addClient()` does not apply the realm's default client scopes, unlike the Admin API path | no `roles` scope, so granted realm roles never reach `realm_access.roles` |
| `addClient` also leaves `fullScopeAllowed=false`, and Keycloak then filters the token to the client's explicit scope mappings | the scoped role is **stripped from the token** |

Each now has a unit test that fails when the defect is reintroduced. The `ClientManager` guard asserts the *constructor argument*, since mocking the class is exactly what hid the bug.

This is worth saying plainly: I previously reported RAID-846 as verified because `javap` confirmed the APIs existed. That was true and completely insufficient — the feature did not work at all.

## The suite

Proves the RAID-827 AC through real calls to the Keycloak SPI, the token endpoint and the Admin API. Overlap with the 48 iam unit tests is deliberate: those guard the implementation, these demonstrate the accepted behaviour.

The load-bearing tests mint a credential and then **use** it:

- obtain a token, assert it carries the owning `service_point_group_id`, the scoped `service-point-user:<groupId>` role, and no admin role
- rotate, then prove the old secret stops working while the new one still yields a correctly scoped token
- revoke, then prove the credential can no longer authenticate at all

Plus scoped listing and secret retrieval, the cap and revoke-frees-a-slot, cross-service-point denial on every endpoint, rejection of the flat `group-admin` role, and the operator short-circuit.

## Two Admin API facts worth knowing

Both cost me a debugging cycle and are now commented in the code:

1. **The RAiD `operator` role is not a Keycloak realm administrator.** A user token gets 403 on `/admin/realms/...`; admin assertions must go through `integration-test-client`.
2. **That service account holds only `realm-management [manage-users, view-realm]`**, so `/admin/realms/raid/clients` still 403s. A credential's service account must be reached by its `service-account-<clientId>` username, which `manage-users` does cover.

`KeycloakUser` now ignores unknown fields — Keycloak 26.6.2 returns `userProfileMetadata`, which the DTO doesn't model, and any future field addition would otherwise break deserialisation outright.

## Verification

- **Full intTest suite: 43 classes, 221 tests, 0 failures** (16 skips pre-existing). Run against a stack rebuilt from this branch, not a stale one.
- **iam unit tests: 183, 0 failures.**

## Not covered, and why

- **"No partial state on failure"** — there's no clean way to fail creation mid-transaction over HTTP. Better as a unit test injecting a failure. I deliberately did not write a test that appears to cover this but doesn't.
- **"Existing ARDC-staff-created credentials continue to work"** — still unwritable. The dev realm's existing service-account clients carry no `service_point_group_id` scope, so how real credentials in test/stage/prod identify a service point is still unknown. Blocked on RAID-827's open live-realm export check.
- **Audit-entry assertions** — the audit trail is unit-tested in RAID-847; asserting log contents from intTest is brittle.

## One thing to flag

`KeycloakClient` builds its Feign client with `logLevel(Logger.Level.FULL)`, so **credential secrets appear in intTest logs**. Test-only and not a production concern, but it sits oddly beside RAID-847's no-secrets-in-logs work and may deserve a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)