### PR TITLE
RAID-876: restore null-safe read in raid list endpoints

### DIFF
--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/RaidIngestService.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/RaidIngestService.java
@@ -6,10 +6,7 @@ import au.org.raid.api.factory.RaidRecordFactory;
 import au.org.raid.api.repository.RaidRepository;
 import au.org.raid.api.service.keycloak.KeycloakService;
 import au.org.raid.api.util.TokenUtil;
-import au.org.raid.db.jooq.tables.records.RaidRecord;
 import au.org.raid.idl.raidv2.model.RaidDto;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,7 +39,6 @@ public class RaidIngestService {
     private final CacheableRaidService cacheableRaidService;
     private final RaidHistoryService raidHistoryService;
     private final RaidDtoReadService raidDtoReadService;
-    private final ObjectMapper objectMapper;
     private final KeycloakService keycloakService;
 
     public void create(final RaidDto raid) {
@@ -187,26 +183,16 @@ public class RaidIngestService {
         final var isServicePointUser = TokenUtil.hasRole(TokenUtil.SERVICE_POINT_USER_ROLE);
 
         return raidRepository.findAllViewable(servicePointId, isServicePointUser, handles)
-                .stream().map(RaidRecord::getMetadata)
-                .map(raidDto -> {
-                    try {
-                        return objectMapper.readValue(raidDto.data(), RaidDto.class);
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException(e);
-                    }
-                }).collect(Collectors.toList());
+                .stream()
+                .map(record -> raidDtoReadService.toRaidDto(record)
+                        .orElseGet(() -> cacheableRaidService.build(record)))
+                .collect(Collectors.toList());
     }
 
     public List<RaidDto> findAll() {
         return raidRepository.findAll().stream()
-                .map(RaidRecord::getMetadata)
-                .map(raidDto -> {
-                    try {
-                        return objectMapper.readValue(raidDto.data(), RaidDto.class);
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException(e);
-                    }
-                })
+                .map(record -> raidDtoReadService.toRaidDto(record)
+                        .orElseGet(() -> cacheableRaidService.build(record)))
                 .collect(Collectors.toList());
     }
 

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/service/RaidIngestServiceTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/service/RaidIngestServiceTest.java
@@ -4,14 +4,17 @@ import au.org.raid.api.factory.HandleFactory;
 import au.org.raid.api.factory.RaidRecordFactory;
 import au.org.raid.api.repository.RaidRepository;
 import au.org.raid.api.service.keycloak.KeycloakService;
+import au.org.raid.api.service.keycloak.dto.RaidPermissionsResponse;
+import au.org.raid.api.util.TokenUtil;
 import au.org.raid.db.jooq.tables.records.RaidRecord;
 import au.org.raid.idl.raidv2.model.RaidDto;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
@@ -61,8 +64,6 @@ class RaidIngestServiceTest {
     RaidHistoryService raidHistoryService;
     @Mock
     RaidDtoReadService raidDtoReadService;
-    @Mock
-    ObjectMapper objectMapper;
     @Mock
     KeycloakService keycloakService;
     @InjectMocks
@@ -131,6 +132,113 @@ class RaidIngestServiceTest {
         when(cacheableRaidService.build(raidRecord)).thenReturn(RAID_DTO);
 
         final var result = raidIngestService.findAllByServicePointId(servicePointId);
+
+        assertThat(result, is(List.of(RAID_DTO)));
+    }
+
+    @Test
+    @DisplayName("findAllByServicePointIdOrHandleIn() delegates resolution to RaidDtoReadService")
+    void findAllByServicePointIdOrHandleIn() {
+        final var servicePointId = 123L;
+        final var userId = "user-id";
+        final var raidRecord = new RaidRecord().setHandle(HANDLE);
+
+        try (MockedStatic<TokenUtil> tokenUtil = Mockito.mockStatic(TokenUtil.class)) {
+            tokenUtil.when(TokenUtil::getUserId).thenReturn(userId);
+            tokenUtil.when(() -> TokenUtil.hasRole(TokenUtil.SERVICE_POINT_USER_ROLE)).thenReturn(true);
+
+            when(keycloakService.getRaidPermissions(userId))
+                    .thenReturn(new RaidPermissionsResponse(List.of(), List.of()));
+            when(raidRepository.findAllViewable(servicePointId, true, List.of()))
+                    .thenReturn(List.of(raidRecord));
+            when(raidDtoReadService.toRaidDto(raidRecord)).thenReturn(Optional.of(RAID_DTO));
+
+            final var result = raidIngestService.findAllByServicePointIdOrHandleIn(servicePointId);
+
+            assertThat(result, is(List.of(RAID_DTO)));
+        }
+    }
+
+    @Test
+    @DisplayName("findAllByServicePointIdOrHandleIn() falls back to cacheableRaidService when metadata is null")
+    void findAllByServicePointIdOrHandleInFallsBackWhenMetadataIsNull() {
+        final var servicePointId = 123L;
+        final var userId = "user-id";
+
+        // RAID-876: a record with no materialised metadata previously caused a
+        // NullPointerException that failed the whole list, not just this record.
+        final var raidRecord = new RaidRecord().setHandle(HANDLE);
+        raidRecord.setMetadata(null);
+
+        try (MockedStatic<TokenUtil> tokenUtil = Mockito.mockStatic(TokenUtil.class)) {
+            tokenUtil.when(TokenUtil::getUserId).thenReturn(userId);
+            tokenUtil.when(() -> TokenUtil.hasRole(TokenUtil.SERVICE_POINT_USER_ROLE)).thenReturn(true);
+
+            when(keycloakService.getRaidPermissions(userId))
+                    .thenReturn(new RaidPermissionsResponse(List.of(), List.of()));
+            when(raidRepository.findAllViewable(servicePointId, true, List.of()))
+                    .thenReturn(List.of(raidRecord));
+            when(raidDtoReadService.toRaidDto(raidRecord)).thenReturn(Optional.empty());
+            when(cacheableRaidService.build(raidRecord)).thenReturn(RAID_DTO);
+
+            final var result = raidIngestService.findAllByServicePointIdOrHandleIn(servicePointId);
+
+            assertThat(result, is(List.of(RAID_DTO)));
+        }
+    }
+
+    @Test
+    @DisplayName("findAllByServicePointIdOrHandleIn() returns resolvable raids alongside one with null metadata")
+    void findAllByServicePointIdOrHandleInResolvesMixedRecords() {
+        final var servicePointId = 123L;
+        final var userId = "user-id";
+
+        final var populatedRecord = new RaidRecord().setHandle(HANDLE);
+        final var nullMetadataRecord = new RaidRecord().setHandle("other/handle");
+        nullMetadataRecord.setMetadata(null);
+
+        try (MockedStatic<TokenUtil> tokenUtil = Mockito.mockStatic(TokenUtil.class)) {
+            tokenUtil.when(TokenUtil::getUserId).thenReturn(userId);
+            tokenUtil.when(() -> TokenUtil.hasRole(TokenUtil.SERVICE_POINT_USER_ROLE)).thenReturn(true);
+
+            when(keycloakService.getRaidPermissions(userId))
+                    .thenReturn(new RaidPermissionsResponse(List.of(), List.of()));
+            when(raidRepository.findAllViewable(servicePointId, true, List.of()))
+                    .thenReturn(List.of(populatedRecord, nullMetadataRecord));
+            when(raidDtoReadService.toRaidDto(populatedRecord)).thenReturn(Optional.of(RAID_DTO));
+            when(raidDtoReadService.toRaidDto(nullMetadataRecord)).thenReturn(Optional.empty());
+            when(cacheableRaidService.build(nullMetadataRecord)).thenReturn(RAID_DTO);
+
+            final var result = raidIngestService.findAllByServicePointIdOrHandleIn(servicePointId);
+
+            assertThat(result, is(List.of(RAID_DTO, RAID_DTO)));
+        }
+    }
+
+    @Test
+    @DisplayName("findAll() delegates resolution to RaidDtoReadService")
+    void findAll() {
+        final var raidRecord = new RaidRecord().setHandle(HANDLE);
+
+        when(raidRepository.findAll()).thenReturn(List.of(raidRecord));
+        when(raidDtoReadService.toRaidDto(raidRecord)).thenReturn(Optional.of(RAID_DTO));
+
+        final var result = raidIngestService.findAll();
+
+        assertThat(result, is(List.of(RAID_DTO)));
+    }
+
+    @Test
+    @DisplayName("findAll() falls back to cacheableRaidService when metadata is null")
+    void findAllFallsBackWhenMetadataIsNull() {
+        final var raidRecord = new RaidRecord().setHandle(HANDLE);
+        raidRecord.setMetadata(null);
+
+        when(raidRepository.findAll()).thenReturn(List.of(raidRecord));
+        when(raidDtoReadService.toRaidDto(raidRecord)).thenReturn(Optional.empty());
+        when(cacheableRaidService.build(raidRecord)).thenReturn(RAID_DTO);
+
+        final var result = raidIngestService.findAll();
 
         assertThat(result, is(List.of(RAID_DTO)));
     }

--- a/documentation/20260908-raid-876-null-metadata-list-500.md
+++ b/documentation/20260908-raid-876-null-metadata-list-500.md
@@ -1,0 +1,113 @@
+# RAID-876: GET /raid/ 500s a whole service point when any raid has NULL metadata
+
+**Date:** 2026-09-08
+**JIRA:** [RAID-876](https://ardc.atlassian.net/browse/RAID-876)
+**PR:** raid-au [#PR](https://github.com/au-research/raid-au/pull/PR)
+
+## What was wrong
+
+`GET /raid/` returned 500 for an entire service point if any single raid row had a
+`NULL` metadata column:
+
+```
+ERROR a.o.r.a.e.raidv2.RaidExceptionHandler : Unhandled exception
+java.lang.NullPointerException: Cannot invoke "org.jooq.JSONB.data()" because "raidDto" is null
+```
+
+`RaidIngestService.findAllByServicePointIdOrHandleIn` and `RaidIngestService.findAll`
+read the materialised `metadata` column directly, with no null guard:
+
+```java
+.stream().map(RaidRecord::getMetadata)
+.map(raidDto -> objectMapper.readValue(raidDto.data(), RaidDto.class))
+```
+
+`RaidRecord.getMetadata()` returns `null` for such rows, so `JSONB.data()` throws. One
+unresolvable row took down the whole list, not just that row.
+
+## How it got there
+
+Three changes, in sequence:
+
+| Change | Effect | Safe? |
+|---|---|---|
+| `V27__normalise_raid_tables.sql` | Normalised the JSONB blob into relational tables; `alter column metadata drop not null` | Yes, nothing read it |
+| RAID-518 (`59bc91bd`) | Reintroduced `metadata` as a materialised cache written on mint and update | Yes, reads still went via the guarded path |
+| **RAID-507 (`acde8d82`)** | **List endpoints read the column directly for speed, dropping both fallbacks** | **No** |
+
+The pre-RAID-507 implementation was null-safe by design:
+
+```java
+raidDtoReadService.toRaidDto(record)
+        .orElseGet(() -> cacheableRaidService.build(record));
+```
+
+`RaidDtoReadService.toRaidDto` explicitly guards `record.getMetadata() != null` and falls
+back to raid history; `CacheableRaidService.build` is a second fallback that rebuilds the
+DTO from the relational tables. RAID-507 bypassed both.
+
+Four sibling methods on the same class (`findAllByServicePointIdOrNotConfidential`,
+`findAllByServicePointId`, `findAllByContributor`, `findAllByOrganisation`) never stopped
+using the safe pattern, so the two affected methods were inconsistent with the rest of the
+class.
+
+## Why rows have NULL metadata
+
+`RaidRecordFactory` sets `metadata_schema` but never `metadata`. Rows minted between V27
+and RAID-518 that have not been updated since therefore have `NULL` metadata.
+
+`RaidMetadataBackfillService` exists to populate them, but:
+
+- it is only reachable through a manual admin endpoint, `POST /backfill-metadata`
+  (`AdminController:17`), so it does not run on deploy; and
+- it reconstructs through `raidHistoryService.findByHandle`, skipping any handle it cannot
+  rebuild:
+
+```java
+log.warn("Could not reconstruct RaidDto for handle {}, skipping backfill", record.getHandle());
+```
+
+Observed in the `raid-sandbox` environment, where all three seeded raids have `NULL`
+metadata and `raid_archive` is empty, so backfill could not have helped.
+
+## What changed
+
+Both methods now use the same guarded pattern as their four siblings:
+
+```java
+return raidRepository.findAllViewable(servicePointId, isServicePointUser, handles)
+        .stream()
+        .map(record -> raidDtoReadService.toRaidDto(record)
+                .orElseGet(() -> cacheableRaidService.build(record)))
+        .collect(Collectors.toList());
+```
+
+This preserves the RAID-507 performance intent. `toRaidDto` still tries the materialised
+column first, so populated rows take the fast path unchanged; only `NULL` or unparseable
+rows pay the assembly cost.
+
+The now-unused `ObjectMapper` field and three imports were removed from
+`RaidIngestService`.
+
+## Tests
+
+Five tests added to `RaidIngestServiceTest`:
+
+- `findAllByServicePointIdOrHandleIn()` delegates resolution to `RaidDtoReadService`
+- `findAllByServicePointIdOrHandleIn()` falls back to `cacheableRaidService` when metadata is null
+- `findAllByServicePointIdOrHandleIn()` returns resolvable raids alongside one with null metadata
+- `findAll()` delegates resolution to `RaidDtoReadService`
+- `findAll()` falls back to `cacheableRaidService` when metadata is null
+
+All five were verified to fail against the unfixed code with the exact production NPE, then
+pass with the fix. Full `./gradlew build` and `./gradlew intTest` both green locally.
+
+## Follow-up worth considering
+
+Not addressed here, since they are beyond the scope of this bug:
+
+- **Backfill is manual.** Nothing runs `POST /backfill-metadata` on deploy, so `NULL`
+  metadata rows persist indefinitely in every environment.
+- **Prod exposure is unquantified.** Prod raids generally do have history, so backfill would
+  mostly succeed there, but no one has checked whether prod holds rows that would fail to
+  reconstruct.

--- a/documentation/20260908-raid-876-null-metadata-list-500.md
+++ b/documentation/20260908-raid-876-null-metadata-list-500.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-08
 **JIRA:** [RAID-876](https://ardc.atlassian.net/browse/RAID-876)
-**PR:** raid-au [#PR](https://github.com/au-research/raid-au/pull/PR)
+**PR:** raid-au [#648](https://github.com/au-research/raid-au/pull/648)
 
 ## What was wrong
 


### PR DESCRIPTION
> **Targets `feature/RAID-806`**, not `main`, so the fix reaches the sandbox rehearsal without waiting on the story to merge. Branch is rebased onto `feature/RAID-806`, so the diff is just the two RAID-876 commits.

## Problem

`GET /raid/` returns 500 for an **entire service point** when any single raid row has a `NULL` metadata column:

```
java.lang.NullPointerException: Cannot invoke "org.jooq.JSONB.data()" because "raidDto" is null
```

`RaidIngestService.findAllByServicePointIdOrHandleIn` and `findAll` read the materialised `metadata` column with no null guard. One unresolvable row takes down the whole list, not just that row.

Observed in `raid-sandbox`, where all three seeded raids have `NULL` metadata.

## Cause

Introduced by RAID-507 (`acde8d82`), which switched these two methods from building the DTO to reading the materialised column for speed. The previous implementation was null-safe:

```java
raidDtoReadService.toRaidDto(record).orElseGet(() -> cacheableRaidService.build(record));
```

`toRaidDto` explicitly guards `record.getMetadata() != null` and falls back to raid history; `CacheableRaidService.build` is a second fallback rebuilding from the relational tables. RAID-507 bypassed both.

Rows have `NULL` metadata because V27 dropped `NOT NULL` when the blob was normalised, `RaidRecordFactory` never populates it, and RAID-518 only reintroduced it as a cache written on mint/update. `RaidMetadataBackfillService` can populate historic rows but is manual (`POST /backfill-metadata`) and skips handles it cannot reconstruct.

## Fix

Both methods now use the same guarded pattern as the four sibling methods on the class that never stopped using it (`findAllByServicePointIdOrNotConfidential`, `findAllByServicePointId`, `findAllByContributor`, `findAllByOrganisation`).

This preserves RAID-507's performance intent: `toRaidDto` tries the materialised column first, so populated rows take the fast path unchanged, and only `NULL` or unparseable rows pay the assembly cost.

Also removes the now-unused `ObjectMapper` field and three imports.

## Tests

Five tests added to `RaidIngestServiceTest`. Each was verified to **fail against the unfixed code** with the exact production NPE, then pass with the fix.

Validated against the `feature/RAID-806` base with a freshly recreated database (26 migrations through V47, including the V46 renumbering):

- `./gradlew build` green
- `./gradlew intTest` green locally

## Not addressed here

- Backfill is manual, so `NULL` metadata rows persist indefinitely in every environment
- Prod exposure is unquantified — no one has checked whether prod holds rows that would fail to reconstruct

🤖 Generated with [Claude Code](https://claude.com/claude-code)