### PR TITLE
RAID-862: derive Service Point ID range from Registration Agency identity

### DIFF
--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/servicepoint/RegistrationAgency.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/servicepoint/RegistrationAgency.java
@@ -1,0 +1,20 @@
+package au.org.raid.api.config.servicepoint;
+
+/**
+ * One Registration Agency's Service Point ID block allocation, as recorded in
+ * registration-agencies.yaml.
+ *
+ * @param name     the agency's name, used in error messages
+ * @param instance the agency's RAiD instance domain, or null for a reserved block
+ * @param ror      the agency's ROR, or null for a reserved block
+ * @param block    the allocated block index; the block's first Service Point ID is block * blockSize
+ * @param reserved true for a block held back rather than allocated to an agency
+ */
+public record RegistrationAgency(
+        String name,
+        String instance,
+        String ror,
+        int block,
+        boolean reserved
+) {
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/servicepoint/RegistrationAgencyNotRegisteredException.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/servicepoint/RegistrationAgencyNotRegisteredException.java
@@ -1,0 +1,13 @@
+package au.org.raid.api.config.servicepoint;
+
+/**
+ * Thrown during startup when this instance's Registration Agency cannot be
+ * resolved to a Service Point ID block. Deliberately fatal: an instance with no
+ * allocated block would mint Service Point IDs that collide with another
+ * agency's in federated RAiD metadata.
+ */
+public class RegistrationAgencyNotRegisteredException extends RuntimeException {
+    public RegistrationAgencyNotRegisteredException(final String message) {
+        super(message);
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/servicepoint/RegistrationAgencyRegister.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/servicepoint/RegistrationAgencyRegister.java
@@ -1,0 +1,183 @@
+package au.org.raid.api.config.servicepoint;
+
+import org.springframework.beans.factory.config.YamlMapFactoryBean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The register of Registration Agency Service Point ID block allocations.
+ *
+ * <p>Loaded straight from the classpath rather than bound as Spring configuration
+ * so that no environment variable can reassign an agency's block: allocation is
+ * the Registration Authority's to make, and travels with the artefact.
+ */
+@Component
+public class RegistrationAgencyRegister {
+    static final String DEFAULT_RESOURCE_PATH = "registration-agencies.yaml";
+    private static final String ROR_PREFIX = "https://ror.org/";
+
+    private final long blockSize;
+    private final List<RegistrationAgency> agencies;
+
+    public RegistrationAgencyRegister() {
+        this(new ClassPathResource(DEFAULT_RESOURCE_PATH));
+    }
+
+    RegistrationAgencyRegister(final Resource resource) {
+        final var contents = read(resource);
+        this.blockSize = blockSize(contents);
+        this.agencies = agencies(contents);
+        validate();
+    }
+
+    /**
+     * The first Service Point ID of the block allocated to the agency identified
+     * by {@code ror}.
+     *
+     * @throws RegistrationAgencyNotRegisteredException if the ROR is missing or unallocated
+     */
+    public long servicePointIdStart(final String ror) {
+        if (ror == null || ror.isBlank()) {
+            throw new RegistrationAgencyNotRegisteredException(
+                    "raid.identifier.registration-agency-identifier is not set. Set it to the ROR of " +
+                            "the Registration Agency operating this instance. Its Service Point ID range " +
+                            "is derived from that ROR, and is assigned by the RAiD Registration Authority.");
+        }
+
+        return find(ror)
+                .map(this::startOf)
+                .orElseThrow(() -> new RegistrationAgencyNotRegisteredException(
+                        "Registration Agency '" + ror + "' has no Service Point ID range allocated. " +
+                                "Contact the RAiD Registration Authority to be allocated one, which is then " +
+                                "recorded in " + DEFAULT_RESOURCE_PATH + " and released. This instance cannot " +
+                                "start until then, because minting without an allocated range would produce " +
+                                "Service Point IDs that collide with another agency's."));
+    }
+
+    public Optional<RegistrationAgency> find(final String ror) {
+        return agencies.stream()
+                .filter(agency -> !agency.reserved())
+                .filter(agency -> agency.ror().equals(ror))
+                .findFirst();
+    }
+
+    public long blockSize() {
+        return blockSize;
+    }
+
+    public List<RegistrationAgency> agencies() {
+        return List.copyOf(agencies);
+    }
+
+    long startOf(final RegistrationAgency agency) {
+        return agency.block() * blockSize;
+    }
+
+    private Map<String, Object> read(final Resource resource) {
+        if (!resource.exists()) {
+            throw new IllegalStateException(
+                    "Registration Agency register not found at " + resource.getDescription());
+        }
+
+        final var factory = new YamlMapFactoryBean();
+        factory.setResources(resource);
+        factory.afterPropertiesSet();
+
+        final var contents = factory.getObject();
+
+        if (contents == null || contents.isEmpty()) {
+            throw new IllegalStateException(
+                    "Registration Agency register at " + resource.getDescription() + " is empty");
+        }
+
+        return contents;
+    }
+
+    private long blockSize(final Map<String, Object> contents) {
+        if (!(contents.get("blockSize") instanceof Number size)) {
+            throw new IllegalStateException("Registration Agency register has no blockSize");
+        }
+
+        return size.longValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<RegistrationAgency> agencies(final Map<String, Object> contents) {
+        if (!(contents.get("agencies") instanceof List<?> entries) || entries.isEmpty()) {
+            throw new IllegalStateException("Registration Agency register lists no agencies");
+        }
+
+        final var parsed = new ArrayList<RegistrationAgency>();
+
+        for (final var entry : entries) {
+            final var fields = (Map<String, Object>) entry;
+
+            parsed.add(new RegistrationAgency(
+                    (String) fields.get("name"),
+                    (String) fields.get("instance"),
+                    (String) fields.get("ror"),
+                    fields.get("block") instanceof Number block ? block.intValue() : 0,
+                    Boolean.TRUE.equals(fields.get("reserved"))
+            ));
+        }
+
+        return parsed;
+    }
+
+    /**
+     * Guards the invariants an onboarding pull request is most likely to break.
+     * A duplicated block or ROR would reintroduce exactly the collision this
+     * register exists to prevent, so it must fail the build rather than a deploy.
+     */
+    private void validate() {
+        if (blockSize <= 0) {
+            throw new IllegalStateException("Registration Agency register blockSize must be positive");
+        }
+
+        final Set<Integer> blocks = new HashSet<>();
+        final Set<String> rors = new HashSet<>();
+
+        for (final var agency : agencies) {
+            if (agency.name() == null || agency.name().isBlank()) {
+                throw new IllegalStateException("Registration Agency register has an entry with no name");
+            }
+
+            if (agency.block() <= 0) {
+                throw new IllegalStateException(
+                        "Registration Agency '" + agency.name() + "' has no positive block");
+            }
+
+            if (!blocks.add(agency.block())) {
+                throw new IllegalStateException(
+                        "Block " + agency.block() + " is allocated more than once, which would let two " +
+                                "Registration Agencies mint colliding Service Point IDs");
+            }
+
+            if (agency.reserved()) {
+                if (agency.ror() != null) {
+                    throw new IllegalStateException(
+                            "Reserved block " + agency.block() + " must not carry a ROR");
+                }
+                continue;
+            }
+
+            if (agency.ror() == null || !agency.ror().startsWith(ROR_PREFIX)) {
+                throw new IllegalStateException(
+                        "Registration Agency '" + agency.name() + "' must have a ROR beginning " + ROR_PREFIX);
+            }
+
+            if (!rors.add(agency.ror())) {
+                throw new IllegalStateException(
+                        "ROR " + agency.ror() + " appears more than once in the Registration Agency register");
+            }
+        }
+    }
+}

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/servicepoint/ServicePointIdRangeConfig.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/servicepoint/ServicePointIdRangeConfig.java
@@ -1,0 +1,54 @@
+package au.org.raid.api.config.servicepoint;
+
+import au.org.raid.api.config.properties.IdentifierProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+
+/**
+ * Resolves this instance's Service Point ID range from its Registration Agency
+ * ROR and exposes it to Flyway as the {@code servicePointIdStart} placeholder.
+ *
+ * <p>Runs while the Flyway bean is being built, so an instance whose agency has
+ * no allocated range fails before any migration executes. That ordering matters:
+ * the database is left untouched and the previously deployed version keeps
+ * serving, rather than a half-applied renumbering being committed.
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ServicePointIdRangeConfig implements InitializingBean {
+    public static final String SERVICE_POINT_ID_START_PLACEHOLDER = "servicePointIdStart";
+
+    private final RegistrationAgencyRegister register;
+    private final IdentifierProperties identifierProperties;
+
+    /**
+     * Fails startup for a deployment that never builds a Flyway bean, such as one
+     * with {@code spring.flyway.enabled: false}, where the customizer below would
+     * otherwise never run and an unallocated instance could mint regardless.
+     */
+    @Override
+    public void afterPropertiesSet() {
+        register.servicePointIdStart(identifierProperties.getRegistrationAgencyIdentifier());
+    }
+
+    @Bean
+    public FlywayConfigurationCustomizer servicePointIdRangeCustomizer() {
+        return configuration -> {
+            final var ror = identifierProperties.getRegistrationAgencyIdentifier();
+            final var start = register.servicePointIdStart(ror);
+
+            log.info("Registration Agency {} is allocated Service Point IDs from {}", ror, start);
+
+            final var placeholders = new HashMap<>(configuration.getPlaceholders());
+            placeholders.put(SERVICE_POINT_ID_START_PLACEHOLDER, Long.toString(start));
+            configuration.placeholders(placeholders);
+        };
+    }
+}

--- a/api-svc/raid-api/src/main/resources/application-dev.yaml
+++ b/api-svc/raid-api/src/main/resources/application-dev.yaml
@@ -1,5 +1,10 @@
 raid:
   environment: dev
+  identifier:
+    # Required since the default was removed: without it a local instance now
+    # refuses to start. ARDC's ROR, because local development is development of
+    # ARDC's own instance.
+    registration-agency-identifier: https://ror.org/038sjwq14
   isni-client:
     url-format: http://localhost:1080/sru/?query=pica.isn+%3D+%22__ISNI__%22&operation=searchRetrieve&recordSchema=isni-b
   orcid-client:

--- a/api-svc/raid-api/src/main/resources/application.yaml
+++ b/api-svc/raid-api/src/main/resources/application.yaml
@@ -70,7 +70,11 @@ raid:
     schema-uri: https://raid.org/
     license: Creative Commons CC-0
     landing-prefix: https://static.${raid.environment}.raid.org.au/raids/
-    registration-agency-identifier: https://ror.org/038sjwq14
+    # No default. This is the ROR of the Registration Agency operating the
+    # instance: it is published as identifier.registrationAgency.id on every RAiD
+    # minted, and the Service Point ID range is derived from it. Defaulting it to
+    # ARDC would let another agency's deployment silently inherit ARDC's identity
+    # and mint into ARDC's Service Point ID range. Every deployment must set it.
     name-prefix: https://raid.org/
   spatial-coverage:
     schema-uri:

--- a/api-svc/raid-api/src/main/resources/registration-agencies.yaml
+++ b/api-svc/raid-api/src/main/resources/registration-agencies.yaml
@@ -1,0 +1,42 @@
+# Service Point ID block allocations for RAiD Registration Agencies.
+#
+# Each Registration Agency is allocated a distinct numeric block so that Service
+# Point IDs are unique across the federation. The ID is published in RAiD
+# metadata as identifier.owner.servicePoint, so two agencies minting the same
+# value would be indistinguishable to consumers.
+#
+# A block's first ID is `block * blockSize`; block 2 starts at 20000000. There is
+# nothing special about a single leading digit — block 10 simply starts at
+# 100000000 — so never assume a fixed number of digits.
+#
+# Allocations are made by the RAiD Registration Authority and captured in each
+# agency's legal agreement. This file is the authoritative copy in software:
+# onboarding an agency is a pull request here plus a release, not a change an
+# agency makes in its own deployment configuration.
+#
+# An instance resolves its own entry by raid.identifier.registration-agency-identifier,
+# and refuses to start when that ROR is absent from this file.
+
+blockSize: 10000000
+
+agencies:
+  # Reserved so local development, integration tests and fixtures can never be
+  # mistaken for a real agency's Service Point.
+  - name: Local development and test
+    block: 1
+    reserved: true
+
+  - name: ARDC
+    instance: raid.org.au
+    ror: https://ror.org/038sjwq14
+    block: 2
+
+  - name: SDSC
+    instance: projectpid.org
+    ror: https://ror.org/04mg3nk07
+    block: 4
+
+  # TODO:RL SURF (block 3), DRAC (block 5) and TIB (block 6) are allocated but
+  # their RORs are not yet known. SURF is deployed, so its instance will refuse
+  # to start until its entry is added here. Blocks 3, 5 and 6 are reserved for
+  # them and must not be allocated to anyone else.

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/config/servicepoint/RegistrationAgencyRegisterTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/config/servicepoint/RegistrationAgencyRegisterTest.java
@@ -1,0 +1,226 @@
+package au.org.raid.api.config.servicepoint;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RegistrationAgencyRegisterTest {
+    private static final String ARDC_ROR = "https://ror.org/038sjwq14";
+    private static final String SDSC_ROR = "https://ror.org/04mg3nk07";
+
+    private static Resource register(final String yaml) {
+        return new ByteArrayResource(yaml.getBytes());
+    }
+
+    private static RegistrationAgencyRegister shipped() {
+        return new RegistrationAgencyRegister(
+                new ClassPathResource(RegistrationAgencyRegister.DEFAULT_RESOURCE_PATH));
+    }
+
+    @Test
+    @DisplayName("derives a block's first Service Point ID from its index")
+    void derivesStartFromBlock() {
+        final var subject = shipped();
+
+        assertThat(subject.servicePointIdStart(ARDC_ROR)).isEqualTo(20000000L);
+        assertThat(subject.servicePointIdStart(SDSC_ROR)).isEqualTo(40000000L);
+    }
+
+    @Test
+    @DisplayName("scales past a single leading digit")
+    void scalesPastOneDigit() {
+        final var subject = new RegistrationAgencyRegister(register("""
+                blockSize: 10000000
+                agencies:
+                  - name: Fortieth agency
+                    ror: https://ror.org/example40
+                    block: 40
+                """));
+
+        assertThat(subject.servicePointIdStart("https://ror.org/example40")).isEqualTo(400000000L);
+    }
+
+    @Test
+    @DisplayName("refuses to start when no agency identifier is configured")
+    void rejectsMissingIdentifier() {
+        final var subject = shipped();
+
+        assertThatThrownBy(() -> subject.servicePointIdStart(null))
+                .isInstanceOf(RegistrationAgencyNotRegisteredException.class)
+                .hasMessageContaining("raid.identifier.registration-agency-identifier is not set");
+
+        assertThatThrownBy(() -> subject.servicePointIdStart("  "))
+                .isInstanceOf(RegistrationAgencyNotRegisteredException.class)
+                .hasMessageContaining("raid.identifier.registration-agency-identifier is not set");
+    }
+
+    @Test
+    @DisplayName("refuses to start for an agency with no allocation, and says where to get one")
+    void rejectsUnregisteredAgency() {
+        final var subject = shipped();
+
+        assertThatThrownBy(() -> subject.servicePointIdStart("https://ror.org/notallocated"))
+                .isInstanceOf(RegistrationAgencyNotRegisteredException.class)
+                .hasMessageContaining("https://ror.org/notallocated")
+                .hasMessageContaining("RAiD Registration Authority");
+    }
+
+    @Test
+    @DisplayName("never resolves a reserved block to an agency")
+    void reservedBlockIsNotResolvable() {
+        final var subject = new RegistrationAgencyRegister(register("""
+                blockSize: 10000000
+                agencies:
+                  - name: Local development and test
+                    block: 1
+                    reserved: true
+                  - name: An agency
+                    ror: https://ror.org/example
+                    block: 2
+                """));
+
+        assertThat(subject.find("https://ror.org/example")).isPresent();
+        assertThat(subject.agencies()).hasSize(2);
+        assertThat(subject.agencies())
+                .filteredOn(RegistrationAgency::reserved)
+                .singleElement()
+                .satisfies(reserved -> assertThat(reserved.ror()).isNull());
+    }
+
+    @Test
+    @DisplayName("rejects a block allocated twice")
+    void rejectsDuplicateBlock() {
+        assertThatThrownBy(() -> new RegistrationAgencyRegister(register("""
+                blockSize: 10000000
+                agencies:
+                  - name: First
+                    ror: https://ror.org/first
+                    block: 2
+                  - name: Second
+                    ror: https://ror.org/second
+                    block: 2
+                """)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("allocated more than once");
+    }
+
+    @Test
+    @DisplayName("rejects a ROR listed twice")
+    void rejectsDuplicateRor() {
+        assertThatThrownBy(() -> new RegistrationAgencyRegister(register("""
+                blockSize: 10000000
+                agencies:
+                  - name: First
+                    ror: https://ror.org/same
+                    block: 2
+                  - name: Second
+                    ror: https://ror.org/same
+                    block: 3
+                """)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("appears more than once");
+    }
+
+    @Test
+    @DisplayName("rejects an agency with no ROR or a malformed one")
+    void rejectsBadRor() {
+        assertThatThrownBy(() -> new RegistrationAgencyRegister(register("""
+                blockSize: 10000000
+                agencies:
+                  - name: No ROR
+                    block: 2
+                """)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("must have a ROR");
+
+        assertThatThrownBy(() -> new RegistrationAgencyRegister(register("""
+                blockSize: 10000000
+                agencies:
+                  - name: Not a ROR
+                    ror: 038sjwq14
+                    block: 2
+                """)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("must have a ROR");
+    }
+
+    @Test
+    @DisplayName("rejects a reserved block carrying a ROR")
+    void rejectsReservedWithRor() {
+        assertThatThrownBy(() -> new RegistrationAgencyRegister(register("""
+                blockSize: 10000000
+                agencies:
+                  - name: Reserved
+                    ror: https://ror.org/example
+                    block: 1
+                    reserved: true
+                """)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("must not carry a ROR");
+    }
+
+    @Test
+    @DisplayName("rejects an entry with no name or no positive block")
+    void rejectsIncompleteEntry() {
+        assertThatThrownBy(() -> new RegistrationAgencyRegister(register("""
+                blockSize: 10000000
+                agencies:
+                  - ror: https://ror.org/example
+                    block: 2
+                """)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("no name");
+
+        assertThatThrownBy(() -> new RegistrationAgencyRegister(register("""
+                blockSize: 10000000
+                agencies:
+                  - name: No block
+                    ror: https://ror.org/example
+                """)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("no positive block");
+    }
+
+    @Test
+    @DisplayName("rejects a register with no agencies or no blockSize")
+    void rejectsEmptyRegister() {
+        assertThatThrownBy(() -> new RegistrationAgencyRegister(register("blockSize: 10000000\n")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("lists no agencies");
+
+        assertThatThrownBy(() -> new RegistrationAgencyRegister(register("""
+                agencies:
+                  - name: An agency
+                    ror: https://ror.org/example
+                    block: 2
+                """)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("no blockSize");
+    }
+
+    /**
+     * The gate on any future onboarding pull request. A duplicated block or ROR
+     * would reintroduce the collision the register exists to prevent, so the
+     * shipped file must satisfy every invariant at build time.
+     */
+    @Test
+    @DisplayName("the shipped register is internally consistent")
+    void shippedRegisterIsValid() {
+        final var subject = shipped();
+
+        assertThat(subject.blockSize()).isEqualTo(10000000L);
+        assertThat(subject.agencies()).isNotEmpty();
+        assertThat(subject.find(ARDC_ROR))
+                .get()
+                .satisfies(ardc -> assertThat(ardc.block()).isEqualTo(2));
+        assertThat(subject.agencies())
+                .filteredOn(agency -> agency.block() == 1)
+                .singleElement()
+                .satisfies(local -> assertThat(local.reserved()).isTrue());
+    }
+}

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/config/servicepoint/ServicePointIdRangeConfigTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/config/servicepoint/ServicePointIdRangeConfigTest.java
@@ -1,0 +1,82 @@
+package au.org.raid.api.config.servicepoint;
+
+import au.org.raid.api.config.properties.IdentifierProperties;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static au.org.raid.api.config.servicepoint.ServicePointIdRangeConfig.SERVICE_POINT_ID_START_PLACEHOLDER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class ServicePointIdRangeConfigTest {
+    private static final String ARDC_ROR = "https://ror.org/038sjwq14";
+
+    private IdentifierProperties identifierProperties;
+    private ServicePointIdRangeConfig subject;
+
+    @BeforeEach
+    void setUp() {
+        identifierProperties = new IdentifierProperties();
+        subject = new ServicePointIdRangeConfig(new RegistrationAgencyRegister(), identifierProperties);
+    }
+
+    @Test
+    @DisplayName("sets the Flyway placeholder from the configured agency's allocation")
+    void setsPlaceholder() {
+        identifierProperties.setRegistrationAgencyIdentifier(ARDC_ROR);
+        final var configuration = new FluentConfiguration();
+
+        subject.servicePointIdRangeCustomizer().customize(configuration);
+
+        assertThat(configuration.getPlaceholders())
+                .containsEntry(SERVICE_POINT_ID_START_PLACEHOLDER, "20000000");
+    }
+
+    @Test
+    @DisplayName("keeps placeholders that were already configured")
+    void preservesExistingPlaceholders() {
+        identifierProperties.setRegistrationAgencyIdentifier(ARDC_ROR);
+        final var configuration = new FluentConfiguration()
+                .placeholders(java.util.Map.of("existing", "value"));
+
+        subject.servicePointIdRangeCustomizer().customize(configuration);
+
+        assertThat(configuration.getPlaceholders())
+                .containsEntry("existing", "value")
+                .containsEntry(SERVICE_POINT_ID_START_PLACEHOLDER, "20000000");
+    }
+
+    @Test
+    @DisplayName("fails before Flyway runs when the agency is not registered")
+    void failsForUnregisteredAgency() {
+        identifierProperties.setRegistrationAgencyIdentifier("https://ror.org/notallocated");
+        final var configuration = new FluentConfiguration();
+
+        assertThatThrownBy(() -> subject.servicePointIdRangeCustomizer().customize(configuration))
+                .isInstanceOf(RegistrationAgencyNotRegisteredException.class);
+
+        assertThat(configuration.getPlaceholders())
+                .doesNotContainKey(SERVICE_POINT_ID_START_PLACEHOLDER);
+    }
+
+    @Test
+    @DisplayName("fails startup even when Flyway is disabled and the customizer never runs")
+    void failsWhenFlywayDisabled() {
+        identifierProperties.setRegistrationAgencyIdentifier(null);
+
+        assertThatThrownBy(() -> subject.afterPropertiesSet())
+                .isInstanceOf(RegistrationAgencyNotRegisteredException.class)
+                .hasMessageContaining("raid.identifier.registration-agency-identifier is not set");
+    }
+
+    @Test
+    @DisplayName("starts normally for a registered agency")
+    void startsForRegisteredAgency() {
+        identifierProperties.setRegistrationAgencyIdentifier(ARDC_ROR);
+
+        assertThatNoException().isThrownBy(() -> subject.afterPropertiesSet());
+    }
+}


### PR DESCRIPTION
Part of RAID-806. Targets the `feature/RAID-806` integration branch, not `main`.

## Why

Every RAiD instance's `service_point.id` starts at a hardcoded `20000000`, and that raw integer is published as `identifier.owner.servicePoint`. Two Registration Agencies can therefore mint Service Points with identical IDs, indistinguishable in federated metadata.

The range is **derived from agency identity rather than configured directly**. Nothing in a deployment identifies it as SURF, so a separately configured range would have no independent check on it — a mis-set number would pass every validation built on that same number. Deriving it from `raid.identifier.registration-agency-identifier` ties the failure to a visible one: an agency using the wrong ROR to obtain another's block would publish every RAiD under that agency's name.

## What

- `registration-agencies.yaml` ships in the artefact. Read straight from the classpath via `YamlMapFactoryBean`, **not** bound as Spring configuration, so no environment variable can reassign an agency's block. Blocks are stored as an index with the start computed as `block * blockSize`, so a missing zero is not expressible.
- `RegistrationAgencyRegister` validates on construction: unique blocks, unique RORs, well-formed RORs, reserved blocks carrying no ROR. This is the gate on any future onboarding PR.
- `ServicePointIdRangeConfig` resolves the ROR and exposes it as the `servicePointIdStart` Flyway placeholder for the V46 migration (RAID-863), merging rather than replacing existing placeholders. It runs in a `FlywayConfigurationCustomizer`, so an unallocated instance fails **before any migration executes** — database untouched, previous version still serving.
- The same check is repeated in `afterPropertiesSet`. intTest sets `spring.flyway.enabled: false`, so without it a Flyway-disabled deployment would build no customizer and mint with no allocation.
- The ARDC default is removed from `application.yaml`. It would let another agency's deployment silently inherit ARDC's identity and mint into ARDC's range. `application-dev.yaml` now sets it explicitly — without that, local `bootRun` no longer starts.
- Block 1 is reserved so local and test data can never be mistaken for a real agency's Service Point.

## Blocking caveat for the reviewer

**The register is incomplete and this must not reach SURF as-is.** SURF (block 3), DRAC (block 5) and TIB (block 6) are allocated but their RORs are not known, so they are not yet in the file (`TODO:RL`). SURF's instance **is deployed** and will refuse to start until its entry is added. That is correct behaviour, but it is a release-coordination point rather than something to discover on deploy.

RAID-866 must also merge before or with this, or every environment fails to start on the property that no longer has a default.

## Testing

- 17 new unit tests covering derivation, both refusal paths and every register invariant.
- Full `intTest` green locally: **221 tests, 0 failures, 0 errors, 16 skipped**.
- Verified against a real `bootRun`, which logged `Registration Agency https://ror.org/038sjwq14 is allocated Service Point IDs from 20000000` before Flyway ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)