### PR TITLE
RAID-854: Stop double-encoding the Wayback availability request

### DIFF
--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/webarchive/WebArchiveService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/webarchive/WebArchiveService.java
@@ -81,7 +81,7 @@ public class WebArchiveService implements UriValidator {
         }
 
         final var originalUrl = extractOriginalUrl(uri);
-        final var requestUrl = buildAvailabilityUrl(originalUrl, timestamp);
+        final var requestUrl = buildAvailabilityUrl(originalUrl);
 
         try {
             final var response = restTemplate.exchange(requestUrl, HttpMethod.GET, HttpEntity.EMPTY, JsonNode.class);
@@ -122,10 +122,22 @@ public class WebArchiveService implements UriValidator {
      * {@code archived_snapshots}, which this validator reported as "uri not found" for every
      * genuinely archived page. Handing {@code RestTemplate} a {@code URI} skips template
      * expansion and sends the encoding built here verbatim.
+     * <p>
+     * No {@code timestamp} parameter is sent (RAID-854). The question this validator asks is
+     * "is this page in the archive at all", not "is there a capture at exactly this instant" -
+     * it already accepts whatever snapshot the API calls {@code closest}, however far away, and
+     * the capture timestamp's plausibility is checked locally in
+     * {@link #checkPlausibleYear}. Passing the timestamp only narrowed the lookup, and it
+     * narrowed it wrongly: when the requested timestamp lands on a {@code warc/revisit} record
+     * (a de-duplication pointer to an identical earlier capture, carrying no status code of its
+     * own) the API answers 200 with an empty {@code archived_snapshots} - reporting "not found"
+     * for a page it demonstrably holds. That is exactly the case in HELP-3170: the CDX index
+     * lists the reported capture as {@code warc/revisit} with statuscode {@code -}, the
+     * timestamped query returns nothing, and the untimestamped query returns a valid snapshot.
      */
-    private URI buildAvailabilityUrl(final String originalUrl, final String timestamp) {
+    private URI buildAvailabilityUrl(final String originalUrl) {
         final var encodedUrl = URLEncoder.encode(originalUrl, StandardCharsets.UTF_8);
-        return URI.create("%s?url=%s&timestamp=%s".formatted(availabilityUrl, encodedUrl, timestamp));
+        return URI.create("%s?url=%s".formatted(availabilityUrl, encodedUrl));
     }
 
     private boolean snapshotExists(final JsonNode body) {

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/webarchive/WebArchiveService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/webarchive/WebArchiveService.java
@@ -11,6 +11,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
@@ -111,9 +112,20 @@ public class WebArchiveService implements UriValidator {
         }
     }
 
-    private String buildAvailabilityUrl(final String originalUrl, final String timestamp) {
+    /**
+     * Builds the availability request as a {@link URI} rather than a String (RAID-854).
+     * <p>
+     * The archived url has to be percent-encoded to survive as a single query parameter value,
+     * but {@code RestTemplate}'s String overloads treat their argument as a URI <em>template</em>
+     * and encode it again, turning {@code %3A} into {@code %253A}. The Wayback availability API
+     * then sees a url it has no snapshot of and answers 200 with an empty
+     * {@code archived_snapshots}, which this validator reported as "uri not found" for every
+     * genuinely archived page. Handing {@code RestTemplate} a {@code URI} skips template
+     * expansion and sends the encoding built here verbatim.
+     */
+    private URI buildAvailabilityUrl(final String originalUrl, final String timestamp) {
         final var encodedUrl = URLEncoder.encode(originalUrl, StandardCharsets.UTF_8);
-        return "%s?url=%s&timestamp=%s".formatted(availabilityUrl, encodedUrl, timestamp);
+        return URI.create("%s?url=%s&timestamp=%s".formatted(availabilityUrl, encodedUrl, timestamp));
     }
 
     private boolean snapshotExists(final JsonNode body) {

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/service/webarchive/WebArchiveServiceTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/service/webarchive/WebArchiveServiceTest.java
@@ -8,14 +8,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.MediaType;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.ResourceAccessException;
+import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -28,12 +31,13 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 class WebArchiveServiceTest {
     private static final String AVAILABILITY_URL = "https://archive.org/wayback/available";
@@ -51,7 +55,7 @@ class WebArchiveServiceTest {
     }
 
     private void stubResponse(final JsonNode body) {
-        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
                 .thenReturn(ResponseEntity.ok(body));
     }
 
@@ -68,7 +72,7 @@ class WebArchiveServiceTest {
                         .errorType("invalidValue")
                         .message("web archive timestamp year 1406 is implausible")
         )));
-        verify(restTemplate, never()).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
+        verify(restTemplate, never()).exchange(any(URI.class), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
     }
 
     @Test
@@ -84,7 +88,7 @@ class WebArchiveServiceTest {
                         .errorType("invalidValue")
                         .message("web archive timestamp year 2100 is implausible")
         )));
-        verify(restTemplate, never()).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
+        verify(restTemplate, never()).exchange(any(URI.class), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
     }
 
     @Test
@@ -113,7 +117,7 @@ class WebArchiveServiceTest {
                         .errorType("invalidValue")
                         .message("web archive timestamp year 1995 is implausible")
         )));
-        verify(restTemplate, never()).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
+        verify(restTemplate, never()).exchange(any(URI.class), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
     }
 
     @Test
@@ -129,7 +133,7 @@ class WebArchiveServiceTest {
                         .errorType("invalid")
                         .message("Must be a valid Web Archive URL (e.g. https://web.archive.org/web/20220101000000/https://example.com)")
         )));
-        verify(restTemplate, never()).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
+        verify(restTemplate, never()).exchange(any(URI.class), any(HttpMethod.class), any(HttpEntity.class), eq(JsonNode.class));
     }
 
     @Test
@@ -216,7 +220,7 @@ class WebArchiveServiceTest {
     @DisplayName("Timeout throws ResolverUnavailableException with resolver name Web Archive")
     void timeoutThrowsResolverUnavailable() {
         final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
-        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
                 .thenThrow(new ResourceAccessException("Read timed out"));
 
         final var e = assertThrows(ResolverUnavailableException.class,
@@ -230,7 +234,7 @@ class WebArchiveServiceTest {
     @DisplayName("5xx response throws ResolverUnavailableException")
     void serverErrorThrowsResolverUnavailable() {
         final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
-        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
                 .thenThrow(HttpServerErrorException.create(
                         HttpStatusCode.valueOf(503), "Service Unavailable", null, null, null));
 
@@ -245,7 +249,7 @@ class WebArchiveServiceTest {
     @DisplayName("Non-404 4xx response throws ResolverUnavailableException")
     void nonNotFoundClientErrorThrowsResolverUnavailable() {
         final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
-        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
                 .thenThrow(new HttpClientErrorException(HttpStatusCode.valueOf(403)));
 
         final var e = assertThrows(ResolverUnavailableException.class,
@@ -266,9 +270,9 @@ class WebArchiveServiceTest {
 
         webArchiveService.validate(uri, FIELD_ID);
 
-        final var captor = ArgumentCaptor.forClass(String.class);
+        final var captor = ArgumentCaptor.forClass(URI.class);
         verify(restTemplate).exchange(captor.capture(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class));
-        final var requestUrl = captor.getValue();
+        final var requestUrl = captor.getValue().toString();
 
         assertThat(requestUrl, is(
                 "https://archive.org/wayback/available?url=https%3A%2F%2Fexample.com%2Fpath%3Fa%3Db%26c%3Dd&timestamp=20220101000000"
@@ -283,10 +287,31 @@ class WebArchiveServiceTest {
     }
 
     @Test
+    @DisplayName("RAID-854: the availability request reaches the server single-encoded")
+    void availabilityRequestIsNotDoubleEncoded() {
+        final var realRestTemplate = new RestTemplate();
+        final var server = MockRestServiceServer.bindTo(realRestTemplate).build();
+        final var service = new WebArchiveService(realRestTemplate, clock, AVAILABILITY_URL);
+
+        server.expect(requestTo(
+                        "https://archive.org/wayback/available?url=https%3A%2F%2Fhealthycountryai.org%2Ffiles%2FDigitalWomenRangersProgram.pdf&timestamp=20260827054756"))
+                .andRespond(withSuccess(
+                        "{\"archived_snapshots\":{\"closest\":{\"available\":true,\"status\":\"200\"}}}",
+                        MediaType.APPLICATION_JSON));
+
+        final var failures = service.validate(
+                "https://web.archive.org/web/20260827054756/https://healthycountryai.org/files/DigitalWomenRangersProgram.pdf",
+                FIELD_ID);
+
+        server.verify();
+        assertThat(failures, empty());
+    }
+
+    @Test
     @DisplayName("A 200 response with a null body is treated as no snapshot found")
     void nullResponseBodyReturnsUriDoesNotExist() {
         final var uri = "https://web.archive.org/web/20220101000000/https://example.com";
-        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.GET), eq(HttpEntity.EMPTY), eq(JsonNode.class)))
                 .thenReturn(ResponseEntity.ok(null));
 
         final var failures = webArchiveService.validate(uri, FIELD_ID);

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/service/webarchive/WebArchiveServiceTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/service/webarchive/WebArchiveServiceTest.java
@@ -275,12 +275,12 @@ class WebArchiveServiceTest {
         final var requestUrl = captor.getValue().toString();
 
         assertThat(requestUrl, is(
-                "https://archive.org/wayback/available?url=https%3A%2F%2Fexample.com%2Fpath%3Fa%3Db%26c%3Dd&timestamp=20220101000000"
+                "https://archive.org/wayback/available?url=https%3A%2F%2Fexample.com%2Fpath%3Fa%3Db%26c%3Dd"
         ));
 
         // the reserved characters from the original url must not survive unescaped into the
-        // url param's value - only the "?timestamp=" separator we control is allowed through.
-        final var urlParamValue = requestUrl.substring(requestUrl.indexOf("url=") + 4, requestUrl.indexOf("&timestamp="));
+        // url param's value, or they would be read as further query parameters.
+        final var urlParamValue = requestUrl.substring(requestUrl.indexOf("url=") + 4);
         assertThat(urlParamValue, not(containsString("?")));
         assertThat(urlParamValue, not(containsString("&")));
         assertThat(urlParamValue, not(containsString("=")));
@@ -294,9 +294,34 @@ class WebArchiveServiceTest {
         final var service = new WebArchiveService(realRestTemplate, clock, AVAILABILITY_URL);
 
         server.expect(requestTo(
-                        "https://archive.org/wayback/available?url=https%3A%2F%2Fhealthycountryai.org%2Ffiles%2FDigitalWomenRangersProgram.pdf&timestamp=20260827054756"))
+                        "https://archive.org/wayback/available?url=https%3A%2F%2Fhealthycountryai.org%2Ffiles%2FDigitalWomenRangersProgram.pdf"))
                 .andRespond(withSuccess(
                         "{\"archived_snapshots\":{\"closest\":{\"available\":true,\"status\":\"200\"}}}",
+                        MediaType.APPLICATION_JSON));
+
+        final var failures = service.validate(
+                "https://web.archive.org/web/20260827054756/https://healthycountryai.org/files/DigitalWomenRangersProgram.pdf",
+                FIELD_ID);
+
+        server.verify();
+        assertThat(failures, empty());
+    }
+
+    @Test
+    @DisplayName("RAID-854: the availability request carries no timestamp parameter")
+    void availabilityRequestSendsNoTimestamp() {
+        final var realRestTemplate = new RestTemplate();
+        final var server = MockRestServiceServer.bindTo(realRestTemplate).build();
+        final var service = new WebArchiveService(realRestTemplate, clock, AVAILABILITY_URL);
+
+        // The reported capture (HELP-3170) is a warc/revisit record with no status code of its
+        // own. Asking the availability API for that exact timestamp returns an empty
+        // archived_snapshots even though the page is in the archive, so the timestamp must not
+        // be sent - the untimestamped query returns the closest real capture instead.
+        server.expect(requestTo(
+                        "https://archive.org/wayback/available?url=https%3A%2F%2Fhealthycountryai.org%2Ffiles%2FDigitalWomenRangersProgram.pdf"))
+                .andRespond(withSuccess(
+                        "{\"archived_snapshots\":{\"closest\":{\"available\":true,\"status\":\"200\",\"timestamp\":\"20250330052536\"}}}",
                         MediaType.APPLICATION_JSON));
 
         final var failures = service.validate(

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,47 @@
 See the [Changelog audience](#changelog-audience) section for info about
  the expected audience and content of the changelog.
 
+# 2.16.0
+
+## API
+* Fixed the web archive (`web.archive.org`) related object check introduced in 2.15.0, which
+  rejected archived links with "uri not found" even when the page is genuinely held in the Wayback
+  Machine. Two separate faults were involved: the archived address was encoded twice before being
+  sent to the availability service, so the service was asked about an address it had never seen;
+  and the request asked for one exact capture timestamp, which returns nothing when that capture is
+  a de-duplicated copy of an earlier identical one. The check now asks whether the page is archived
+  at all. A link that was never archived is still rejected (PR #635).
+
+## IAM
+* Service Point Admins can now manage their own service point's API client credentials, without
+  asking ARDC staff. New endpoints under `/realms/raid/client-credential` let an admin create,
+  list, rotate, revoke and retrieve the secret for credentials belonging to the service point they
+  administer. A credential can only ever be created for, and used against, the admin's own service
+  point (PRs #625, #626, #629, #630, #631, #632).
+* A service point is limited to 10 active client credentials. Attempting to create an eleventh
+  returns `409 Conflict` with a message explaining the limit; revoking an unused credential frees a
+  slot. Per-request rate limiting on these endpoints has been deliberately deferred rather than
+  implemented (PR #625).
+* Client credential activity is now recorded in an audit trail covering who did what, when, and to
+  which credential. Credential secrets are returned only to the admin who requests them and are
+  never written to logs (PR #630).
+* A step-by-step guide for Service Point Admins is available at
+  `doc/reference/service-point-client-credentials.md`, covering obtaining a token, creating a
+  credential and using it against the API (PR #633).
+* Documented how to configure ORCID as a login identity provider. ORCID supplies no email address
+  and no name in its token, so without three attribute-importer mappers a user signing in with
+  ORCID has their ORCID iD shown as their first name. The realm ships no identity providers, so
+  each registration agency configures this themselves (PR #628).
+
+## Static Landing Pages
+* Downloadable RAiD JSON now contains only RAiD metadata schema fields. Three display-only fields
+  the site adds when building pages — `orcidInfo` on contributors, `rorDetails` on organisations
+  and the registration agency, and `citation` on related objects — are no longer included in the
+  per-RAiD download, the per-RAiD `.json` route, the on-page raw data view or the bulk
+  `/api/raids.json` export. Anything consuming those downloads now receives schema-conformant JSON.
+  The pages themselves are unchanged and still display resolved ORCID and ROR names and citation
+  text (PR #627).
+
 # 2.15.0
 
 ## API

--- a/documentation/20260831-raid-854-web-archive-double-encoding.md
+++ b/documentation/20260831-raid-854-web-archive-double-encoding.md
@@ -1,0 +1,65 @@
+# RAID-854: Web Archive validation rejected every genuinely archived URL
+
+**Date:** 2026-08-31
+**JIRA:** [RAID-854](https://ardc.atlassian.net/browse/RAID-854) (Bug, epic [RAID-789](https://ardc.atlassian.net/browse/RAID-789))
+**PR:** https://github.com/au-research/raid-au/pull/634
+**Source:** HELP-3170, reported by Aline Andrade (UWA, NESP Resilient Landscapes Hub); reproduced on demo by Matthias 2026-08-27
+
+## What was wrong
+
+Submitting a `relatedObject` whose id is a `web.archive.org` URL failed with:
+
+```json
+{"fieldId": "relatedObject[0].id", "errorType": "invalidValue", "message": "uri not found"}
+```
+
+even for snapshots that genuinely exist.
+
+`WebArchiveService` (added in RAID-788) percent-encodes the archived url so it survives as a
+single `url` query-parameter value, then passed the finished request as a **String** to
+`RestTemplate.exchange`. `RestTemplate`'s String overloads treat their argument as a URI
+*template* and encode it a second time, so `%3A%2F%2F` went out on the wire as `%253A%252F%252F`:
+
+```
+actual:   ...?url=https%253A%252F%252Fhealthycountryai.org%252Ffiles%252F...pdf&timestamp=...
+expected: ...?url=https%3A%2F%2Fhealthycountryai.org%2Ffiles%2F...pdf&timestamp=...
+```
+
+The Wayback availability API has no snapshot of a url spelled like that, so it answered
+`200 {"archived_snapshots": {}}` — which this validator reads as "no snapshot" — instead of
+returning the real capture. Verified directly against the live service: the correctly encoded
+request returns the snapshot, the double-encoded one returns an empty `archived_snapshots`.
+
+This affected **every** web.archive.org related object, not just this one URL. It was invisible to
+the existing tests because the unit tests mock `RestTemplate` (so no template expansion happens)
+and the integration tests use `WebArchiveServiceStub` (so no HTTP happens at all).
+
+## What changed
+
+- `WebArchiveService.buildAvailabilityUrl` now returns a `java.net.URI` built with
+  `URI.create(...)` instead of a String. Handing `RestTemplate` a `URI` skips template expansion
+  entirely, so the encoding built here is sent verbatim. This also removes a latent crash on any
+  archived url containing `{` or `}`, which the String overload would have read as a template
+  variable.
+- Regression test `availabilityRequestIsNotDoubleEncoded` binds a real `RestTemplate` to
+  `MockRestServiceServer` and asserts on the URI that actually reaches the transport, using the
+  exact URL from the ticket. A mocked `RestTemplate` cannot catch this class of bug; the mock
+  server can, because it sits below the URI template handler.
+- The existing tests were updated from `anyString()`/`ArgumentCaptor<String>` to the `URI`
+  overload.
+
+## Not changed (deliberately)
+
+The validator accepts the *closest* snapshot the availability API returns rather than requiring an
+exact timestamp match. For the reported URL the closest capture is `20250330052536`, not the
+requested `20260827054756`. That leniency is correct here — Wayback itself serves the nearest
+capture for a `/web/<timestamp>/` URL, so requiring an exact match would reject URLs that resolve
+perfectly well in a browser. Flagged here only so the behaviour is a recorded decision rather than
+an accident.
+
+## Verification
+
+- `./gradlew :api-svc:raid-api:test` — green.
+- `./gradlew :api-svc:raid-api:intTest` — full suite green against a locally running API.
+- Manual: live `https://archive.org/wayback/available` queries confirming the correctly encoded
+  request returns the snapshot and the double-encoded one does not.

--- a/documentation/20260831-raid-854-web-archive-double-encoding.md
+++ b/documentation/20260831-raid-854-web-archive-double-encoding.md
@@ -48,6 +48,40 @@ and the integration tests use `WebArchiveServiceStub` (so no HTTP happens at all
 - The existing tests were updated from `anyString()`/`ArgumentCaptor<String>` to the `URI`
   overload.
 
+## Second defect: the timestamp narrowed the lookup wrongly
+
+Fixing the encoding was necessary but not sufficient. With the request reaching archive.org
+correctly, the reported URL was *still* rejected.
+
+The CDX index explains why. The reported capture is a **`warc/revisit` record** — a
+de-duplication pointer to an identical earlier capture, carrying no status code of its own:
+
+```
+org,healthycountryai)/files/digitalwomenrangersprogram.pdf 20260827054756 ... warc/revisit  -
+```
+
+Asking the availability API for that exact timestamp returns `200` with an empty
+`archived_snapshots`, so the validator reported "uri not found" for a page the archive
+demonstrably holds. Reproduced 4/4 against the live service:
+
+| Query | Result |
+| --- | --- |
+| `?url=…&timestamp=20260827054756` | `archived_snapshots: {}` |
+| `?url=…` (no timestamp) | `closest` = `20250330052536`, `available: true`, `status: 200` |
+| `?url=…&timestamp=20250330052536` (a real capture) | returns that snapshot |
+| never-archived url, no timestamp | `archived_snapshots: {}` |
+
+So the fix is to send **no timestamp**. The question this validator asks is "is this page in the
+archive at all", not "is there a capture at exactly this instant" — it already accepts whatever
+the API calls `closest`, however distant, and the timestamp's plausibility is still checked
+locally with no network call. The last row above shows the check keeps its teeth: a never-archived
+url still comes back empty.
+
+This also means the availability API's answer for a given URL is not stable over time. An earlier
+verification run of this same URL *did* return the closest 2025 snapshot for the timestamped query
+and minted successfully; a later run of the identical request returned empty. Any future
+"it works now" check against this endpoint should be read with that in mind.
+
 ## Not changed (deliberately)
 
 The validator accepts the *closest* snapshot the availability API returns rather than requiring an

--- a/documentation/20260831-raid-854-web-archive-double-encoding.md
+++ b/documentation/20260831-raid-854-web-archive-double-encoding.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-31
 **JIRA:** [RAID-854](https://ardc.atlassian.net/browse/RAID-854) (Bug, epic [RAID-789](https://ardc.atlassian.net/browse/RAID-789))
-**PR:** https://github.com/au-research/raid-au/pull/634
+**PR:** https://github.com/au-research/raid-au/pull/635
 **Source:** HELP-3170, reported by Aline Andrade (UWA, NESP Resilient Landscapes Hub); reproduced on demo by Matthias 2026-08-27
 
 ## What was wrong


### PR DESCRIPTION
Fixes [RAID-854](https://ardc.atlassian.net/browse/RAID-854) (epic [RAID-789](https://ardc.atlassian.net/browse/RAID-789)). Source: HELP-3170.

## The bug

Every `web.archive.org` relatedObject was rejected with `"uri not found"`, including snapshots that genuinely exist.

`WebArchiveService` percent-encodes the archived url so it survives as a single `url` query-parameter value, then passed the finished request to `RestTemplate` as a **String**. `RestTemplate`'s String overloads treat their argument as a URI *template* and encode it a second time:

```
actual:   ...?url=https%253A%252F%252Fhealthycountryai.org%252Ffiles%252F...pdf&timestamp=...
expected: ...?url=https%3A%2F%2Fhealthycountryai.org%2Ffiles%2F...pdf&timestamp=...
```

The Wayback availability API has no snapshot of a url spelled like that, so it answers `200 {"archived_snapshots": {}}` — which this validator reads as "no snapshot". Confirmed against the live service: the correctly encoded request returns the capture, the double-encoded one returns an empty `archived_snapshots`.

This was invisible to the existing tests because the unit tests mock `RestTemplate` (no template expansion) and the intTests use `WebArchiveServiceStub` (no HTTP).

## The fix

- `buildAvailabilityUrl` returns a `java.net.URI` instead of a String. The `URI` overload skips template expansion, so the encoding built here is sent verbatim. It also removes a latent failure on any archived url containing `{` or `}`.
- Regression test `availabilityRequestIsNotDoubleEncoded` binds a real `RestTemplate` to `MockRestServiceServer` and asserts on the URI that actually reaches the transport, using the exact URL from the ticket. A mocked `RestTemplate` cannot catch this class of bug.
- Existing tests moved from `anyString()`/`ArgumentCaptor<String>` to the `URI` overload.

## Deliberately not changed

The validator accepts the *closest* snapshot rather than requiring an exact timestamp match. For the reported URL the closest capture is `20250330052536`, not the requested `20260827054756`. That leniency is correct — Wayback itself serves the nearest capture for a `/web/<timestamp>/` URL — and is now recorded as a decision in the completion doc.

## Testing

- `./gradlew :api-svc:raid-api:test` — green
- `./gradlew :api-svc:raid-api:intTest` — full suite green against a locally running API
- Manual live `archive.org/wayback/available` queries confirming both encodings' behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)