### PR TITLE
RAID-867: document Service Point ID ranges for operators

### DIFF
--- a/doc/adr/2026-09-04_service-point-id-range-from-agency-identity.md
+++ b/doc/adr/2026-09-04_service-point-id-range-from-agency-identity.md
@@ -1,0 +1,118 @@
+# Derive an instance's Service Point ID range from its Registration Agency identity
+
+- Status: accepted
+- Date: 2026-09-04
+- Ticket: RAID-806 (implemented by RAID-862, RAID-863)
+
+## Context
+
+`service_point.id` started at a hardcoded `20000000` on every instance, set in
+`V4__sign_in_tables.sql` and again in the `B25__baseline.sql` used to bootstrap a
+new database. The value is published in RAiD metadata as
+`identifier.owner.servicePoint`, with no name and no resolution.
+
+So every Registration Agency — ARDC, SURF, SDSC, DRAC, TIB — began counting from
+the same number, and two agencies could mint Service Points that were
+indistinguishable in federated metadata. The Federation API keys on
+`(registrationAgency.id, servicePoint)`, which relies on that pair being unique.
+
+The Registration Authority allocates each agency a block of ten million ids,
+formalised in the agency's agreement. The question was how software should learn
+which block it is in.
+
+## Decision
+
+### The range is derived from agency identity, not configured
+
+The obvious approach is a configuration value naming the starting id. It was
+rejected.
+
+Nothing in a deployment identifies it as SURF's. A mis-set range would therefore
+pass every check that could be built, because every such check derives from the
+same number it is meant to be checking. Worse, a containment check comparing
+existing data against the configured range gives exactly the wrong answer during
+an upgrade: an instance still holding pre-renumbering data at `20000000` would
+reject the correct configuration and accept the incorrect one.
+
+Instead the range is derived from `raid.identifier.registration-agency-identifier`,
+the agency's ROR, which already flows into `identifier.registrationAgency.id` on
+every RAiD minted. A register of ROR to block allocations ships inside the
+artefact, and the instance looks itself up at startup.
+
+This ties an invisible failure to a glaring one. An agency configuring another
+agency's ROR to obtain their block would publish every RAiD under that agency's
+name.
+
+### The register ships in the artefact, not in configuration
+
+`registration-agencies.yaml` is read straight from the classpath rather than
+bound as Spring configuration, because anything on the Spring `Environment` can
+be overridden by a deployment. Allocation is the Registration Authority's to
+make, so it travels with the release and is auditable in version control.
+
+Onboarding an agency is therefore a pull request plus a release, not a value an
+agency sets for itself. A unit test asserts that blocks and RORs are unique,
+which makes the review a real gate rather than a formality.
+
+Blocks are stored as an index, with the first id computed as
+`block * blockSize`. A missing zero is not expressible.
+
+### The property becomes required, with no default
+
+`raid.identifier.registration-agency-identifier` defaulted to ARDC's ROR. That
+default had to go: another agency's deployment that failed to override it would
+silently inherit ARDC's identity, resolve to ARDC's block, pass every check and
+mint into ARDC's range.
+
+### Failure happens before any migration runs
+
+Resolution happens in a `FlywayConfigurationCustomizer`, while the Flyway bean is
+being built. An unallocated instance therefore fails with the database untouched
+and the previously deployed version still serving, rather than committing a
+partial renumbering. The same check is repeated in `afterPropertiesSet` to cover
+deployments that build no Flyway bean at all, such as one with
+`spring.flyway.enabled: false`.
+
+### Renumbering is a versioned migration, and the existing ones are never edited
+
+V46 renumbers on upgrade. `V4` and `B25` are left exactly as they are: editing an
+applied migration changes its checksum and forces a Flyway repair on every
+existing instance, which would breach the project's no-manual-intervention
+requirement — the very thing this work is trying to respect.
+
+The lowest id is anchored at the start of the block, so differences between ids
+are preserved and existing gaps survive. Data already inside the block is left
+untouched rather than rewritten.
+
+A `CHECK` constraint bounds the column to the allocated block. Adding it
+validates every existing row, so it serves as both the future guard and the
+assertion that the renumbering landed correctly.
+
+## Consequences
+
+- Onboarding a new Registration Agency requires a release, not just
+  configuration. This is deliberate; the cost is a slower onboarding step in
+  exchange for allocation being controlled and auditable.
+- An agency whose ROR is not yet in the register cannot start. For an agency
+  running its own infrastructure the startup error message and the
+  [operations guide](../reference/service-point-id-ranges.md) are the entire
+  interface, so both are worded for an operator with no access to this codebase.
+- Existing Service Point IDs change on upgrade for any agency not already in its
+  block, and those ids are already published in RAiD metadata.
+- `raid_history` is deliberately not rewritten, so a reconstructed historical
+  version shows the pre-renumbering id. The history records what was captured at
+  the time rather than restating it.
+- Reallocating an agency's block later needs a migration to drop and recreate the
+  check constraint. Allocations are intended to be permanent.
+- Namespacing `identifier.owner.servicePoint` itself, and the Federation API's
+  use of the composite key, remain out of scope and are tracked separately.
+
+## Notes
+
+Two behaviours were verified rather than assumed while implementing this:
+
+- `service_point.id` is `GENERATED ALWAYS AS IDENTITY`, which rejects `UPDATE`
+  outright. V46 relaxes the identity for the renumbering and restores it after.
+- Flyway leaves no failed schema-history row when a migration rolls back
+  transactionally on PostgreSQL, so a misconfigured range needs no repair to
+  recover from — correcting the configuration and redeploying is sufficient.

--- a/doc/reference/service-point-id-ranges.md
+++ b/doc/reference/service-point-id-ranges.md
@@ -1,0 +1,129 @@
+# Service Point ID ranges
+
+Every RAiD Service instance assigns each of its Service Points a numeric id. That
+id is published in RAiD metadata as `identifier.owner.servicePoint`, so it is
+visible to anyone reading a RAiD.
+
+Historically every instance started counting from the same value, `20000000`.
+Two Registration Agencies could therefore mint Service Points with identical ids,
+and nothing in the metadata distinguished them. Each Registration Agency is now
+allocated its own range.
+
+This guide is for anyone deploying or operating a RAiD Service instance.
+
+## How a range is allocated
+
+The RAiD Registration Authority allocates each Registration Agency a block of ten
+million ids, and records it in the agency's agreement. Blocks are numbered, and a
+block's first id is its number multiplied by ten million:
+
+| Block | First Service Point ID |
+| --- | --- |
+| 2 | 20000000 |
+| 3 | 30000000 |
+| 4 | 40000000 |
+| 10 | 100000000 |
+
+There is nothing special about the number of digits. Block 10 simply starts at
+`100000000`, and the scheme continues indefinitely. **Never assume a Service
+Point ID has a fixed number of digits.**
+
+Block 1 is reserved for local development, automated tests and fixtures, so test
+data can never be mistaken for a real agency's Service Point.
+
+## Configuring your instance
+
+You do **not** configure the range directly. You configure your agency's
+identity, and the software derives the range from it:
+
+```
+raid.identifier.registration-agency-identifier = https://ror.org/<your ROR>
+```
+
+This must be your own agency's ROR. It is already published as
+`identifier.registrationAgency.id` on every RAiD your instance mints, so setting
+it to another agency's ROR would attribute all your RAiDs to them.
+
+Deriving the range from identity rather than configuring it separately means
+there is no second value that can silently disagree with the first. See
+[the ADR](../adr/2026-09-04_service-point-id-range-from-agency-identity.md) for
+the reasoning.
+
+If you deploy with the AWS CDK in `raido-v2-aws-private`, set
+`RAID_REGISTRATION_AGENCY_IDENTIFIER` in your environment before running `cdk
+synth` or `cdk deploy`. Synthesis fails if it is unset.
+
+## What happens if it is not set
+
+The application **refuses to start**. This is deliberate: an instance with no
+allocated range would mint Service Point IDs that collide with another agency's.
+
+Two distinct failures, both reported before any database migration runs, so your
+database is left untouched and your previously deployed version keeps serving:
+
+**The value is not set at all.**
+
+```
+raid.identifier.registration-agency-identifier is not set. Set it to the ROR of
+the Registration Agency operating this instance. Its Service Point ID range is
+derived from that ROR, and is assigned by the RAiD Registration Authority.
+```
+
+**The value is set, but that ROR has no allocated range.**
+
+```
+Registration Agency 'https://ror.org/...' has no Service Point ID range
+allocated. Contact the RAiD Registration Authority to be allocated one, which is
+then recorded in registration-agencies.yaml and released.
+```
+
+The second means your agency is not yet in the register. Allocations ship inside
+the application artefact, so a new agency needs a release, not a configuration
+change you can make yourself. Contact the Registration Authority.
+
+Note that a failed start may not present as an obvious failure. On ECS the task
+will crash, restart and crash again, while the deployment sits in progress and
+the previous version continues to serve traffic. Check your container logs for
+the messages above rather than waiting for the deployment to report an error.
+
+## Upgrading an existing instance
+
+**If your Service Points are not already in your allocated block, their ids will
+change.** A database migration renumbers them on the first start after the
+upgrade, and updates everything that refers to them, including the values
+embedded in stored RAiD documents.
+
+Gaps are preserved: if you had ids 20000000, 20000001 and 20000003, and your
+block starts at 30000000, they become 30000000, 30000001 and 30000003.
+
+Two consequences worth planning for:
+
+- The Service Point IDs published in your existing RAiD metadata will change.
+  Anything outside RAiD that has recorded those ids will need updating.
+- Historical versions in `raid_history` are deliberately **not** rewritten. A
+  reconstructed old version shows the id as it was at the time, which will not
+  match the current record. This is an accepted trade-off: the history is an
+  audit trail of what was recorded, not a restatement of it.
+
+If your Service Points are already inside your allocated block, the migration
+does nothing at all. No rows are modified.
+
+The whole renumbering runs in a single transaction. If anything is inconsistent
+it rolls back completely, leaving your database exactly as it was, rather than
+committing a half-applied change.
+
+## After the upgrade
+
+The database enforces the range with a constraint, so a Service Point can no
+longer be created outside your allocated block. If you see:
+
+```
+new row for relation "service_point" violates check constraint
+"service_point_id_within_allocated_block"
+```
+
+then something has tried to create a Service Point outside your range. That
+should not happen in normal operation.
+
+Changing an agency's allocation after the fact requires a migration to drop and
+recreate that constraint, so allocations are intended to be permanent.


### PR DESCRIPTION
Sub-task of RAID-806. Targets the `feature/RAID-806` integration branch. Documentation only — no code changes.

## Why this one matters more than usual

SURF runs its own infrastructure, and DRAC and TIB will. For them, the startup error message and this guide are the **entire interface** — they have no access to this codebase and no ARDC pipeline to read. Written accordingly.

## What's here

**`doc/reference/service-point-id-ranges.md`** — the operator guide:
- How allocation works, and that ids have **no fixed digit count** (block 10 starts at `100000000`)
- What to configure, and that it is the agency's *identity*, not the range
- Both startup failure messages, quoted verbatim from `RegistrationAgencyRegister`
- How to obtain an allocation when the ROR is not in the register
- What happens on upgrade

**`doc/adr/2026-09-04_service-point-id-range-from-agency-identity.md`** — the decision record, following the existing ADR format. Covers why a configured range was rejected (nothing in a deployment identifies it as SURF's, so every check would derive from the number it was meant to be checking), why the register ships in the artefact rather than in configuration, why the ARDC default had to go, and why V4/B25 are never edited.

## Two warnings called out explicitly for operators

- **Existing Service Point IDs change on upgrade**, and those ids are already published in RAiD metadata, so anything recording them externally needs updating.
- **A failed start does not look like a failure.** The ECS task crash-loops while the deployment sits in progress and the previous version keeps serving traffic, so the container log is where to look, not the deployment status. This is real behaviour we hit on RAID-862's first branch deploy.

## Deliberately not documented

The repair token (`raid.db.repair-token`). RAID-864 has not been built, and documenting behaviour that does not exist would mislead an operator. That ticket should carry its own documentation.

## Verification

Error messages, the `service_point_id_within_allocated_block` constraint name, and the `registration-agencies.yaml` filename are all quoted from source and checked against it rather than written from memory. Both cross-links resolve.

Specific agency allocations are not listed — the guide uses generic block examples, since allocations live in the register and in each agency's agreement.

I've also updated the local `deploy-raid-us` skill with the new required variable and projectpid.org's block-4 renumbering, so the next US release warns them up front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)