### PR TITLE
RAID-856: Discover the group to break from the environment

### DIFF
--- a/documentation/20260831-raid-856-e2e-fixture-users.md
+++ b/documentation/20260831-raid-856-e2e-fixture-users.md
@@ -1,0 +1,77 @@
+# RAID-856: Branch pipeline E2e-Test stage restored
+
+**Date:** 2026-08-31
+**JIRA:** [RAID-856](https://ardc.atlassian.net/browse/RAID-856)
+**PRs:** raid-au [#636](https://github.com/au-research/raid-au/pull/636), raido-v2-aws-private [#44](https://github.com/au-research/raido-v2-aws-private/pull/44)
+
+## What was wrong
+
+The Branch-Build-Deploy `E2e-Test` stage had failed on **every** execution since `000d6af8`
+("Add e2e tests for RAID-659, RAID-480 and RAID-608") merged on 2026-08-24. Three separate gaps,
+all from the same root cause: the e2e suite gained environment-dependent fixtures and nothing
+outside local dev was given them.
+
+### 1. Missing credentials (2 hard failures)
+
+Both new Playwright auth-setup projects threw immediately:
+
+```
+Error: VITE_KEYCLOAK_E2E_OPERATOR_USER environment variable is not set.
+Error: VITE_KEYCLOAK_E2E_UNAPPROVED_ADMIN_USER environment variable is not set.
+```
+
+A failed setup project fails the stage *and* skips every spec depending on it — 2 failed,
+3 never ran, 28 passed.
+
+### 2. Missing fixture users
+
+The three users documented in `iam/doc/keycloak-configuration.md` existed only in the local dev
+realm. Verified missing from `iam.test.raid.org.au`: `raid-operator`,
+`raid-au-unapproved-admin`, `raid-au-pending-user`.
+
+### 3. A test that could only pass locally
+
+`service-point-group-id-error.spec.ts` targeted the `raido` service point assuming its `group_id`
+is `169bd3f3…` — a pairing set by `db/env/dev/V32.1__update_service_point_repository.sql`. Branch
+and test environments run `db/migration,db/env/test` and never apply it. There, `raido` has a null
+`groupId` and `169bd3f3…` belongs to the `RAiD AU (branch-…)` service point created at deploy time.
+
+## What changed
+
+- **Test realm** — provisioned the three fixture users with exactly the documented roles and
+  membership. `raid-au-unapproved-admin` is deliberately a raw, self-joined member of `raid-au`
+  with `group-admin` but **no** `service-point-user`; that unapproved state is the whole point of
+  the RAID-608 regression test. Verified: it gets a 401 from `PUT /group/grant`, and the operator
+  can list the group's members and see `raid-au-pending-user` among them.
+- **Secrets** — `raid_operator_password` and `raid_au_unapproved_admin_password`, defined in
+  `AdminSecrets` alongside the existing per-fixture-user secrets.
+- **Buildspec** — the four missing `VITE_KEYCLOAK_E2E_*` variables, plus read grants.
+- **The test** — now discovers which group to break from the running environment. A valid group
+  cell's tooltip is the group id itself, so it breaks the first resolvable row's lookup and uses
+  the second as the control, tracking rows by DataGrid `data-id` rather than display name.
+
+## Verification
+
+Run against the deployed branch environment with exactly the env the buildspec supplies:
+
+| Stage | Result |
+| --- | --- |
+| Before any fix | 2 failed, 3 did not run, 28 passed |
+| After the credentials fix | 1 failed, 33 passed |
+| After the test fix | **34 passed** |
+
+CDK: `npm run build` clean, 153 tests passing. Frontend unit tests: 147 passing.
+
+## Not resolved
+
+`cdk diff` / `deploy` of the Admin stacks fails with `Unable to resolve AWS account to use`. This
+reproduces on unmodified `main`, so it is pre-existing and independent — but the buildspec change
+cannot reach the pipeline until it is sorted out, which means the E2e stage stays red in CI even
+though the suite itself is now green.
+
+## Lesson
+
+This is the same shape as the resolver-stub CDK companion problem: a change lands in `raid-au`
+that needs a matching change in `raido-v2-aws-private`, and without it the deployed environments
+silently diverge from local dev. Worth a checklist item for changes adding environment-dependent
+test fixtures.

--- a/raid-agency-app/e2e/tests/operator/service-point-group-id-error.spec.ts
+++ b/raid-agency-app/e2e/tests/operator/service-point-group-id-error.spec.ts
@@ -9,59 +9,97 @@
 // point and flags just that row via `groupIdError`, which
 // ServicePointsTable/GroupIdCell renders as an "Group ID is invalid" icon.
 //
-// This test targets the seeded "raido" service point (group_id
-// 169bd3f3-dd42-4ac0-b89a-fb49648e5eff - see
-// api-svc/db/src/main/resources/db/env/dev/V32.1__update_service_point_repository.sql)
-// and mocks only that group's Keycloak lookup to fail, leaving every other
-// service point's lookup untouched, to prove the failure is now isolated.
+// The test breaks exactly one service point's group lookup and leaves every
+// other one untouched, to prove the failure is now isolated to its own row.
+//
+// Which service point that is, and which group id to break, are discovered
+// from the running environment rather than hardcoded (RAID-856). The pairing
+// this test used to assume - the "raido" service point carrying group
+// 169bd3f3... - is created by db/env/dev/V32.1__update_service_point_repository.sql,
+// which only local dev applies. Branch and test environments run
+// db/migration,db/env/test, where "raido" has no group at all and the group
+// belongs to a "RAiD AU (branch-...)" service point created at deploy time,
+// so the hardcoded version could only ever pass locally.
 //
 // Runs against the "operator" role (chromium-operator project) since the
 // operator table is only rendered for users with the `operator` realm role.
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Locator, type Page } from "@playwright/test";
 
-const RAID_AU_GROUP_ID = "169bd3f3-dd42-4ac0-b89a-fb49648e5eff";
+/** Rows whose group resolved cleanly - the only ones whose lookup is worth breaking. */
+function rowsWithResolvedGroup(page: Page): Locator {
+  return page.locator('[role="row"][data-id]').filter({
+    has: page.locator(
+      '[data-field="groupId"] [data-testid="CheckCircleOutlineIcon"]'
+    ),
+  });
+}
 
 test.describe("Service points: invalid group ID handling", () => {
   test(
     "shows a graceful per-row error instead of breaking the whole table",
     { tag: "@local" },
     async ({ page }) => {
+      await page.goto("/service-points");
+      await expect(page.getByRole("grid")).toBeVisible({ timeout: 15000 });
+
+      const resolved = rowsWithResolvedGroup(page);
+      const resolvedCount = await resolved.count();
+
+      // Isolation is only observable with a second, unaffected row to compare
+      // against, so this needs two service points with working groups.
+      test.skip(
+        resolvedCount < 2,
+        `needs two service points with resolvable groups, found ${resolvedCount}`
+      );
+
+      const affectedId = await resolved.nth(0).getAttribute("data-id");
+      const controlId = await resolved.nth(1).getAttribute("data-id");
+
+      // A valid group cell's tooltip is the group id itself, so the environment
+      // tells us which group to break.
+      await resolved
+        .nth(0)
+        .locator('[data-field="groupId"] [data-testid="CheckCircleOutlineIcon"]')
+        .hover();
+      const tooltip = page.getByRole("tooltip");
+      await expect(tooltip).toBeVisible();
+      const targetGroupId = (await tooltip.textContent())?.trim();
+      expect(targetGroupId, "expected the valid group cell to expose its group id")
+        .toBeTruthy();
+
       await page.route(
         (url) =>
           url.pathname.endsWith("/group") &&
-          url.searchParams.get("groupId") === RAID_AU_GROUP_ID,
+          url.searchParams.get("groupId") === targetGroupId,
         (route) => route.fulfill({ status: 404, body: "Group not found" })
       );
 
-      await page.goto("/service-points");
-
-      const grid = page.getByRole("grid");
-      await expect(grid).toBeVisible({ timeout: 15000 });
+      await page.reload();
+      await expect(page.getByRole("grid")).toBeVisible({ timeout: 15000 });
 
       // The whole view must not have fallen back to the generic error state.
       await expect(
         page.getByText("Service point could not be fetched")
       ).toHaveCount(0);
 
-      const affectedRow = page.getByRole("row").filter({ hasText: "raido" });
-      await expect(affectedRow).toBeVisible();
-      await expect(
-        affectedRow.locator('[data-field="groupId"] [data-testid="ErrorOutlineIcon"]')
-      ).toBeVisible();
+      const affectedRow = page.locator(`[role="row"][data-id="${affectedId}"]`);
+      const affectedIcon = affectedRow.locator(
+        '[data-field="groupId"] [data-testid="ErrorOutlineIcon"]'
+      );
+      await expect(affectedIcon).toBeVisible();
 
-      await affectedRow
-        .locator('[data-field="groupId"] [data-testid="ErrorOutlineIcon"]')
-        .hover();
+      await affectedIcon.hover();
       await expect(page.getByRole("tooltip")).toHaveText("Group ID is invalid");
 
-      // Other, unaffected service points still render normally.
-      const uqRow = page
-        .getByRole("row")
-        .filter({ hasText: "RAiD AU Test Registry 2" });
-      await expect(uqRow).toBeVisible();
+      // The other service point, whose group lookup was left alone, still
+      // renders normally - the failure did not spread.
+      const controlRow = page.locator(`[role="row"][data-id="${controlId}"]`);
+      await expect(controlRow).toBeVisible();
       await expect(
-        uqRow.locator('[data-field="groupId"] [data-testid="CheckCircleOutlineIcon"]')
+        controlRow.locator(
+          '[data-field="groupId"] [data-testid="CheckCircleOutlineIcon"]'
+        )
       ).toBeVisible();
     }
   );


### PR DESCRIPTION
## The problem

`service-point-group-id-error.spec.ts` targeted the `raido` service point on the assumption its `group_id` is `169bd3f3…`. That pairing is set by `api-svc/db/src/main/resources/db/env/dev/V32.1__update_service_point_repository.sql`, and **only local dev applies that migration**.

Branch and test environments run `db/migration,db/env/test`. Confirmed against the deployed branch env:

| Service point | groupId there |
| --- | --- |
| `raido` (20000000) | `null` |
| `RAiD AU (branch-raid-854)` (20000005) | `169bd3f3…` |

So the row under test never showed the error icon, and the test could only ever pass locally — it has been failing in CI since it merged.

## The fix

Find the rows whose group resolved cleanly, break the first one's lookup, and use the second as the control. A valid group cell's tooltip is the group id itself (see `GroupIdCell`), so the environment supplies the id to mock rather than the test hardcoding one. Rows are then tracked by DataGrid `data-id` rather than by display name.

It skips with an explicit reason if fewer than two service points have resolvable groups, since isolation isn't observable without a control.

The assertions are unchanged — no whole-table error state, the affected row shows "Group ID is invalid", the untouched row still renders normally. Only the selection of *which* row is environment-derived.

## Testing

- Full e2e suite against the deployed branch environment: **34/34 passing** (was 33/34 with this one failing, and 28 passing before the credentials fix).
- Frontend unit tests: 147 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)