### PR TITLE
RAID-881: add SURF to the Registration Agency register

### DIFF
--- a/api-svc/raid-api/src/main/resources/registration-agencies.yaml
+++ b/api-svc/raid-api/src/main/resources/registration-agencies.yaml
@@ -31,12 +31,18 @@ agencies:
     ror: https://ror.org/038sjwq14
     block: 2
 
+  # `instance` omitted: SURF's hostname is not recorded here yet. It is
+  # documentation only — nothing resolves it — so it can be added later.
+  - name: SURF
+    ror: https://ror.org/009vhk114
+    block: 3
+
   - name: SDSC
     instance: projectpid.org
     ror: https://ror.org/04mg3nk07
     block: 4
 
-  # TODO:RL SURF (block 3), DRAC (block 5) and TIB (block 6) are allocated but
-  # their RORs are not yet known. SURF is deployed, so its instance will refuse
-  # to start until its entry is added here. Blocks 3, 5 and 6 are reserved for
-  # them and must not be allocated to anyone else.
+  # TODO:RL DRAC (block 5) and TIB (block 6) are allocated but their RORs are not
+  # yet known. Neither is deployed, so their absence blocks nothing today, but an
+  # instance whose ROR is missing here refuses to start. Blocks 5 and 6 are
+  # reserved for them and must not be allocated to anyone else.

--- a/api-svc/raid-api/src/test/java/au/org/raid/api/config/servicepoint/RegistrationAgencyRegisterTest.java
+++ b/api-svc/raid-api/src/test/java/au/org/raid/api/config/servicepoint/RegistrationAgencyRegisterTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RegistrationAgencyRegisterTest {
     private static final String ARDC_ROR = "https://ror.org/038sjwq14";
+    private static final String SURF_ROR = "https://ror.org/009vhk114";
     private static final String SDSC_ROR = "https://ror.org/04mg3nk07";
 
     private static Resource register(final String yaml) {
@@ -28,7 +29,22 @@ class RegistrationAgencyRegisterTest {
         final var subject = shipped();
 
         assertThat(subject.servicePointIdStart(ARDC_ROR)).isEqualTo(20000000L);
+        assertThat(subject.servicePointIdStart(SURF_ROR)).isEqualTo(30000000L);
         assertThat(subject.servicePointIdStart(SDSC_ROR)).isEqualTo(40000000L);
+    }
+
+    /**
+     * SURF is deployed, so an instance of theirs starting is not hypothetical: a
+     * release that omits their ROR stops their service. This asserts against the
+     * shipped register rather than a fixture, so removing the entry fails here.
+     */
+    @Test
+    @DisplayName("resolves every deployed agency's ROR")
+    void resolvesDeployedAgencies() {
+        final var subject = shipped();
+
+        assertThat(subject.servicePointIdStart(SURF_ROR)).isPositive();
+        assertThat(subject.servicePointIdStart(SDSC_ROR)).isPositive();
     }
 
     @Test


### PR DESCRIPTION
[RAID-881](https://ardc.atlassian.net/browse/RAID-881), sub-task of
[RAID-806](https://ardc.atlassian.net/browse/RAID-806). Targets
`feature/RAID-806`.

This clears the blocker on #651.

## Why

SURF is allocated Service Point ID block 3, but was absent from
`registration-agencies.yaml` because their ROR was not known when RAID-862
landed. An instance whose `registration-agency-identifier` is missing from the
register **refuses to start** — deliberately, so a mis-set agency identity fails
loudly rather than silently minting into another agency's block. SURF is
deployed, so releasing RAID-806 without their entry would have stopped their
service.

## What changed

SURF added at block 3, so their Service Point IDs start at `30000000`.

The ROR was verified against the ROR API rather than taken on trust:
`https://ror.org/009vhk114` resolves to SURF, status active, Netherlands.

`instance` is omitted. It is documentation only and nothing resolves it, and
SURF's hostname is not known here — better absent than invented.

DRAC (block 5) and TIB (block 6) are still unknown and stay reserved. The
`TODO:RL` is narrowed to them, and now records that neither is deployed, so
their absence blocks nothing today.

## Testing

`RegistrationAgencyRegisterTest` gains SURF to the derivation assertion
(`30000000`), plus a new `resolvesDeployedAgencies` case. That one asserts
against the *shipped* register rather than a fixture, so deleting SURF's or
SDSC's entry fails the build — the property worth protecting is that a deployed
agency can always start.

- `./gradlew :api-svc:raid-api:test` green.
- Full `intTest` green locally: 235 tests, 0 failures, 0 errors, 16 skipped.

## Note

The operator doc's allocation table maps block numbers to first ids and is not
an agency roster, so it needs no change.