### PR TITLE
RAID-826: Service Point client credentials management UI

### DIFF
--- a/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
+++ b/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
@@ -1,0 +1,97 @@
+// RAID-826: e2e test for the Service Point Admin self-service client
+// credentials screen (create / view secret / rotate / revoke), against the
+// real IAM backend endpoints from RAID-827.
+//
+// Runs against the "operator" role (chromium-operator project). The backend
+// grants Operator a uniform short-circuit on these endpoints alongside the
+// scoped "service-point-admin:<groupId>" role, so this covers the full
+// lifecycle end-to-end without provisioning a dedicated scoped-admin e2e
+// persona (which would need real Keycloak realm changes across
+// environments - see the RAID-826 plan notes for that known coverage gap).
+//
+// Which service point to use is discovered from the running environment
+// rather than hardcoded, following the same reasoning as RAID-856's fix to
+// service-point-group-id-error.spec.ts: only a service point with a
+// resolved (valid) group id renders the Client credentials tab at all.
+
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+function rowsWithResolvedGroup(page: Page): Locator {
+  return page.locator('[role="row"][data-id]').filter({
+    has: page.locator(
+      '[data-field="groupId"] [data-testid="CheckCircleOutlineIcon"]'
+    ),
+  });
+}
+
+test.describe("Service point client credentials", () => {
+  test(
+    "supports create, view secret (masked/reveal/copy), rotate, and revoke",
+    { tag: "@local" },
+    async ({ page, context }) => {
+      await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+      await page.goto("/service-points");
+      await expect(page.getByRole("grid")).toBeVisible({ timeout: 15000 });
+
+      const resolved = rowsWithResolvedGroup(page);
+      const count = await resolved.count();
+      test.skip(count < 1, "needs at least one service point with a resolved group");
+
+      const servicePointId = await resolved.first().getAttribute("data-id");
+      await page.goto(`/service-points/${servicePointId}`);
+
+      const credentialsTab = page.getByRole("tab", { name: "Client credentials" });
+      await expect(credentialsTab).toBeVisible({ timeout: 10000 });
+      await credentialsTab.click();
+      await expect(page).toHaveURL(/[?&]tab=credentials/);
+
+      await page.getByText("Create client credential").click();
+      const label = `e2e-cred-${Date.now()}`;
+      await page.getByLabel("Label").fill(label);
+      await page.getByRole("button", { name: "Create", exact: true }).click();
+
+      const clientIdField = page.getByLabel("Client ID");
+      const secretField = page.getByLabel("Secret");
+      await expect(secretField).toBeVisible({ timeout: 10000 });
+
+      // Masked by default.
+      const maskedValue = await secretField.inputValue();
+      expect(maskedValue).toMatch(/^•+$/);
+
+      await page.getByRole("button", { name: "Reveal secret" }).click();
+      const revealedSecret = await secretField.inputValue();
+      expect(revealedSecret).not.toMatch(/^•+$/);
+      expect(revealedSecret.length).toBeGreaterThan(0);
+
+      await page.getByRole("button", { name: "Copy secret" }).click();
+      const copiedSecret = await page.evaluate(() => navigator.clipboard.readText());
+      expect(copiedSecret).toBe(revealedSecret);
+
+      await page.getByRole("button", { name: "Reveal client id" }).click();
+      const revealedClientId = await clientIdField.inputValue();
+      expect(revealedClientId).not.toMatch(/^•+$/);
+
+      await page.getByRole("button", { name: "Done" }).click();
+
+      const row = page.getByRole("row").filter({ hasText: label });
+      await expect(row).toBeVisible();
+      await expect(row.getByText("Enabled")).toBeVisible();
+
+      await row.getByLabel("rotate secret").click();
+      await expect(page.getByText(/Secret rotated/i)).toBeVisible({ timeout: 10000 });
+      const rotatedSecret = await secretField.inputValue();
+      expect(rotatedSecret).toMatch(/^•+$/);
+      await page.getByRole("button", { name: "Done" }).click();
+
+      await row.getByLabel("revoke").click();
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole("button", { name: "Revoke" }).click();
+
+      await expect(row.getByText("Revoked")).toBeVisible({ timeout: 10000 });
+      await expect(row.getByLabel("rotate secret")).toBeDisabled();
+      await expect(row.getByLabel("revoke")).toBeDisabled();
+    }
+  );
+});

--- a/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
+++ b/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
@@ -55,6 +55,13 @@ test.describe("Service point client credentials", () => {
       const secretField = page.getByLabel("Secret");
       await expect(secretField).toBeVisible({ timeout: 10000 });
 
+      // Client ID is plaintext straight away - it's already plaintext in the
+      // table below, so there's nothing to reveal (RAID-826 comment thread).
+      const revealedClientId = await clientIdField.inputValue();
+      expect(revealedClientId).not.toMatch(/^•+$/);
+      expect(revealedClientId.length).toBeGreaterThan(0);
+      await expect(page.getByRole("button", { name: "Reveal client id" })).toHaveCount(0);
+
       // Masked by default.
       const maskedValue = await secretField.inputValue();
       expect(maskedValue).toMatch(/^•+$/);
@@ -67,10 +74,6 @@ test.describe("Service point client credentials", () => {
       await page.getByRole("button", { name: "Copy secret" }).click();
       const copiedSecret = await page.evaluate(() => navigator.clipboard.readText());
       expect(copiedSecret).toBe(revealedSecret);
-
-      await page.getByRole("button", { name: "Reveal client id" }).click();
-      const revealedClientId = await clientIdField.inputValue();
-      expect(revealedClientId).not.toMatch(/^•+$/);
 
       await page.getByRole("button", { name: "Done" }).click();
 

--- a/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
+++ b/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
@@ -48,53 +48,76 @@ test.describe("Service point client credentials", () => {
 
       await page.getByText("Create client credential").click();
       const label = `e2e-cred-${Date.now()}`;
-      await page.getByLabel("Label").fill(label);
-      await page.getByRole("button", { name: "Create", exact: true }).click();
 
-      const clientIdField = page.getByLabel("Client ID");
-      const secretField = page.getByLabel("Secret");
-      await expect(secretField).toBeVisible({ timeout: 10000 });
+      // Best-effort cleanup: MUI's Tooltip clones an aria-label from its
+      // `title` onto a wrapper span around each icon button, so every
+      // getByLabel() below must use `exact: true` (case-sensitive) to land on
+      // the real button - our aria-labels are lowercase, the tooltip clones
+      // are capitalised - rather than the ambiguous default (case-insensitive
+      // substring) match, which is what actually broke this test in CI: a
+      // second credential from an earlier failed retry made getByLabel
+      // resolve to several elements at once. Revoking in `finally` also stops
+      // failed runs from piling up unrevoked credentials against the
+      // 10-per-service-point cap.
+      try {
+        await page.getByLabel("Label").fill(label);
+        await page.getByRole("button", { name: "Create", exact: true }).click();
 
-      // Client ID is plaintext straight away - it's already plaintext in the
-      // table below, so there's nothing to reveal (RAID-826 comment thread).
-      const revealedClientId = await clientIdField.inputValue();
-      expect(revealedClientId).not.toMatch(/^•+$/);
-      expect(revealedClientId.length).toBeGreaterThan(0);
-      await expect(page.getByRole("button", { name: "Reveal client id" })).toHaveCount(0);
+        const clientIdField = page.getByLabel("Client ID", { exact: true });
+        const secretField = page.getByLabel("Secret", { exact: true });
+        await expect(secretField).toBeVisible({ timeout: 10000 });
 
-      // Masked by default.
-      const maskedValue = await secretField.inputValue();
-      expect(maskedValue).toMatch(/^•+$/);
+        // Client ID is plaintext straight away - it's already plaintext in
+        // the table below, so there's nothing to reveal (RAID-826 comment thread).
+        const revealedClientId = await clientIdField.inputValue();
+        expect(revealedClientId).not.toMatch(/^•+$/);
+        expect(revealedClientId.length).toBeGreaterThan(0);
+        await expect(page.getByRole("button", { name: "Reveal client id" })).toHaveCount(0);
 
-      await page.getByRole("button", { name: "Reveal secret" }).click();
-      const revealedSecret = await secretField.inputValue();
-      expect(revealedSecret).not.toMatch(/^•+$/);
-      expect(revealedSecret.length).toBeGreaterThan(0);
+        // Masked by default.
+        const maskedValue = await secretField.inputValue();
+        expect(maskedValue).toMatch(/^•+$/);
 
-      await page.getByRole("button", { name: "Copy secret" }).click();
-      const copiedSecret = await page.evaluate(() => navigator.clipboard.readText());
-      expect(copiedSecret).toBe(revealedSecret);
+        await page.getByRole("button", { name: "Reveal secret" }).click();
+        const revealedSecret = await secretField.inputValue();
+        expect(revealedSecret).not.toMatch(/^•+$/);
+        expect(revealedSecret.length).toBeGreaterThan(0);
 
-      await page.getByRole("button", { name: "Done" }).click();
+        await page.getByRole("button", { name: "Copy secret" }).click();
+        const copiedSecret = await page.evaluate(() => navigator.clipboard.readText());
+        expect(copiedSecret).toBe(revealedSecret);
 
-      const row = page.getByRole("row").filter({ hasText: label });
-      await expect(row).toBeVisible();
-      await expect(row.getByText("Enabled")).toBeVisible();
+        await page.getByRole("button", { name: "Done" }).click();
 
-      await row.getByLabel("rotate secret").click();
-      await expect(page.getByText(/Secret rotated/i)).toBeVisible({ timeout: 10000 });
-      const rotatedSecret = await secretField.inputValue();
-      expect(rotatedSecret).toMatch(/^•+$/);
-      await page.getByRole("button", { name: "Done" }).click();
+        const row = page.getByRole("row").filter({ hasText: label });
+        await expect(row).toBeVisible();
+        await expect(row.getByText("Enabled")).toBeVisible();
 
-      await row.getByLabel("revoke").click();
-      const dialog = page.getByRole("dialog");
-      await expect(dialog).toBeVisible();
-      await dialog.getByRole("button", { name: "Revoke" }).click();
+        await row.getByLabel("rotate secret", { exact: true }).click();
+        await expect(page.getByText(/Secret rotated/i)).toBeVisible({ timeout: 10000 });
+        const rotatedSecret = await secretField.inputValue();
+        expect(rotatedSecret).toMatch(/^•+$/);
+        await page.getByRole("button", { name: "Done" }).click();
 
-      await expect(row.getByText("Revoked")).toBeVisible({ timeout: 10000 });
-      await expect(row.getByLabel("rotate secret")).toBeDisabled();
-      await expect(row.getByLabel("revoke")).toBeDisabled();
+        await row.getByLabel("revoke", { exact: true }).click();
+        const dialog = page.getByRole("dialog");
+        await expect(dialog).toBeVisible();
+        await dialog.getByRole("button", { name: "Revoke" }).click();
+
+        await expect(row.getByText("Revoked")).toBeVisible({ timeout: 10000 });
+        await expect(row.getByLabel("rotate secret", { exact: true })).toBeDisabled();
+        await expect(row.getByLabel("revoke", { exact: true })).toBeDisabled();
+      } finally {
+        const row = page.getByRole("row").filter({ hasText: label });
+        const revokeButton = row.getByLabel("revoke", { exact: true });
+        if (await revokeButton.isVisible().catch(() => false)) {
+          const stillEnabled = await revokeButton.isEnabled().catch(() => false);
+          if (stillEnabled) {
+            await revokeButton.click();
+            await page.getByRole("dialog").getByRole("button", { name: "Revoke" }).click();
+          }
+        }
+      }
     }
   );
 });

--- a/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
+++ b/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
@@ -94,7 +94,9 @@ test.describe("Service point client credentials", () => {
         await expect(row.getByText("Enabled")).toBeVisible();
 
         await row.getByLabel("rotate secret", { exact: true }).click();
-        await expect(page.getByText(/Secret rotated/i)).toBeVisible({ timeout: 10000 });
+        // Scoped to the panel's heading, not getByText: the rotate success
+        // snackbar ("...secret rotated successfully") also matches /Secret rotated/i.
+        await expect(page.getByRole("heading", { name: /Secret rotated/i })).toBeVisible({ timeout: 10000 });
         const rotatedSecret = await secretField.inputValue();
         expect(rotatedSecret).toMatch(/^•+$/);
         await page.getByRole("button", { name: "Done" }).click();

--- a/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
+++ b/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
@@ -41,9 +41,12 @@ test.describe("Service point client credentials", () => {
       const servicePointId = await resolved.first().getAttribute("data-id");
       await page.goto(`/service-points/${servicePointId}`);
 
-      const credentialsTab = page.getByRole("tab", { name: "Client credentials" });
-      await expect(credentialsTab).toBeVisible({ timeout: 10000 });
-      await credentialsTab.click();
+      // RAID-826 v3: "Client credentials" is a left sidebar nav item (a
+      // button), not a tab - the page moved from a tabbed card to a
+      // dashboard-style sidebar switcher.
+      const credentialsNavItem = page.getByRole("button", { name: "Client credentials" });
+      await expect(credentialsNavItem).toBeVisible({ timeout: 10000 });
+      await credentialsNavItem.click();
       await expect(page).toHaveURL(/[?&]tab=credentials/);
 
       await page.getByText("Create client credential").click();

--- a/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
+++ b/raid-agency-app/e2e/tests/operator/service-point-client-credentials.spec.ts
@@ -70,12 +70,15 @@ test.describe("Service point client credentials", () => {
         const secretField = page.getByLabel("Secret", { exact: true });
         await expect(secretField).toBeVisible({ timeout: 10000 });
 
-        // Client ID is plaintext straight away - it's already plaintext in
-        // the table below, so there's nothing to reveal (RAID-826 comment thread).
+        // Client ID isn't shown anywhere else (removed from the table per the
+        // ticket's AC), so it stays masked-by-default here, same as the secret.
+        const maskedClientId = await clientIdField.inputValue();
+        expect(maskedClientId).toMatch(/^•+$/);
+
+        await page.getByRole("button", { name: "Reveal client id" }).click();
         const revealedClientId = await clientIdField.inputValue();
         expect(revealedClientId).not.toMatch(/^•+$/);
         expect(revealedClientId.length).toBeGreaterThan(0);
-        await expect(page.getByRole("button", { name: "Reveal client id" })).toHaveCount(0);
 
         // Masked by default.
         const maskedValue = await secretField.inputValue();

--- a/raid-agency-app/src/auth/keycloak/hooks/useAuthHelper.ts
+++ b/raid-agency-app/src/auth/keycloak/hooks/useAuthHelper.ts
@@ -21,6 +21,14 @@ export function useAuthHelper() {
         [tokenParsed]
     );
 
+    // Scoped role, e.g. "service-point-admin:<groupId>" - distinct from the
+    // flat GROUP_ADMIN role, which client-credential endpoints reject outright.
+    const isServicePointAdminOf = useCallback(
+        (groupId?: string): boolean =>
+            !!groupId && !!user?.roles?.includes(`service-point-admin:${groupId}`),
+        [user]
+    );
+
     const getValidToken = async () => {
         try {
             setIsRefreshing(true);
@@ -62,12 +70,13 @@ export function useAuthHelper() {
             isOperator: hasRole(REALM_ROLES.OPERATOR),
             groupId: tokenParsed?.service_point_group_id,
             hasRole,
+            isServicePointAdminOf,
             getValidToken,
             fetchWithAuth,
             isRefreshing,
             token,
             user
         }),
-        [hasRole, tokenParsed, token, user, isRefreshing]
+        [hasRole, isServicePointAdminOf, tokenParsed, token, user, isRefreshing]
     );
 }

--- a/raid-agency-app/src/constants/messages.ts
+++ b/raid-agency-app/src/constants/messages.ts
@@ -65,6 +65,13 @@ export const messages = {
     servicePointDeletionFailed: "Service point deletion failed",
     servicePointUniqueRepositoryID: "Repository ID must be unique. The provided Repository ID is already in use.",
 
+    // Client credential messages
+    clientCredentialCreated: "Client credential created successfully",
+    clientCredentialRotated: "Client credential secret rotated successfully",
+    clientCredentialRevoked: "Client credential revoked successfully",
+    clientCredentialLimitReached: (activeCount: number) =>
+        `Credential limit reached (${activeCount}/10). Revoke a credential to free up a slot.`,
+
     //Generic messages
     requestFailedTitle: "Error while processing your request",
     requestFailedContent: "Please try again or email: services@ardc.edu.au"

--- a/raid-agency-app/src/pages/service-point/ServicePoint.tsx
+++ b/raid-agency-app/src/pages/service-point/ServicePoint.tsx
@@ -6,19 +6,32 @@ import { Loading } from "@/pages/loading";
 import { fetchServicePointWithMembers } from "@/services/service-points";
 import { ServicePointWithMembers } from "@/types";
 import { Home as HomeIcon, Hub as HubIcon } from "@mui/icons-material";
-import { Alert, Card, CardContent, CardHeader, Container, Stack } from "@mui/material";
+import { Alert, Card, CardContent, CardHeader, Container, Stack, Tab, Tabs } from "@mui/material";
 
 import { ServicePointUsersList } from "@/containers/header/service-point-users/ServicePointUsersList";
+import { ClientCredentialsPanel } from "./components/client-credentials/ClientCredentialsPanel";
 import { useKeycloak } from "@/contexts/keycloak-context";
 import { useQuery } from "@tanstack/react-query";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { ServicePointUpdateForm } from "./";
 import { RefreshCcw } from "lucide-react";
+import type { SyntheticEvent } from "react";
+
+type ServicePointTab = "users" | "credentials";
 
 export const ServicePoint = () => {
-  const { isOperator } = useAuthHelper();
+  const { isOperator, isServicePointAdminOf } = useAuthHelper();
   const { isInitialized, authenticated, token, tokenParsed } = useKeycloak();
   const { servicePointId } = useParams() as { servicePointId: string };
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const activeTab: ServicePointTab = searchParams.get("tab") === "credentials" ? "credentials" : "users";
+
+  const handleTabChange = (_: SyntheticEvent, value: ServicePointTab) => {
+    const next = new URLSearchParams(searchParams);
+    next.set("tab", value);
+    setSearchParams(next);
+  };
 
   const getServicePoint = async () => {
     return await fetchServicePointWithMembers({
@@ -67,6 +80,11 @@ export const ServicePoint = () => {
     },
   ];
 
+  const groupId = servicePointQuery.data.groupId;
+  const canShowUsers =
+    !!groupId && (isOperator || tokenParsed?.service_point_group_id === groupId);
+  const canShowCredentials = !!groupId && (isOperator || isServicePointAdminOf(groupId));
+
   return (
     <Container sx={{pb:2}}>
       <Stack direction="column" gap={2}>
@@ -77,23 +95,34 @@ export const ServicePoint = () => {
             <ServicePointUpdateForm servicePoint={servicePointQuery.data!} />
           </CardContent>
         </Card>
-        <Card>
-          <CardHeader title="Service point users" />
-          <CardContent>
-            {(servicePointQuery.data.groupId &&
-              (isOperator ||
-                tokenParsed?.service_point_group_id ===
-                  servicePointQuery.data.groupId) && (
-                <ServicePointUsersList
-                  servicePointWithMembers={servicePointQuery.data}
-                />
-              )) || (
-              <Alert severity="warning">
-                No group id set or access not allowed
-              </Alert>
-            )}
-          </CardContent>
-        </Card>
+        {canShowUsers && canShowCredentials ? (
+          <Card>
+            <Tabs value={activeTab} onChange={handleTabChange} sx={{ borderBottom: 1, borderColor: "divider", px: 1 }}>
+              <Tab label="Users" value="users" />
+              <Tab label="Client credentials" value="credentials" />
+            </Tabs>
+            <CardContent>
+              {activeTab === "users" ? (
+                <ServicePointUsersList servicePointWithMembers={servicePointQuery.data} />
+              ) : (
+                <ClientCredentialsPanel groupId={groupId as string} />
+              )}
+            </CardContent>
+          </Card>
+        ) : (
+          <Card>
+            <CardHeader title="Service point users" />
+            <CardContent>
+              {canShowUsers ? (
+                <ServicePointUsersList servicePointWithMembers={servicePointQuery.data} />
+              ) : (
+                <Alert severity="warning">
+                  No group id set or access not allowed
+                </Alert>
+              )}
+            </CardContent>
+          </Card>
+        )}
       </Stack>
     </Container>
   );

--- a/raid-agency-app/src/pages/service-point/ServicePoint.tsx
+++ b/raid-agency-app/src/pages/service-point/ServicePoint.tsx
@@ -143,18 +143,34 @@ export const ServicePoint = () => {
           </Card>
         ) : (
           <Card>
-            <Box sx={{ display: "flex", alignItems: "stretch", maxHeight: "calc(100vh - 220px)" }}>
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: { xs: "column", sm: "row" },
+                alignItems: "stretch",
+                maxHeight: { xs: "none", sm: "calc(100vh - 220px)" },
+              }}
+            >
               <Box
                 sx={{
-                  width: 240,
+                  width: { xs: "100%", sm: 240 },
                   flexShrink: 0,
-                  borderRight: 1,
+                  borderRight: { xs: 0, sm: 1 },
+                  borderBottom: { xs: 1, sm: 0 },
                   borderColor: "divider",
-                  py: 2,
-                  overflowY: "auto",
+                  py: { xs: 1, sm: 2 },
+                  overflowY: { xs: "visible", sm: "auto" },
+                  overflowX: { xs: "auto", sm: "visible" },
                 }}
               >
-                <List component="nav">
+                <List
+                  component="nav"
+                  sx={{
+                    display: "flex",
+                    flexDirection: { xs: "row", sm: "column" },
+                    py: 0,
+                  }}
+                >
                   {sections.map((section) => {
                     const selected = activeSection?.key === section.key;
                     return (
@@ -162,13 +178,22 @@ export const ServicePoint = () => {
                         key={section.key}
                         selected={selected}
                         onClick={() => handleSelectSection(section.key)}
-                        sx={{
-                          borderLeft: 3,
-                          borderColor: selected ? "primary.main" : "transparent",
-                          "&.Mui-selected, &.Mui-selected:hover": {
-                            backgroundColor: "action.selected",
-                            color: "primary.main",
-                          },
+                        sx={(theme) => {
+                          const accent = selected ? theme.palette.primary.main : "transparent";
+                          return {
+                            flexShrink: 0,
+                            whiteSpace: "nowrap",
+                            [theme.breakpoints.up("sm")]: {
+                              borderLeft: `3px solid ${accent}`,
+                            },
+                            [theme.breakpoints.down("sm")]: {
+                              borderBottom: `3px solid ${accent}`,
+                            },
+                            "&.Mui-selected, &.Mui-selected:hover": {
+                              backgroundColor: theme.palette.action.selected,
+                              color: theme.palette.primary.main,
+                            },
+                          };
                         }}
                       >
                         <ListItemIcon sx={{ minWidth: 36, color: selected ? "primary.main" : "inherit" }}>
@@ -180,7 +205,7 @@ export const ServicePoint = () => {
                   })}
                 </List>
               </Box>
-              <Box sx={{ flex: 1, minWidth: 0, p: 3, overflowY: "auto" }}>
+              <Box sx={{ flex: 1, minWidth: 0, p: { xs: 2, sm: 3 }, overflowY: { xs: "visible", sm: "auto" } }}>
                 <Typography variant="h6" sx={{ mb: 2 }}>
                   {activeSection?.label}
                 </Typography>

--- a/raid-agency-app/src/pages/service-point/ServicePoint.tsx
+++ b/raid-agency-app/src/pages/service-point/ServicePoint.tsx
@@ -5,8 +5,20 @@ import { useAuthHelper } from "@/auth/keycloak";
 import { Loading } from "@/pages/loading";
 import { fetchServicePointWithMembers } from "@/services/service-points";
 import { ServicePointWithMembers } from "@/types";
-import { Home as HomeIcon, Hub as HubIcon } from "@mui/icons-material";
-import { Alert, Card, CardContent, CardHeader, Container, Stack, Tab, Tabs } from "@mui/material";
+import { Group as GroupIcon, Home as HomeIcon, Hub as HubIcon, Key as KeyIcon } from "@mui/icons-material";
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Container,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Stack,
+  Typography,
+} from "@mui/material";
 
 import { ServicePointUsersList } from "@/containers/header/service-point-users/ServicePointUsersList";
 import { ClientCredentialsPanel } from "./components/client-credentials/ClientCredentialsPanel";
@@ -15,23 +27,22 @@ import { useQuery } from "@tanstack/react-query";
 import { useParams, useSearchParams } from "react-router-dom";
 import { ServicePointUpdateForm } from "./";
 import { RefreshCcw } from "lucide-react";
-import type { SyntheticEvent } from "react";
+import type { ReactNode } from "react";
 
-type ServicePointTab = "users" | "credentials";
+type SectionKey = "update" | "users" | "credentials";
+
+interface Section {
+  key: SectionKey;
+  label: string;
+  icon: ReactNode;
+  content: ReactNode;
+}
 
 export const ServicePoint = () => {
   const { isOperator, isServicePointAdminOf } = useAuthHelper();
   const { isInitialized, authenticated, token, tokenParsed } = useKeycloak();
   const { servicePointId } = useParams() as { servicePointId: string };
   const [searchParams, setSearchParams] = useSearchParams();
-
-  const activeTab: ServicePointTab = searchParams.get("tab") === "credentials" ? "credentials" : "users";
-
-  const handleTabChange = (_: SyntheticEvent, value: ServicePointTab) => {
-    const next = new URLSearchParams(searchParams);
-    next.set("tab", value);
-    setSearchParams(next);
-  };
 
   const getServicePoint = async () => {
     return await fetchServicePointWithMembers({
@@ -85,42 +96,88 @@ export const ServicePoint = () => {
     !!groupId && (isOperator || tokenParsed?.service_point_group_id === groupId);
   const canShowCredentials = !!groupId && (isOperator || isServicePointAdminOf(groupId));
 
+  const sections: Section[] = [];
+  if (isOperator) {
+    sections.push({
+      key: "update",
+      label: "Update service point",
+      icon: <RefreshCcw size={20} />,
+      content: <ServicePointUpdateForm servicePoint={servicePointQuery.data!} />,
+    });
+  }
+  if (canShowUsers) {
+    sections.push({
+      key: "users",
+      label: "Users",
+      icon: <GroupIcon />,
+      content: <ServicePointUsersList servicePointWithMembers={servicePointQuery.data} />,
+    });
+  }
+  if (canShowCredentials) {
+    sections.push({
+      key: "credentials",
+      label: "Client credentials",
+      icon: <KeyIcon />,
+      content: <ClientCredentialsPanel groupId={groupId as string} />,
+    });
+  }
+
+  const requestedKey = searchParams.get("tab");
+  const activeSection = sections.find((section) => section.key === requestedKey) ?? sections[0];
+
+  const handleSelectSection = (key: SectionKey) => {
+    const next = new URLSearchParams(searchParams);
+    next.set("tab", key);
+    setSearchParams(next);
+  };
+
   return (
-    <Container sx={{pb:2}}>
+    <Container sx={{ pb: 2 }}>
       <Stack direction="column" gap={2}>
         <BreadcrumbsBar breadcrumbs={breadcrumbs} />
-        <Card hidden={!isOperator} variant="outlined" sx={{ mt: 2 }}>
-          <CardHeader title={<><RefreshCcw /> Update Service Point</>} />
-          <CardContent>
-            <ServicePointUpdateForm servicePoint={servicePointQuery.data!} />
-          </CardContent>
-        </Card>
-        {canShowUsers && canShowCredentials ? (
+        {sections.length === 0 ? (
           <Card>
-            <Tabs value={activeTab} onChange={handleTabChange} sx={{ borderBottom: 1, borderColor: "divider", px: 1 }}>
-              <Tab label="Users" value="users" />
-              <Tab label="Client credentials" value="credentials" />
-            </Tabs>
             <CardContent>
-              {activeTab === "users" ? (
-                <ServicePointUsersList servicePointWithMembers={servicePointQuery.data} />
-              ) : (
-                <ClientCredentialsPanel groupId={groupId as string} />
-              )}
+              <Alert severity="warning">No group id set or access not allowed</Alert>
             </CardContent>
           </Card>
         ) : (
           <Card>
-            <CardHeader title="Service point users" />
-            <CardContent>
-              {canShowUsers ? (
-                <ServicePointUsersList servicePointWithMembers={servicePointQuery.data} />
-              ) : (
-                <Alert severity="warning">
-                  No group id set or access not allowed
-                </Alert>
-              )}
-            </CardContent>
+            <Box sx={{ display: "flex", alignItems: "stretch" }}>
+              <Box sx={{ width: 240, flexShrink: 0, borderRight: 1, borderColor: "divider", py: 2 }}>
+                <List component="nav">
+                  {sections.map((section) => {
+                    const selected = activeSection?.key === section.key;
+                    return (
+                      <ListItemButton
+                        key={section.key}
+                        selected={selected}
+                        onClick={() => handleSelectSection(section.key)}
+                        sx={{
+                          borderLeft: 3,
+                          borderColor: selected ? "primary.main" : "transparent",
+                          "&.Mui-selected, &.Mui-selected:hover": {
+                            backgroundColor: "action.selected",
+                            color: "primary.main",
+                          },
+                        }}
+                      >
+                        <ListItemIcon sx={{ minWidth: 36, color: selected ? "primary.main" : "inherit" }}>
+                          {section.icon}
+                        </ListItemIcon>
+                        <ListItemText primary={section.label} />
+                      </ListItemButton>
+                    );
+                  })}
+                </List>
+              </Box>
+              <Box sx={{ flex: 1, minWidth: 0, p: 3 }}>
+                <Typography variant="h6" sx={{ mb: 2 }}>
+                  {activeSection?.label}
+                </Typography>
+                {activeSection?.content}
+              </Box>
+            </Box>
           </Card>
         )}
       </Stack>

--- a/raid-agency-app/src/pages/service-point/ServicePoint.tsx
+++ b/raid-agency-app/src/pages/service-point/ServicePoint.tsx
@@ -143,8 +143,17 @@ export const ServicePoint = () => {
           </Card>
         ) : (
           <Card>
-            <Box sx={{ display: "flex", alignItems: "stretch" }}>
-              <Box sx={{ width: 240, flexShrink: 0, borderRight: 1, borderColor: "divider", py: 2 }}>
+            <Box sx={{ display: "flex", alignItems: "stretch", maxHeight: "calc(100vh - 220px)" }}>
+              <Box
+                sx={{
+                  width: 240,
+                  flexShrink: 0,
+                  borderRight: 1,
+                  borderColor: "divider",
+                  py: 2,
+                  overflowY: "auto",
+                }}
+              >
                 <List component="nav">
                   {sections.map((section) => {
                     const selected = activeSection?.key === section.key;
@@ -171,7 +180,7 @@ export const ServicePoint = () => {
                   })}
                 </List>
               </Box>
-              <Box sx={{ flex: 1, minWidth: 0, p: 3 }}>
+              <Box sx={{ flex: 1, minWidth: 0, p: 3, overflowY: "auto" }}>
                 <Typography variant="h6" sx={{ mb: 2 }}>
                   {activeSection?.label}
                 </Typography>

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsPanel.test.tsx
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsPanel.test.tsx
@@ -110,6 +110,11 @@ describe("ClientCredentialsPanel", () => {
       expect.anything()
     ));
 
+    // Client ID is shown in plaintext straight away - it's already plaintext
+    // in the table, so masking it here would only add friction (RAID-826).
+    expect(screen.getByLabelText("Client ID")).toHaveValue("raid-cred-abc123");
+    expect(screen.queryByRole("button", { name: /Reveal client id/i })).not.toBeInTheDocument();
+
     const secretField = await screen.findByLabelText("Secret");
     expect(secretField).toHaveValue("•".repeat(24));
 

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsPanel.test.tsx
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsPanel.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ClientCredentialsPanel } from "./ClientCredentialsPanel";
+import { ClientCredentialApiError } from "@/services/client-credentials";
+import type { ClientCredential, ClientCredentialSecret } from "@/services/client-credentials";
+
+vi.mock("@/contexts/keycloak-context", () => ({
+  useKeycloak: () => ({ token: "mock-token" }),
+}));
+
+vi.mock("@/components/snackbar", () => ({
+  useSnackbar: () => ({ openSnackbar: vi.fn() }),
+}));
+
+const mockFetchClientCredentials = vi.fn();
+const mockCreateClientCredential = vi.fn();
+const mockRotateClientCredential = vi.fn();
+const mockRevokeClientCredential = vi.fn();
+const mockGetClientCredentialSecret = vi.fn();
+
+vi.mock("@/services/client-credentials", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/client-credentials")>();
+  return {
+    ...actual,
+    fetchClientCredentials: (...args: unknown[]) => mockFetchClientCredentials(...args),
+    createClientCredential: (...args: unknown[]) => mockCreateClientCredential(...args),
+    rotateClientCredential: (...args: unknown[]) => mockRotateClientCredential(...args),
+    revokeClientCredential: (...args: unknown[]) => mockRevokeClientCredential(...args),
+    getClientCredentialSecret: (...args: unknown[]) => mockGetClientCredentialSecret(...args),
+  };
+});
+
+const makeCredential = (overrides: Partial<ClientCredential> = {}): ClientCredential => ({
+  clientId: "raid-cred-abc123",
+  label: "rspace-integration",
+  createdAt: "2026-06-02T00:00:00Z",
+  lastRotatedAt: null,
+  enabled: true,
+  ...overrides,
+});
+
+const makeSecret = (overrides: Partial<ClientCredentialSecret> = {}): ClientCredentialSecret => ({
+  clientId: "raid-cred-abc123",
+  label: "rspace-integration",
+  secret: "supersecretvalue",
+  createdAt: "2026-06-02T00:00:00Z",
+  lastRotatedAt: null,
+  ...overrides,
+});
+
+const renderPanel = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ClientCredentialsPanel groupId="group-1" />
+    </QueryClientProvider>
+  );
+};
+
+describe("ClientCredentialsPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+    });
+  });
+
+  it("shows the empty state and never renders a 'last used' column", async () => {
+    mockFetchClientCredentials.mockResolvedValue([]);
+    renderPanel();
+
+    expect(await screen.findByText(/No client credentials yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/last used/i)).not.toBeInTheDocument();
+  });
+
+  it("lists existing credentials with Created and Last rotated, not Last used", async () => {
+    mockFetchClientCredentials.mockResolvedValue([makeCredential()]);
+    renderPanel();
+
+    expect(await screen.findByText("rspace-integration")).toBeInTheDocument();
+    expect(screen.getByText("Created")).toBeInTheDocument();
+    expect(screen.getByText("Last rotated")).toBeInTheDocument();
+    expect(screen.queryByText(/last used/i)).not.toBeInTheDocument();
+  });
+
+  it("disables create and shows a limit message when 10 active credentials exist", async () => {
+    mockFetchClientCredentials.mockResolvedValue(
+      Array.from({ length: 10 }, (_, i) => makeCredential({ clientId: `cred-${i}`, label: `cred-${i}` }))
+    );
+    renderPanel();
+
+    fireEvent.click(await screen.findByText("Create client credential"));
+    expect(await screen.findByText(/Credential limit reached \(10\/10\)/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+  });
+
+  it("creates a credential and shows the masked secret with working reveal and copy", async () => {
+    mockFetchClientCredentials.mockResolvedValue([]);
+    mockCreateClientCredential.mockResolvedValue(makeSecret());
+    renderPanel();
+
+    fireEvent.click(await screen.findByText("Create client credential"));
+    fireEvent.change(screen.getByLabelText("Label"), { target: { value: "rspace-integration" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(mockCreateClientCredential).toHaveBeenCalledWith(
+      { groupId: "group-1", label: "rspace-integration", token: "mock-token" },
+      expect.anything()
+    ));
+
+    const secretField = await screen.findByLabelText("Secret");
+    expect(secretField).toHaveValue("•".repeat(24));
+
+    fireEvent.click(screen.getByRole("button", { name: /Reveal secret/i }));
+    expect(secretField).toHaveValue("supersecretvalue");
+
+    fireEvent.click(screen.getByRole("button", { name: /Copy secret/i }));
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith("supersecretvalue"));
+  });
+
+  it("shows the newly created credential in the list as soon as it's created, before Done is clicked", async () => {
+    mockFetchClientCredentials.mockResolvedValue([]);
+    mockCreateClientCredential.mockResolvedValue(makeSecret());
+    renderPanel();
+
+    expect(await screen.findByText(/No client credentials yet/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Create client credential"));
+    fireEvent.change(screen.getByLabelText("Label"), { target: { value: "rspace-integration" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    // The row shows up immediately, while the secret panel is still open -
+    // not only after "Done" is clicked, and not only after a background refetch.
+    expect(await screen.findByText("rspace-integration")).toBeInTheDocument();
+    expect(screen.queryByText(/No client credentials yet/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(screen.getByText("rspace-integration")).toBeInTheDocument();
+  });
+
+  it("shows a specific message when create is rejected with a 409", async () => {
+    mockFetchClientCredentials.mockResolvedValue([]);
+    mockCreateClientCredential.mockRejectedValue(
+      new ClientCredentialApiError("Credential limit reached (10/10)", 409)
+    );
+    renderPanel();
+
+    fireEvent.click(await screen.findByText("Create client credential"));
+    fireEvent.change(screen.getByLabelText("Label"), { target: { value: "one-too-many" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(await screen.findByText(/Credential limit reached \(10\/10\)/i)).toBeInTheDocument();
+  });
+
+  it("rotates a credential and reveals the new secret", async () => {
+    mockFetchClientCredentials.mockResolvedValue([makeCredential()]);
+    mockRotateClientCredential.mockResolvedValue(makeSecret({ secret: "rotatedsecretvalue" }));
+    renderPanel();
+
+    const row = (await screen.findByText("rspace-integration")).closest("tr") as HTMLElement;
+    fireEvent.click(within(row).getByLabelText("rotate secret"));
+
+    await waitFor(() => expect(mockRotateClientCredential).toHaveBeenCalledWith(
+      { clientId: "raid-cred-abc123", token: "mock-token" },
+      expect.anything()
+    ));
+    expect(await screen.findByText(/Secret rotated/i)).toBeInTheDocument();
+  });
+
+  it("revokes a credential after confirmation", async () => {
+    mockFetchClientCredentials.mockResolvedValue([makeCredential()]);
+    mockRevokeClientCredential.mockResolvedValue(undefined);
+    renderPanel();
+
+    const row = (await screen.findByText("rspace-integration")).closest("tr") as HTMLElement;
+    fireEvent.click(within(row).getByLabelText("revoke"));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Revoke" }));
+
+    await waitFor(() => expect(mockRevokeClientCredential).toHaveBeenCalledWith(
+      { clientId: "raid-cred-abc123", token: "mock-token" },
+      expect.anything()
+    ));
+  });
+});

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsPanel.test.tsx
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsPanel.test.tsx
@@ -75,7 +75,7 @@ describe("ClientCredentialsPanel", () => {
     expect(screen.queryByText(/last used/i)).not.toBeInTheDocument();
   });
 
-  it("lists existing credentials with Created and Last rotated, not Last used", async () => {
+  it("lists existing credentials with Created and Last rotated, not Last used or Client ID", async () => {
     mockFetchClientCredentials.mockResolvedValue([makeCredential()]);
     renderPanel();
 
@@ -83,6 +83,9 @@ describe("ClientCredentialsPanel", () => {
     expect(screen.getByText("Created")).toBeInTheDocument();
     expect(screen.getByText("Last rotated")).toBeInTheDocument();
     expect(screen.queryByText(/last used/i)).not.toBeInTheDocument();
+    // The ticket's AC only lists label/created/last-rotated for the table -
+    // Client ID isn't part of it, and only appears in the secret panel.
+    expect(screen.queryByText("Client ID")).not.toBeInTheDocument();
   });
 
   it("disables create and shows a limit message when 10 active credentials exist", async () => {
@@ -110,10 +113,13 @@ describe("ClientCredentialsPanel", () => {
       expect.anything()
     ));
 
-    // Client ID is shown in plaintext straight away - it's already plaintext
-    // in the table, so masking it here would only add friction (RAID-826).
-    expect(screen.getByLabelText("Client ID")).toHaveValue("raid-cred-abc123");
-    expect(screen.queryByRole("button", { name: /Reveal client id/i })).not.toBeInTheDocument();
+    // Client ID isn't shown anywhere else (removed from the table per the
+    // ticket's AC - RAID-826), so it stays masked-by-default here too.
+    const clientIdField = screen.getByLabelText("Client ID");
+    expect(clientIdField).toHaveValue("•".repeat(24));
+
+    fireEvent.click(screen.getByRole("button", { name: /Reveal client id/i }));
+    expect(clientIdField).toHaveValue("raid-cred-abc123");
 
     const secretField = await screen.findByLabelText("Secret");
     expect(secretField).toHaveValue("•".repeat(24));

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsPanel.tsx
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsPanel.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { Alert, Stack } from "@mui/material";
+import { useKeycloak } from "@/contexts/keycloak-context";
+import { Loading } from "@/pages/loading";
+import { ErrorAlertComponent } from "@/components/error-alert-component";
+import type { ClientCredentialSecret } from "@/services/client-credentials";
+import { useClientCredentials } from "./useClientCredentialMutations";
+import { CreateClientCredentialForm } from "./CreateClientCredentialForm";
+import { ClientCredentialsTable } from "./ClientCredentialsTable";
+import { SecretRevealPanel } from "./SecretRevealPanel";
+
+const SECRET_HEADINGS: Record<"created" | "rotated" | "viewed", string> = {
+  created: "Credential created",
+  rotated: "Secret rotated",
+  viewed: "Viewing secret",
+};
+
+export function ClientCredentialsPanel({ groupId }: { groupId: string }) {
+  const { token } = useKeycloak();
+  const [revealed, setRevealed] = useState<{ secret: ClientCredentialSecret; action: "created" | "rotated" | "viewed" } | null>(null);
+
+  const query = useClientCredentials(groupId, token);
+
+  if (query.isPending) {
+    return <Loading />;
+  }
+
+  if (query.isError) {
+    return <ErrorAlertComponent error="Client credentials could not be fetched" />;
+  }
+
+  const credentials = query.data;
+  const activeCount = credentials.filter((c) => c.enabled).length;
+
+  return (
+    <Stack gap={2}>
+      <CreateClientCredentialForm
+        groupId={groupId}
+        token={token}
+        activeCount={activeCount}
+        onCreated={(secret) => setRevealed({ secret, action: "created" })}
+      />
+
+      {revealed && (
+        <SecretRevealPanel
+          credential={revealed.secret}
+          heading={`${SECRET_HEADINGS[revealed.action]} — ${revealed.secret.label}`}
+          onClose={() => setRevealed(null)}
+        />
+      )}
+
+      {credentials.length === 0 ? (
+        <Alert severity="info">
+          No client credentials yet. Create one above to let a system authenticate on this service point's behalf.
+        </Alert>
+      ) : (
+        <ClientCredentialsTable
+          credentials={credentials}
+          groupId={groupId}
+          token={token}
+          onSecretRevealed={(secret, action) => setRevealed({ secret, action })}
+        />
+      )}
+    </Stack>
+  );
+}

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsTable.tsx
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsTable.tsx
@@ -1,0 +1,169 @@
+import { useState } from "react";
+import {
+  Chip,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  Visibility as VisibilityIcon,
+  Autorenew as AutorenewIcon,
+  DeleteOutline as DeleteOutlineIcon,
+} from "@mui/icons-material";
+import CustomizedDialogs from "@/components/alert-dialog/alert-dialog";
+import { useSnackbar } from "@/components/snackbar";
+import type { ClientCredential, ClientCredentialSecret } from "@/services/client-credentials";
+import {
+  useRotateClientCredential,
+  useRevokeClientCredential,
+  useViewClientCredentialSecret,
+} from "./useClientCredentialMutations";
+
+export function ClientCredentialsTable({
+  credentials,
+  groupId,
+  token,
+  onSecretRevealed,
+}: {
+  credentials: ClientCredential[];
+  groupId: string;
+  token: string | undefined;
+  onSecretRevealed: (secret: ClientCredentialSecret, action: "viewed" | "rotated") => void;
+}) {
+  const snackbar = useSnackbar();
+  const [revokeTarget, setRevokeTarget] = useState<ClientCredential | null>(null);
+
+  const viewSecretMutation = useViewClientCredentialSecret();
+  const rotateMutation = useRotateClientCredential(groupId, snackbar);
+  const revokeMutation = useRevokeClientCredential(groupId, snackbar);
+
+  const handleView = (credential: ClientCredential) => {
+    viewSecretMutation.mutate(
+      { clientId: credential.clientId, token },
+      { onSuccess: (secret) => onSecretRevealed(secret, "viewed") }
+    );
+  };
+
+  const handleRotate = (credential: ClientCredential) => {
+    rotateMutation.mutate(
+      { clientId: credential.clientId, token },
+      { onSuccess: (secret) => onSecretRevealed(secret, "rotated") }
+    );
+  };
+
+  const handleConfirmRevoke = () => {
+    if (!revokeTarget) return;
+    revokeMutation.mutate({ clientId: revokeTarget.clientId, token });
+    setRevokeTarget(null);
+  };
+
+  return (
+    <TableContainer>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Label</TableCell>
+            <TableCell>Client ID</TableCell>
+            <TableCell>Created</TableCell>
+            <TableCell>Last rotated</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell align="right">Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {credentials.map((credential) => {
+            const disabled = !credential.enabled;
+            return (
+              <TableRow key={credential.clientId} sx={{ opacity: disabled ? 0.55 : 1 }}>
+                <TableCell>{credential.label}</TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+                    {credential.clientId}
+                  </Typography>
+                </TableCell>
+                <TableCell>{new Date(credential.createdAt).toLocaleString("en-AU")}</TableCell>
+                <TableCell>
+                  {credential.lastRotatedAt ? new Date(credential.lastRotatedAt).toLocaleString("en-AU") : "—"}
+                </TableCell>
+                <TableCell>
+                  <Chip
+                    label={credential.enabled ? "Enabled" : "Revoked"}
+                    size="small"
+                    color={credential.enabled ? "success" : "default"}
+                  />
+                </TableCell>
+                <TableCell align="right">
+                  <Tooltip title={disabled ? "Unavailable — revoked" : "View secret"}>
+                    <span>
+                      <IconButton
+                        size="small"
+                        aria-label="view secret"
+                        disabled={disabled}
+                        onClick={() => handleView(credential)}
+                      >
+                        <VisibilityIcon fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <Tooltip title={disabled ? "Unavailable — revoked" : "Rotate secret"}>
+                    <span>
+                      <IconButton
+                        size="small"
+                        aria-label="rotate secret"
+                        disabled={disabled}
+                        onClick={() => handleRotate(credential)}
+                      >
+                        <AutorenewIcon fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <Tooltip title={disabled ? "Already revoked" : "Revoke"}>
+                    <span>
+                      <IconButton
+                        size="small"
+                        color="error"
+                        aria-label="revoke"
+                        disabled={disabled}
+                        onClick={() => setRevokeTarget(credential)}
+                      >
+                        <DeleteOutlineIcon fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      <CustomizedDialogs
+        modalTitle="Revoke client credential"
+        modalContent={`Revoke "${revokeTarget?.label ?? ""}"? Any system using it will lose access immediately. This can't be undone.`}
+        alertOpen={!!revokeTarget}
+        onClose={() => setRevokeTarget(null)}
+        modalAction={true}
+        modalActions={[
+          {
+            label: "Cancel",
+            onClick: () => setRevokeTarget(null),
+            icon: DeleteOutlineIcon,
+            bgColor: "grey.500",
+          },
+          {
+            label: "Revoke",
+            onClick: handleConfirmRevoke,
+            icon: DeleteOutlineIcon,
+            bgColor: "error.main",
+          },
+        ]}
+      />
+    </TableContainer>
+  );
+}

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsTable.tsx
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsTable.tsx
@@ -25,6 +25,14 @@ import {
   useViewClientCredentialSecret,
 } from "./useClientCredentialMutations";
 
+const CLIENT_ID_VISIBLE_CHARS = 16;
+
+function truncateClientId(clientId: string): string {
+  return clientId.length > CLIENT_ID_VISIBLE_CHARS
+    ? `${clientId.slice(0, CLIENT_ID_VISIBLE_CHARS)}…`
+    : clientId;
+}
+
 export function ClientCredentialsTable({
   credentials,
   groupId,
@@ -64,8 +72,8 @@ export function ClientCredentialsTable({
   };
 
   return (
-    <TableContainer>
-      <Table size="small">
+    <TableContainer sx={{ overflowX: "auto" }}>
+      <Table size="small" sx={{ minWidth: 640 }}>
         <TableHead>
           <TableRow>
             <TableCell>Label</TableCell>
@@ -81,24 +89,26 @@ export function ClientCredentialsTable({
             const disabled = !credential.enabled;
             return (
               <TableRow key={credential.clientId} sx={{ opacity: disabled ? 0.55 : 1 }}>
-                <TableCell>{credential.label}</TableCell>
-                <TableCell>
-                  <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
-                    {credential.clientId}
-                  </Typography>
+                <TableCell sx={{ whiteSpace: "nowrap" }}>{credential.label}</TableCell>
+                <TableCell sx={{ whiteSpace: "nowrap" }}>
+                  <Tooltip title={credential.clientId}>
+                    <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+                      {truncateClientId(credential.clientId)}
+                    </Typography>
+                  </Tooltip>
                 </TableCell>
-                <TableCell>{new Date(credential.createdAt).toLocaleString("en-AU")}</TableCell>
-                <TableCell>
+                <TableCell sx={{ whiteSpace: "nowrap" }}>{new Date(credential.createdAt).toLocaleString("en-AU")}</TableCell>
+                <TableCell sx={{ whiteSpace: "nowrap" }}>
                   {credential.lastRotatedAt ? new Date(credential.lastRotatedAt).toLocaleString("en-AU") : "—"}
                 </TableCell>
-                <TableCell>
+                <TableCell sx={{ whiteSpace: "nowrap" }}>
                   <Chip
                     label={credential.enabled ? "Enabled" : "Revoked"}
                     size="small"
                     color={credential.enabled ? "success" : "default"}
                   />
                 </TableCell>
-                <TableCell align="right">
+                <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
                   <Tooltip title={disabled ? "Unavailable — revoked" : "View secret"}>
                     <span>
                       <IconButton

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsTable.tsx
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/ClientCredentialsTable.tsx
@@ -9,7 +9,6 @@ import {
   TableHead,
   TableRow,
   Tooltip,
-  Typography,
 } from "@mui/material";
 import {
   Visibility as VisibilityIcon,
@@ -24,14 +23,6 @@ import {
   useRevokeClientCredential,
   useViewClientCredentialSecret,
 } from "./useClientCredentialMutations";
-
-const CLIENT_ID_VISIBLE_CHARS = 16;
-
-function truncateClientId(clientId: string): string {
-  return clientId.length > CLIENT_ID_VISIBLE_CHARS
-    ? `${clientId.slice(0, CLIENT_ID_VISIBLE_CHARS)}…`
-    : clientId;
-}
 
 export function ClientCredentialsTable({
   credentials,
@@ -77,7 +68,6 @@ export function ClientCredentialsTable({
         <TableHead>
           <TableRow>
             <TableCell>Label</TableCell>
-            <TableCell>Client ID</TableCell>
             <TableCell>Created</TableCell>
             <TableCell>Last rotated</TableCell>
             <TableCell>Status</TableCell>
@@ -90,13 +80,6 @@ export function ClientCredentialsTable({
             return (
               <TableRow key={credential.clientId} sx={{ opacity: disabled ? 0.55 : 1 }}>
                 <TableCell sx={{ whiteSpace: "nowrap" }}>{credential.label}</TableCell>
-                <TableCell sx={{ whiteSpace: "nowrap" }}>
-                  <Tooltip title={credential.clientId}>
-                    <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
-                      {truncateClientId(credential.clientId)}
-                    </Typography>
-                  </Tooltip>
-                </TableCell>
                 <TableCell sx={{ whiteSpace: "nowrap" }}>{new Date(credential.createdAt).toLocaleString("en-AU")}</TableCell>
                 <TableCell sx={{ whiteSpace: "nowrap" }}>
                   {credential.lastRotatedAt ? new Date(credential.lastRotatedAt).toLocaleString("en-AU") : "—"}

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/CreateClientCredentialForm.tsx
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/CreateClientCredentialForm.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { SquarePen } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createClientCredential, ClientCredentialApiError, ClientCredentialSecret, ClientCredential } from "@/services/client-credentials";
+import { messages } from "@/constants/messages";
+
+const CREDENTIAL_LIMIT = 10;
+
+export function CreateClientCredentialForm({
+  groupId,
+  token,
+  activeCount,
+  onCreated,
+}: {
+  groupId: string;
+  token: string | undefined;
+  activeCount: number;
+  onCreated: (secret: ClientCredentialSecret) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [label, setLabel] = useState("");
+  const atCap = activeCount >= CREDENTIAL_LIMIT;
+  const queryClient = useQueryClient();
+
+  const createMutation = useMutation({
+    mutationFn: createClientCredential,
+    onSuccess: (secret) => {
+      setLabel("");
+      setExpanded(false);
+
+      // The create response already has everything a list row needs, so the
+      // new credential is inserted directly into the cache rather than
+      // triggering a refetch - which would just be a slower round-trip to
+      // fetch data we already have, and risks racing back over this update
+      // with a response that started before the create did.
+      const { secret: _secret, ...credential } = secret;
+      const newCredential: ClientCredential = { ...credential, enabled: true };
+      queryClient.setQueryData<ClientCredential[]>(
+        ["clientCredentials", groupId],
+        (existing) => [newCredential, ...(existing ?? [])]
+      );
+
+      onCreated(secret);
+    },
+  });
+
+  const handleCreate = () => {
+    if (!label.trim() || atCap) return;
+    createMutation.mutate({ groupId, label: label.trim(), token });
+  };
+
+  const isLimitError = createMutation.error instanceof ClientCredentialApiError && createMutation.error.status === 409;
+
+  return (
+    <Accordion disableGutters expanded={expanded} onChange={(_, isExpanded) => setExpanded(isExpanded)}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls="create-client-credential-content" id="create-client-credential-header">
+        <SquarePen size={19} />
+        <Typography sx={{ ml: 1 }} component="span">
+          Create client credential
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Stack gap={2}>
+          {atCap && (
+            <Alert severity="warning">{messages.clientCredentialLimitReached(activeCount)}</Alert>
+          )}
+          {isLimitError && (
+            // The server's message is authoritative here - the client's activeCount can be
+            // stale when this 409 comes from a race (e.g. another tab creating concurrently).
+            <Alert severity="error">{(createMutation.error as ClientCredentialApiError).message}</Alert>
+          )}
+          {!atCap && createMutation.isError && !isLimitError && (
+            <Alert severity="error">Failed to create client credential. Please try again.</Alert>
+          )}
+          <Stack direction="row" gap={2} alignItems="flex-start">
+            <TextField
+              label="Label"
+              placeholder="e.g. rspace-integration"
+              variant="outlined"
+              size="small"
+              fullWidth
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              disabled={atCap || createMutation.isPending}
+            />
+            <Box>
+              <Button
+                variant="outlined"
+                onClick={handleCreate}
+                disabled={atCap || !label.trim() || createMutation.isPending}
+              >
+                {createMutation.isPending ? <CircularProgress size={20} /> : "Create"}
+              </Button>
+            </Box>
+          </Stack>
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/SecretRevealPanel.tsx
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/SecretRevealPanel.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  IconButton,
+  InputAdornment,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  ContentCopy as ContentCopyIcon,
+  Visibility as VisibilityIcon,
+  VisibilityOff as VisibilityOffIcon,
+} from "@mui/icons-material";
+import { useSnackbar } from "@/components/snackbar";
+import { copyToClipboardWithNotification } from "@/utils/copy-utils/copyWithNotify";
+import type { ClientCredentialSecret } from "@/services/client-credentials";
+
+const MASKED_VALUE = "•".repeat(24);
+
+function MaskableField({ label, value }: { label: string; value: string }) {
+  const [revealed, setRevealed] = useState(false);
+  const snackbar = useSnackbar();
+
+  const handleCopy = () => copyToClipboardWithNotification(value, `${label} copied to clipboard`, snackbar);
+
+  return (
+    <TextField
+      label={label}
+      value={revealed ? value : MASKED_VALUE}
+      fullWidth
+      size="small"
+      InputProps={{
+        readOnly: true,
+        sx: { fontFamily: "monospace" },
+        endAdornment: (
+          <InputAdornment position="end">
+            <Tooltip title={revealed ? `Hide ${label.toLowerCase()}` : `Reveal ${label.toLowerCase()}`}>
+              <IconButton
+                edge="end"
+                size="small"
+                aria-label={revealed ? `Hide ${label.toLowerCase()}` : `Reveal ${label.toLowerCase()}`}
+                onClick={() => setRevealed((prev) => !prev)}
+              >
+                {revealed ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Copy to clipboard">
+              <IconButton edge="end" size="small" aria-label={`Copy ${label.toLowerCase()}`} onClick={handleCopy}>
+                <ContentCopyIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </InputAdornment>
+        ),
+      }}
+    />
+  );
+}
+
+export function SecretRevealPanel({
+  credential,
+  heading,
+  onClose,
+}: {
+  credential: ClientCredentialSecret;
+  heading: string;
+  onClose: () => void;
+}) {
+  return (
+    <Alert severity="warning" variant="outlined">
+      <Stack gap={1.5}>
+        <Typography variant="subtitle2">{heading}</Typography>
+        <MaskableField label="Client ID" value={credential.clientId} />
+        <MaskableField label="Secret" value={credential.secret} />
+        <Typography variant="body2">
+          Store this secret securely — you won't be able to view it here again without revealing it.
+        </Typography>
+        <Box>
+          <Button size="small" onClick={onClose}>
+            Done
+          </Button>
+        </Box>
+      </Stack>
+    </Alert>
+  );
+}

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/SecretRevealPanel.tsx
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/SecretRevealPanel.tsx
@@ -21,8 +21,11 @@ import type { ClientCredentialSecret } from "@/services/client-credentials";
 
 const MASKED_VALUE = "•".repeat(24);
 
-function MaskableField({ label, value }: { label: string; value: string }) {
-  const [revealed, setRevealed] = useState(false);
+// Client ID is shown in plaintext here, not masked - the table already lists
+// it in plaintext (RAID-826 comment thread), so masking it here would only
+// add friction without hiding anything. Only the secret is sensitive.
+function MaskableField({ label, value, maskable = true }: { label: string; value: string; maskable?: boolean }) {
+  const [revealed, setRevealed] = useState(!maskable);
   const snackbar = useSnackbar();
 
   const handleCopy = () => copyToClipboardWithNotification(value, `${label} copied to clipboard`, snackbar);
@@ -38,16 +41,18 @@ function MaskableField({ label, value }: { label: string; value: string }) {
         sx: { fontFamily: "monospace" },
         endAdornment: (
           <InputAdornment position="end">
-            <Tooltip title={revealed ? `Hide ${label.toLowerCase()}` : `Reveal ${label.toLowerCase()}`}>
-              <IconButton
-                edge="end"
-                size="small"
-                aria-label={revealed ? `Hide ${label.toLowerCase()}` : `Reveal ${label.toLowerCase()}`}
-                onClick={() => setRevealed((prev) => !prev)}
-              >
-                {revealed ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
-              </IconButton>
-            </Tooltip>
+            {maskable && (
+              <Tooltip title={revealed ? `Hide ${label.toLowerCase()}` : `Reveal ${label.toLowerCase()}`}>
+                <IconButton
+                  edge="end"
+                  size="small"
+                  aria-label={revealed ? `Hide ${label.toLowerCase()}` : `Reveal ${label.toLowerCase()}`}
+                  onClick={() => setRevealed((prev) => !prev)}
+                >
+                  {revealed ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+                </IconButton>
+              </Tooltip>
+            )}
             <Tooltip title="Copy to clipboard">
               <IconButton edge="end" size="small" aria-label={`Copy ${label.toLowerCase()}`} onClick={handleCopy}>
                 <ContentCopyIcon fontSize="small" />
@@ -73,7 +78,7 @@ export function SecretRevealPanel({
     <Alert severity="warning" variant="outlined">
       <Stack gap={1.5}>
         <Typography variant="subtitle2">{heading}</Typography>
-        <MaskableField label="Client ID" value={credential.clientId} />
+        <MaskableField label="Client ID" value={credential.clientId} maskable={false} />
         <MaskableField label="Secret" value={credential.secret} />
         <Typography variant="body2">
           Store this secret securely — you won't be able to view it here again without revealing it.

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/SecretRevealPanel.tsx
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/SecretRevealPanel.tsx
@@ -21,11 +21,8 @@ import type { ClientCredentialSecret } from "@/services/client-credentials";
 
 const MASKED_VALUE = "•".repeat(24);
 
-// Client ID is shown in plaintext here, not masked - the table already lists
-// it in plaintext (RAID-826 comment thread), so masking it here would only
-// add friction without hiding anything. Only the secret is sensitive.
-function MaskableField({ label, value, maskable = true }: { label: string; value: string; maskable?: boolean }) {
-  const [revealed, setRevealed] = useState(!maskable);
+function MaskableField({ label, value }: { label: string; value: string }) {
+  const [revealed, setRevealed] = useState(false);
   const snackbar = useSnackbar();
 
   const handleCopy = () => copyToClipboardWithNotification(value, `${label} copied to clipboard`, snackbar);
@@ -41,18 +38,16 @@ function MaskableField({ label, value, maskable = true }: { label: string; value
         sx: { fontFamily: "monospace" },
         endAdornment: (
           <InputAdornment position="end">
-            {maskable && (
-              <Tooltip title={revealed ? `Hide ${label.toLowerCase()}` : `Reveal ${label.toLowerCase()}`}>
-                <IconButton
-                  edge="end"
-                  size="small"
-                  aria-label={revealed ? `Hide ${label.toLowerCase()}` : `Reveal ${label.toLowerCase()}`}
-                  onClick={() => setRevealed((prev) => !prev)}
-                >
-                  {revealed ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
-                </IconButton>
-              </Tooltip>
-            )}
+            <Tooltip title={revealed ? `Hide ${label.toLowerCase()}` : `Reveal ${label.toLowerCase()}`}>
+              <IconButton
+                edge="end"
+                size="small"
+                aria-label={revealed ? `Hide ${label.toLowerCase()}` : `Reveal ${label.toLowerCase()}`}
+                onClick={() => setRevealed((prev) => !prev)}
+              >
+                {revealed ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
             <Tooltip title="Copy to clipboard">
               <IconButton edge="end" size="small" aria-label={`Copy ${label.toLowerCase()}`} onClick={handleCopy}>
                 <ContentCopyIcon fontSize="small" />
@@ -78,7 +73,7 @@ export function SecretRevealPanel({
     <Alert severity="warning" variant="outlined">
       <Stack gap={1.5}>
         <Typography variant="subtitle2">{heading}</Typography>
-        <MaskableField label="Client ID" value={credential.clientId} maskable={false} />
+        <MaskableField label="Client ID" value={credential.clientId} />
         <MaskableField label="Secret" value={credential.secret} />
         <Typography variant="body2">
           Store this secret securely — you won't be able to view it here again without revealing it.

--- a/raid-agency-app/src/pages/service-point/components/client-credentials/useClientCredentialMutations.ts
+++ b/raid-agency-app/src/pages/service-point/components/client-credentials/useClientCredentialMutations.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  fetchClientCredentials,
+  rotateClientCredential,
+  revokeClientCredential,
+  getClientCredentialSecret,
+} from "@/services/client-credentials";
+import { useServicePointMutation } from "@/containers/header/service-point-users/useServicePointMutation";
+import { messages } from "@/constants/messages";
+import type { SnackbarContextInterface } from "@/components/snackbar";
+
+export const useClientCredentials = (groupId: string | undefined, token: string | undefined) => {
+  return useQuery({
+    queryKey: ["clientCredentials", groupId],
+    queryFn: () => fetchClientCredentials({ groupId: groupId as string, token }),
+    enabled: !!groupId && !!token,
+  });
+};
+
+// Cast to the factory's looser severity type, matching the existing
+// useModifyUserAccess-style call sites in useServicePointMutation.ts.
+type LooseSnackbar = { openSnackbar: (message: string, duration?: number, severity?: string) => void };
+
+export const useRotateClientCredential = (groupId: string | undefined, snackbar: SnackbarContextInterface) => {
+  return useServicePointMutation({
+    mutationFn: rotateClientCredential,
+    successMessage: messages.clientCredentialRotated,
+    invalidateQueries: [["clientCredentials", groupId]],
+    snackbar: snackbar as LooseSnackbar,
+  });
+};
+
+export const useRevokeClientCredential = (groupId: string | undefined, snackbar: SnackbarContextInterface) => {
+  return useServicePointMutation({
+    mutationFn: revokeClientCredential,
+    successMessage: messages.clientCredentialRevoked,
+    invalidateQueries: [["clientCredentials", groupId]],
+    snackbar: snackbar as LooseSnackbar,
+  });
+};
+
+// Not routed through useServicePointMutation: viewing a secret isn't a
+// state-changing action worth a success snackbar or a cache invalidation,
+// just an on-demand fetch of the current value.
+export const useViewClientCredentialSecret = () => {
+  return useMutation({ mutationFn: getClientCredentialSecret });
+};

--- a/raid-agency-app/src/services/client-credentials/index.tsx
+++ b/raid-agency-app/src/services/client-credentials/index.tsx
@@ -1,0 +1,144 @@
+import { authService } from "@/services/auth-service.ts";
+import { getRuntimeConfig } from "@/config";
+
+const kcClientCredentialBase = () => {
+  const { keycloak } = getRuntimeConfig();
+  return `${keycloak.url}/realms/${keycloak.realm}/client-credential`;
+};
+
+export interface ClientCredential {
+  clientId: string;
+  label: string;
+  createdAt: string;
+  lastRotatedAt: string | null;
+  enabled: boolean;
+}
+
+export interface ClientCredentialSecret extends Omit<ClientCredential, "enabled"> {
+  secret: string;
+}
+
+// The create endpoint's 409 (credential cap reached) needs to be surfaced to
+// the user with its own actionable message, not folded into a generic
+// failure - so it carries the HTTP status through, unlike the other calls.
+export class ClientCredentialApiError extends Error {
+  constructor(message: string, public status: number) {
+    super(message);
+    this.name = "ClientCredentialApiError";
+  }
+}
+
+export async function fetchClientCredentials({
+  groupId,
+  token,
+}: {
+  groupId: string;
+  token: string | undefined;
+}): Promise<ClientCredential[]> {
+  try {
+    if (token === undefined) {
+      throw new Error("Error: Keycloak token not set");
+    }
+    const response = await authService.fetchWithAuth(
+      `${kcClientCredentialBase()}?groupId=${encodeURIComponent(groupId)}`
+    );
+    return await response.json();
+  } catch (error) {
+    const errorMessage = "Error: Client credentials could not be fetched";
+    console.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+}
+
+export async function createClientCredential({
+  groupId,
+  label,
+  token,
+}: {
+  groupId: string;
+  label: string;
+  token: string | undefined;
+}): Promise<ClientCredentialSecret> {
+  if (token === undefined) {
+    throw new Error("Error: Keycloak token not set");
+  }
+  const response = await authService.fetchWithAuth(kcClientCredentialBase(), {
+    method: "POST",
+    body: JSON.stringify({ groupId, label }),
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    throw new ClientCredentialApiError(
+      body?.error || "Error: Client credential could not be created",
+      response.status
+    );
+  }
+  return await response.json();
+}
+
+export async function getClientCredentialSecret({
+  clientId,
+  token,
+}: {
+  clientId: string;
+  token: string | undefined;
+}): Promise<ClientCredentialSecret> {
+  try {
+    if (token === undefined) {
+      throw new Error("Error: Keycloak token not set");
+    }
+    const response = await authService.fetchWithAuth(
+      `${kcClientCredentialBase()}/secret?clientId=${encodeURIComponent(clientId)}`
+    );
+    return await response.json();
+  } catch (error) {
+    const errorMessage = "Error: Client credential secret could not be retrieved";
+    console.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+}
+
+export async function rotateClientCredential({
+  clientId,
+  token,
+}: {
+  clientId: string;
+  token: string | undefined;
+}): Promise<ClientCredentialSecret> {
+  try {
+    if (token === undefined) {
+      throw new Error("Error: Keycloak token not set");
+    }
+    const response = await authService.fetchWithAuth(`${kcClientCredentialBase()}/rotate`, {
+      method: "POST",
+      body: JSON.stringify({ clientId }),
+    });
+    return await response.json();
+  } catch (error) {
+    const errorMessage = "Error: Client credential could not be rotated";
+    console.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+}
+
+export async function revokeClientCredential({
+  clientId,
+  token,
+}: {
+  clientId: string;
+  token: string | undefined;
+}): Promise<void> {
+  try {
+    if (token === undefined) {
+      throw new Error("Error: Keycloak token not set");
+    }
+    await authService.fetchWithAuth(
+      `${kcClientCredentialBase()}?clientId=${encodeURIComponent(clientId)}`,
+      { method: "DELETE" }
+    );
+  } catch (error) {
+    const errorMessage = "Error: Client credential could not be revoked";
+    console.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+}


### PR DESCRIPTION
## What and why

RAID-826: a self-service screen so a Service Point Admin can create, view, rotate, and revoke their service point's client credentials, without asking ARDC staff to do it in Keycloak. Calls the RAID-827 IAM endpoints directly.

Ticket: [RAID-826](https://ardc.atlassian.net/browse/RAID-826). Backend: [RAID-827](https://ardc.atlassian.net/browse/RAID-827) (shipped, verified against a real IAM build — see below).

## What changed

- **New API layer** (`src/services/client-credentials/`) calling the IAM host's `/realms/raid/client-credential[...]` endpoints directly (create/list/rotate/revoke/get-secret), following the existing `keycloak-groups` precedent.
- **New scoped-role check** — `isServicePointAdminOf(groupId)` in `useAuthHelper.ts`. The backend requires the scoped `service-point-admin:<groupId>` realm role (or Operator) and rejects the flat `group-admin` role; the frontend had no code to check a scoped/colon-style role before this.
- **Service Point detail page restructured into a left-sidebar dashboard**: "Update service point" (operator-only), "Users", and "Client credentials" are now sections switched via a sidebar nav (not tabs), each gated by the same role rules as before. The active section is reflected in the URL (`?tab=`) for deep-linking. The content panel is bounded to the viewport and scrolls internally, so the sidebar stays visible instead of scrolling away with a long list.
- **Client credentials table**: label, created, last-rotated, status, actions — matching the ticket's AC exactly (no "last used", no Client ID column).
- **Secret reveal panel**: shown after create/rotate/view-secret, both Client ID and Secret masked-by-default with a reveal toggle and copy-to-clipboard, plus the required "store this securely" reminder.

## Design decisions worth flagging

- **Tabs → sidebar dashboard.** Originally built as two tabs (Users / Client credentials). Revisited after discussing the RAiD display page's upcoming left-nav pattern on the ticket — moved to a sidebar so "Update service point" (previously a separate card) joins the other two sections under one consistent nav. This is a **switcher** (one section rendered at a time), not the RAiD page's **scrollspy** (all sections stacked, nav just jumps/highlights): Update Service Point is a one-shot operator-only edit action, not a peer of the two ongoing management panels, so stacking it into the same continuous scroll didn't make sense.
- **Client ID isn't in the table.** The AC only calls for label/created/last-rotated in the list. An earlier revision added a Client ID column (useful for support/identification) and masked it in the secret panel to match the AC's "masked by default" scenario — a reviewer comment on the ticket pointed out the resulting inconsistency (masked in the panel, plaintext in the table). Resolved by removing the column rather than unmasking further, since it was never actually required.

## Known follow-ups (not blockers here)

- Nothing on the RAiD API side yet consumes the `service-point-user:<groupId>` role a minted credential gets, so a credential can be fully managed here but can't yet authorise real API calls — tracked as a separate backend follow-up.
- e2e coverage exercises the Operator short-circuit, not the scoped `service-point-admin:<groupId>` role's own path directly — none of the existing e2e personas hold that scoped role, and provisioning one needs real Keycloak realm changes across environments (out of scope here).

## Test plan

- [x] Unit tests (Vitest): 8 new tests covering create (incl. at-cap and 409 handling), mask/reveal/copy, rotate, revoke, empty state. Full suite green (155 tests, 19 files).
- [x] e2e (Playwright): full lifecycle against a real IAM backend — create, masked/reveal/copy secret, rotate, revoke. Green in CI.
- [x] `tsc` + `vite build` clean.
- [x] Manually verified locally against a rebuilt IAM container (the shipped backend jar wasn't in the running dev container until rebuilt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
