### PR TITLE
RAID-864: trigger a one-off Flyway repair from configuration

### DIFF
--- a/api-svc/db/build.gradle
+++ b/api-svc/db/build.gradle
@@ -147,6 +147,12 @@ jooq{
           database {
             name = 'org.jooq.meta.postgres.PostgresDatabase'
             outputSchemaToDefault = true
+            /* db_repair_log is created at runtime by RepairLog, before Flyway runs,
+            using plain JDBC — it cannot use a generated class, because the table
+            may not exist until RepairLog itself creates it. Generating a mapping
+            nothing uses would also make the output depend on whether the
+            developer's database happened to have had a repair armed. */
+            excludes = 'db_repair_log'
             schemata {
               schema {
                 inputSchema = apiSvcPgSchema

--- a/api-svc/db/src/main/java/au/org/raid/db/repair/RepairLog.java
+++ b/api-svc/db/src/main/java/au/org/raid/db/repair/RepairLog.java
@@ -1,0 +1,110 @@
+package au.org.raid.db.repair;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+
+/**
+ * Records which Flyway repairs have already been applied, so that arming a repair
+ * through configuration fires exactly once.
+ *
+ * <p>Lives in the db module and uses plain JDBC because it has to run before
+ * Flyway does, which rules out both a migration and anything that depends on the
+ * schema already existing.
+ */
+public class RepairLog {
+    public static final String TABLE_NAME = "db_repair_log";
+
+    private final DataSource dataSource;
+    private final String schema;
+    private final String historyTable;
+
+    /**
+     * @param schema       the schema to hold the log, or null to use the
+     *                     connection's default search path
+     * @param historyTable Flyway's schema history table name, used to tell a
+     *                     never-migrated database from one that needs repairing
+     */
+    public RepairLog(final DataSource dataSource, final String schema, final String historyTable) {
+        this.dataSource = dataSource;
+        this.schema = schema;
+        this.historyTable = historyTable;
+    }
+
+    /**
+     * True when {@code token} has not been recorded, meaning a repair is due.
+     *
+     * <p>Always false on a database Flyway has never migrated: there is no history
+     * to repair. That is not merely an optimisation — creating the log in an empty
+     * schema would make it non-empty, and Flyway would then refuse to migrate with
+     * "Found non-empty schema(s) but no schema history table", leaving an instance
+     * unable to start simply because a repair had been armed.
+     */
+    public boolean shouldRepair(final String token) throws SQLException {
+        try (final var connection = dataSource.getConnection()) {
+            if (!hasSchemaHistory(connection)) {
+                return false;
+            }
+
+            create(connection);
+
+            try (final var statement = connection.prepareStatement(
+                    "select 1 from " + table() + " where token = ?")) {
+                statement.setString(1, token);
+                try (final var results = statement.executeQuery()) {
+                    return !results.next();
+                }
+            }
+        }
+    }
+
+    private boolean hasSchemaHistory(final Connection connection) throws SQLException {
+        final var sql = "select to_regclass(?) is not null";
+        final var qualified = schema == null ? historyTable : schema + "." + historyTable;
+
+        try (final var statement = connection.prepareStatement(sql)) {
+            statement.setString(1, qualified);
+            try (final var results = statement.executeQuery()) {
+                return results.next() && results.getBoolean(1);
+            }
+        }
+    }
+
+    public void record(final String token) throws SQLException {
+        try (final var connection = dataSource.getConnection()) {
+            // Self-sufficient rather than assuming shouldRepair ran first: an
+            // implicit ordering contract between the two would be easy to break.
+            create(connection);
+
+            try (final var statement = connection.prepareStatement(
+                    "insert into " + table() + " (token, repaired_at) values (?, ?)")) {
+                statement.setString(1, token);
+                statement.setTimestamp(2, Timestamp.from(Instant.now()));
+                statement.executeUpdate();
+            }
+        }
+    }
+
+    private String table() {
+        return schema == null ? TABLE_NAME : schema + "." + TABLE_NAME;
+    }
+
+    /**
+     * The schema is created too: a repair can be armed on an instance that has
+     * never migrated, where Flyway has not yet created it.
+     */
+    private void create(final Connection connection) throws SQLException {
+        try (final var statement = connection.createStatement()) {
+            if (schema != null) {
+                statement.execute("create schema if not exists " + schema);
+            }
+            statement.execute("""
+                    create table if not exists %s (
+                        token varchar(256) primary key not null,
+                        repaired_at timestamp not null
+                    )""".formatted(table()));
+        }
+    }
+}

--- a/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/migration/RepairLogIntegrationTest.java
+++ b/api-svc/raid-api/src/intTest/java/au/org/raid/inttest/migration/RepairLogIntegrationTest.java
@@ -1,0 +1,186 @@
+package au.org.raid.inttest.migration;
+
+import au.org.raid.db.repair.RepairLog;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers the one-shot repair bookkeeping behind {@code raid.db.repair-token},
+ * including the situation it exists for: a schema history whose checksum no
+ * longer matches the classpath, which makes every subsequent start fail.
+ */
+@Testcontainers
+class RepairLogIntegrationTest {
+    private static final String SCHEMA = "api_svc";
+
+    /** A self-contained migration set, so this does not depend on the real one. */
+    private static final String LOCATION = "classpath:db/repair-test";
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine");
+
+    private static String jdbcUrl(final String database) {
+        return POSTGRES.getJdbcUrl().replace("/" + POSTGRES.getDatabaseName(), "/" + database);
+    }
+
+    private static DataSource dataSource(final String database) {
+        final var dataSource = new PGSimpleDataSource();
+        dataSource.setUrl(jdbcUrl(database));
+        dataSource.setUser(POSTGRES.getUsername());
+        dataSource.setPassword(POSTGRES.getPassword());
+        return dataSource;
+    }
+
+    private static Connection connectionTo(final String database) throws SQLException {
+        return DriverManager.getConnection(
+                jdbcUrl(database), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+
+    private static String freshDatabase(final String name) throws SQLException {
+        try (var connection = DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+             var statement = connection.createStatement()) {
+            statement.execute("drop database if exists " + name);
+            statement.execute("create database " + name);
+        }
+        return name;
+    }
+
+    private static Flyway flyway(final String database) {
+        return Flyway.configure()
+                .dataSource(jdbcUrl(database), POSTGRES.getUsername(), POSTGRES.getPassword())
+                .locations(LOCATION)
+                .schemas(SCHEMA)
+                .defaultSchema(SCHEMA)
+                .createSchemas(true)
+                .load();
+    }
+
+    /**
+     * Mirrors what {@code FlywayRepairConfig} does once a token is set, so the
+     * repair-once behaviour is exercised end to end against a real database.
+     */
+    private static void migrateWithToken(final String database, final String token) throws SQLException {
+        final var flyway = flyway(database);
+        final var repairLog = new RepairLog(dataSource(database), SCHEMA, "flyway_schema_history");
+
+        if (repairLog.shouldRepair(token)) {
+            flyway.repair();
+            repairLog.record(token);
+        }
+        flyway.migrate();
+    }
+
+    /**
+     * Reproduces the situation a repair exists for. Editing an already-applied
+     * migration changes its checksum, and every later start then fails validation.
+     */
+    private static void corruptStoredChecksum(final Connection connection) throws SQLException {
+        try (var statement = connection.createStatement()) {
+            statement.execute(
+                    "update " + SCHEMA + ".flyway_schema_history set checksum = 1 where version = '1'");
+        }
+    }
+
+    private static long queryLong(final Connection connection, final String sql) throws SQLException {
+        try (Statement statement = connection.createStatement(); ResultSet rs = statement.executeQuery(sql)) {
+            rs.next();
+            return rs.getLong(1);
+        }
+    }
+
+    @Test
+    @DisplayName("repairs once for a token, then never again for that same token")
+    void repairsOnceThenDisarms() throws SQLException {
+        final var database = freshDatabase("repair_once");
+        flyway(database).migrate();
+
+        try (var connection = connectionTo(database)) {
+            corruptStoredChecksum(connection);
+
+            // Without a repair the instance cannot start at all.
+            assertThatThrownBy(() -> flyway(database).migrate())
+                    .hasMessageContaining("Validate failed");
+
+            // Arming the token clears it in a single boot.
+            assertThatNoException().isThrownBy(() -> migrateWithToken(database, "RAID-864"));
+            assertThat(queryLong(connection, "select count(*) from " + SCHEMA + "." + RepairLog.TABLE_NAME
+                    + " where token = 'RAID-864'")).isEqualTo(1);
+
+            // Leaving the token set in deployment configuration is safe: it cannot
+            // fire twice, so nobody has to remember to remove it.
+            corruptStoredChecksum(connection);
+            assertThatThrownBy(() -> migrateWithToken(database, "RAID-864"))
+                    .as("the same token must not repair a second time")
+                    .hasMessageContaining("Validate failed");
+
+            // A different token is a new, deliberate decision, and does fire.
+            assertThatNoException().isThrownBy(() -> migrateWithToken(database, "RAID-999"));
+            assertThat(queryLong(connection,
+                    "select count(*) from " + SCHEMA + "." + RepairLog.TABLE_NAME)).isEqualTo(2);
+        }
+    }
+
+    @Test
+    @DisplayName("does not repair, or create anything, on a database that has never migrated")
+    void doesNothingOnFreshDatabase() throws SQLException {
+        final var database = freshDatabase("repair_fresh");
+
+        // A token armed before anything has ever migrated must still let the
+        // instance start. Creating the log here would leave a non-empty schema
+        // with no history table, and Flyway would then refuse to migrate at all.
+        assertThatNoException().isThrownBy(() -> migrateWithToken(database, "RAID-864"));
+
+        try (var connection = connectionTo(database)) {
+            assertThat(queryLong(connection,
+                    "select count(*) from information_schema.tables where table_schema = '" + SCHEMA
+                            + "' and table_name = '" + RepairLog.TABLE_NAME + "'"))
+                    .as("there is no history to repair, so nothing should be created")
+                    .isZero();
+
+            // Migration still ran normally.
+            assertThat(queryLong(connection, "select count(*) from " + SCHEMA + ".repair_probe")).isZero();
+        }
+
+        // And the token is still available to fire later, once there is history.
+        final var repairLog = new RepairLog(dataSource(database), SCHEMA, "flyway_schema_history");
+        assertThat(repairLog.shouldRepair("RAID-864")).isTrue();
+    }
+
+    @Test
+    @DisplayName("records each distinct token separately as an audit trail")
+    void recordsEachTokenSeparately() throws SQLException {
+        final var database = freshDatabase("repair_audit");
+        flyway(database).migrate();
+
+        final var repairLog = new RepairLog(dataSource(database), SCHEMA, "flyway_schema_history");
+        repairLog.record("RAID-100");
+        repairLog.record("RAID-200");
+
+        assertThat(repairLog.shouldRepair("RAID-100")).isFalse();
+        assertThat(repairLog.shouldRepair("RAID-200")).isFalse();
+        assertThat(repairLog.shouldRepair("RAID-300")).isTrue();
+
+        try (var connection = connectionTo(database)) {
+            assertThat(queryLong(connection, "select count(*) from " + SCHEMA + "." + RepairLog.TABLE_NAME
+                    + " where repaired_at is not null")).isEqualTo(2);
+        }
+    }
+}

--- a/api-svc/raid-api/src/intTest/resources/db/repair-test/V1__repair_probe.sql
+++ b/api-svc/raid-api/src/intTest/resources/db/repair-test/V1__repair_probe.sql
@@ -1,0 +1,6 @@
+-- A trivial migration set for FlywayRepairIntegrationTest, kept separate from the
+-- real migrations so the repair-token behaviour can be exercised without dragging
+-- in the whole schema.
+create table repair_probe (
+    id bigint primary key
+);

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/config/database/FlywayRepairConfig.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/config/database/FlywayRepairConfig.java
@@ -1,0 +1,90 @@
+package au.org.raid.api.config.database;
+
+import au.org.raid.db.repair.RepairLog;
+import lombok.extern.slf4j.Slf4j;
+import org.flywaydb.core.Flyway;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.sql.SQLException;
+
+/**
+ * Lets an operator trigger a one-off Flyway repair through reviewed configuration
+ * rather than by running SQL against a database.
+ *
+ * <p>A repair cannot be delivered as a migration. {@code migrate()} validates
+ * first, so a checksum mismatch aborts before any migration runs and the repair
+ * would never execute in the situation that calls for it. Repair also rewrites
+ * {@code flyway_schema_history}, which is the table the surrounding migrate
+ * operation is writing to. A flag held only in the database fails for the same
+ * reason: nothing could set it without the manual SQL we are trying to avoid.
+ *
+ * <p>So the trigger is configuration and the disarm is the database. Setting
+ * {@code raid.db.repair-token} to a value that has not been seen before runs one
+ * repair and records the token. Leaving the value in place cannot repair twice,
+ * so deployment configuration does not have to be cleaned up afterwards, and
+ * {@link RepairLog} doubles as an audit trail of when each repair ran and what
+ * justified it. Use the ticket key as the token.
+ *
+ * <p>Repairing on every boot was rejected deliberately. Repair rewrites stored
+ * checksums to match the classpath, which makes drift disappear rather than
+ * reporting it; both the V41 out-of-band application and the 2.9.3 production
+ * rollback were caught precisely because Flyway refused to start. Repair also
+ * does not help a downgrade, where the database holds migrations newer than the
+ * artefact — that needs {@code spring.flyway.ignore-migration-patterns} instead.
+ */
+@Slf4j
+@Configuration
+public class FlywayRepairConfig {
+    private final String repairToken;
+
+    public FlywayRepairConfig(@Value("${raid.db.repair-token:}") final String repairToken) {
+        this.repairToken = repairToken;
+    }
+
+    @Bean
+    public FlywayMigrationStrategy repairTokenMigrationStrategy() {
+        return flyway -> {
+            if (repairToken == null || repairToken.isBlank()) {
+                flyway.migrate();
+                return;
+            }
+
+            repairOnce(flyway);
+            flyway.migrate();
+        };
+    }
+
+    private void repairOnce(final Flyway flyway) {
+        final var configuration = flyway.getConfiguration();
+
+        if (configuration.getDataSource() == null) {
+            throw new IllegalStateException(
+                    "raid.db.repair-token is set but Flyway has no data source configured");
+        }
+
+        final var repairLog = new RepairLog(
+                configuration.getDataSource(),
+                configuration.getDefaultSchema(),
+                configuration.getTable());
+
+        try {
+            if (!repairLog.shouldRepair(repairToken)) {
+                log.info("Repair token '{}' has already been applied; skipping repair", repairToken);
+                return;
+            }
+
+            log.warn("Repair token '{}' has not been applied; running a Flyway repair", repairToken);
+            flyway.repair();
+            repairLog.record(repairToken);
+            log.warn("Flyway repair complete and recorded against token '{}'", repairToken);
+        } catch (final SQLException e) {
+            // Deliberately fatal. Carrying on would migrate without the repair the
+            // operator asked for, leaving the instance in a state nobody chose.
+            throw new IllegalStateException(
+                    "Could not apply the repair requested by raid.db.repair-token", e);
+        }
+    }
+}

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/config/database/FlywayRepairConfigTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/config/database/FlywayRepairConfigTest.java
@@ -1,0 +1,43 @@
+package au.org.raid.api.config.database;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * The normal boot path, where no repair is armed. Behaviour with a token needs a
+ * real database and is covered by {@code FlywayRepairIntegrationTest}.
+ */
+class FlywayRepairConfigTest {
+
+    @Test
+    @DisplayName("migrates without repairing when no token is configured")
+    void migratesWithoutRepairing() {
+        final var flyway = mock(Flyway.class);
+
+        new FlywayRepairConfig(null).repairTokenMigrationStrategy().migrate(flyway);
+
+        verify(flyway).migrate();
+        verify(flyway, never()).repair();
+        // Nothing else is touched, so a normal boot never reaches for a connection
+        // or creates the repair log table.
+        verifyNoMoreInteractions(flyway);
+    }
+
+    @Test
+    @DisplayName("treats a blank token as no token")
+    void treatsBlankTokenAsAbsent() {
+        final var flyway = mock(Flyway.class);
+
+        new FlywayRepairConfig("   ").repairTokenMigrationStrategy().migrate(flyway);
+
+        verify(flyway).migrate();
+        verify(flyway, never()).repair();
+        verifyNoMoreInteractions(flyway);
+    }
+}

--- a/doc/reference/service-point-id-ranges.md
+++ b/doc/reference/service-point-id-ranges.md
@@ -127,3 +127,46 @@ should not happen in normal operation.
 
 Changing an agency's allocation after the fact requires a migration to drop and
 recreate that constraint, so allocations are intended to be permanent.
+
+## Recovering from a Flyway validation failure
+
+Occasionally an instance refuses to start because Flyway's stored checksum for an
+already-applied migration no longer matches the file on the classpath:
+
+```
+Validate failed: Migrations have failed validation
+```
+
+This means the schema history and the artefact disagree. Understand why before
+acting: it can indicate a migration was applied out of band, or that a deployment
+is running an older artefact than the database has been migrated to.
+
+If a repair is genuinely the right answer, it is triggered through configuration
+rather than by running SQL:
+
+```
+raid.db.repair-token = <the ticket key justifying the repair>
+```
+
+On the next start, if that token has not been used before, the instance runs one
+Flyway repair, records the token, and then migrates. Set the value, deploy, and
+the repair happens as part of the deployment.
+
+The token is one-shot. Leaving it in your deployment configuration is safe and
+expected — the same value can never repair twice, so there is nothing to clean up
+afterwards. A later repair needs a new token, which is a new deliberate decision.
+
+Two limits worth knowing:
+
+- A repair rewrites stored checksums to match the artefact. That makes drift
+  disappear rather than reporting it, so the token value is the review checkpoint:
+  never set it speculatively.
+- A repair does **not** help a downgrade, where the database holds migrations
+  newer than the artefact you are deploying. That needs
+  `spring.flyway.ignore-migration-patterns` instead, and usually means the wrong
+  image is being deployed.
+
+Applied repairs are recorded in the `db_repair_log` table, with the token and a
+timestamp, as an audit trail. The table is only created when a repair is actually
+armed, and nothing happens on a database that has never been migrated, since
+there is no history to repair.


### PR DESCRIPTION
Sub-task of RAID-806. Targets the `feature/RAID-806` integration branch.

## Why

This closes the last gap in the no-manual-intervention requirement. A Flyway repair was the one operation that needed an operator to run SQL against a database; now it is a reviewed configuration change that takes effect on deploy.

Set `raid.db.repair-token` to a value that has not been used before — the ticket key justifying the repair — and the next start runs one repair, records the token, then migrates.

## Why it can't be a migration

`migrate()` validates first, so a checksum mismatch aborts *before* any migration runs. A repair migration would therefore only ever execute on healthy databases, never in the situation that calls for it. Repair also rewrites `flyway_schema_history`, which is the table the surrounding migrate operation is writing to.

A flag held only in the database fails for the same reason: nothing could set it without the manual SQL we're avoiding. Hence **trigger in configuration, disarm in the database**. The same token can never fire twice, so the value can stay in deployment config with nothing to clean up, and the log is an audit trail of what was repaired and why.

## A real bug the tests caught

Creating the log on a database Flyway has **never** migrated leaves a non-empty schema with no history table — and Flyway then refuses to migrate at all:

```
Found non-empty schema(s) "api_svc" but no schema history table
```

So arming a token on a brand-new instance would have stopped it starting. `shouldRepair` now returns false when there is no schema history, which is also the semantically correct answer: there is nothing to repair. Covered by a test.

## Placement

The bookkeeping (`RepairLog`) is in the **db module**, not raid-api, so intTest can reach it — that suite is deliberately black-box and cannot see raid-api's main classes. Rather than weaken that boundary for one test, the JDBC logic moved to where it arguably belongs anyway, leaving only Spring wiring in `FlywayRepairConfig`.

## Testing

- Unit tests: the unarmed path never touches the database or calls `repair()`.
- Integration tests against a real Postgres, driving an **actually corrupted checksum** so the failure being recovered from is genuine, not simulated: repairs once, refuses to repair again on the same token, fires for a new token, records each separately, and does nothing on a never-migrated database.
- Verified against a real `bootRun`: a normal unarmed boot creates no `db_repair_log` table.
- `./gradlew build` green. Full `intTest`: **230 tests, 0 failures, 0 errors, 16 skipped**.

## Documentation

Added a recovery section to `doc/reference/service-point-id-ranges.md` — the operator guide from RAID-867 — covering how to arm the token, that it is one-shot and safe to leave set, and the two limits: a repair masks drift rather than reporting it, and it does **not** help a downgrade (that needs `ignore-migration-patterns`, and usually means the wrong image is being deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)