### PR TITLE
Fix ISNI contributor identifier helper text and tooltip

### DIFF
--- a/raid-agency-app/e2e/tests/07-contributor-identifier-inference.spec.ts
+++ b/raid-agency-app/e2e/tests/07-contributor-identifier-inference.spec.ts
@@ -1,6 +1,6 @@
-// RAID-861: E2E tests for auto-detect schemaUri recognition on the
-// Contributor identifier field (ISNI), plus a regression guard confirming
-// the existing ORCID lookup widget behaviour is unaffected.
+// RAID-861 / bug/isni-helpertext: E2E tests for auto-detect schemaUri
+// recognition on the Contributor identifier field (ISNI), plus a regression
+// guard confirming the existing ORCID lookup widget behaviour is unaffected.
 //
 // The backend has a real ISNI validator (ISO 7064 MOD 11-2 check-digit, see
 // ContributorValidator/IsniValidator) but resolves ISNI IDs against a live
@@ -69,6 +69,20 @@ test.describe("Contributor identifier auto-detect", { tag: "@local" }, () => {
     await expect(page.getByText("The entered ID is an ISNI")).toBeVisible();
     await expect(page.locator('[aria-label="directions"]')).toHaveCount(0);
 
+    // bug/isni-helpertext: the helper text and tooltip must switch to
+    // ISNI-specific copy too, rather than continuing to describe ORCID's
+    // name-lookup behaviour once an ISNI has been entered.
+    // The Contributor card also has its own section-header info tooltip
+    // sharing the same static id, so scope to the last one - the ORCID/ISNI
+    // identifier field's own tooltip, rendered after it.
+    const contributorTooltipButton = page.locator("#contributor #tooltip-button").last();
+    await expect(page.getByText(/Enter a valid ISNI URL/)).toBeVisible();
+    await expect(page.getByText(/Enter a valid ORCID iD/)).not.toBeVisible();
+    await contributorTooltipButton.click();
+    await expect(page.getByText("ISNI Info")).toBeVisible();
+    await expect(page.getByText(/Credit Name/)).not.toBeVisible();
+    await contributorTooltipButton.click(); // close it before saving
+
     const [request] = await Promise.all([
       page.waitForRequest(
         (req) => req.method() === "POST" && /\/raid\/?$/.test(new URL(req.url()).pathname)
@@ -91,6 +105,21 @@ test.describe("Contributor identifier auto-detect", { tag: "@local" }, () => {
 
     await expect(page.getByText(/^Name:/)).toBeVisible();
     await expect(page.locator('[aria-label="directions"]')).toHaveCount(1);
+
+    // bug/isni-helpertext regression guard: ORCID's own helper text/tooltip
+    // must stay exactly as before - no ISNI copy has leaked in. (The exact
+    // ORCID helper text is environment-configurable via app-config.json's
+    // orcid.helpText, so we only assert the ISNI-specific strings are absent
+    // and the ORCID tooltip title is unchanged.)
+    // The Contributor card also has its own section-header info tooltip
+    // sharing the same static id, so scope to the last one - the ORCID/ISNI
+    // identifier field's own tooltip, rendered after it.
+    const contributorTooltipButton = page.locator("#contributor #tooltip-button").last();
+    await expect(page.getByText(/Enter a valid ISNI URL/)).not.toBeVisible();
+    await contributorTooltipButton.click();
+    await expect(page.getByText("ORCID Lookup Info")).toBeVisible();
+    await expect(page.getByText("ISNI Info")).not.toBeVisible();
+    await contributorTooltipButton.click();
 
     await formPage.save();
     await formPage.waitForSuccessfulSave();

--- a/raid-agency-app/e2e/tests/07-contributor-identifier-inference.spec.ts
+++ b/raid-agency-app/e2e/tests/07-contributor-identifier-inference.spec.ts
@@ -61,6 +61,16 @@ async function setUpFormWithContributorRow(page: import("@playwright/test").Page
 }
 
 test.describe("Contributor identifier auto-detect", { tag: "@local" }, () => {
+  test("the empty field's placeholder mentions ISNI alongside ORCID", async ({
+    page,
+  }) => {
+    await setUpFormWithContributorRow(page);
+
+    await expect(
+      page.locator('#contributor input[aria-label="search orcid"]')
+    ).toHaveAttribute("placeholder", /ISNI/);
+  });
+
   test("pasting an ISNI URL infers the ISNI schemaUri and shows a plain identifier field", async ({
     page,
   }) => {

--- a/raid-agency-app/e2e/tests/07-contributor-identifier-inference.spec.ts
+++ b/raid-agency-app/e2e/tests/07-contributor-identifier-inference.spec.ts
@@ -21,6 +21,7 @@ import { DateSection } from "../page-objects/sections/DateSection";
 import { AccessSection } from "../page-objects/sections/AccessSection";
 import { ContributorSection } from "../page-objects/sections/ContributorSection";
 import { validEmbargoExpiry } from "../utils/date-helpers";
+import { extractPrefixSuffixFromUrl } from "../utils/wait-helpers";
 
 const START_DATE = "2024-03-01";
 const EMBARGOED_LABEL = "Embargoed Access";
@@ -162,5 +163,52 @@ test.describe("Contributor identifier auto-detect", { tag: "@local" }, () => {
     await expect(page.getByText("ISNI", { exact: true })).toBeVisible();
     await expect(page.getByText("ORCID", { exact: true })).not.toBeVisible();
     await expect(page.getByText(MOCKED_ISNI_URL).first()).toBeVisible();
+  });
+
+  test("RAiD edit page keeps the ISNI identifier editable instead of showing an ORCID-style status", async ({
+    page,
+  }) => {
+    const { formPage, contributorSection } = await setUpFormWithContributorRow(page);
+
+    await contributorSection.fillOrcidId(0, MOCKED_ISNI_URL);
+    await formPage.save();
+    await formPage.waitForSuccessfulSave();
+
+    const [prefix, suffix] = extractPrefixSuffixFromUrl(page.url());
+    await formPage.goto(`/raids/${prefix}/${suffix}/edit`);
+
+    // Bug fix: once a saved contributor has a "status" field, ORCID's
+    // identifier field locks and shows a read-only "Contributor Status"
+    // (e.g. AWAITING_AUTHENTICATION) instead - that status concept doesn't
+    // apply to ISNI (no OAuth flow), so the field must stay editable and
+    // pre-filled with the existing ISNI, with no status text shown.
+    await expect(page.getByText(/AWAITING_AUTHENTICATION|AUTHENTICATED|UNAUTHENTICATED/)).not.toBeVisible();
+    await expect(page.locator('#contributor input[aria-label="search orcid"]')).toHaveValue(MOCKED_ISNI_URL);
+  });
+
+  test("correcting an invalid id to a valid ISNI lets the next save succeed without a stale error", async ({
+    page,
+  }) => {
+    const { formPage, contributorSection } = await setUpFormWithContributorRow(page);
+
+    // Trigger the "Invalid ORCID ID" validation error dialog first (same
+    // setup as 04-validation.spec.ts's ORCID-format test).
+    await contributorSection.fillOrcidId(0, "not-an-orcid");
+    await formPage.save();
+    await expect(page.locator("text=Invalid ORCID ID").first()).toBeVisible({
+      timeout: 5000,
+    });
+    await page.getByRole("button", { name: "Close", exact: true }).last().click();
+
+    // Bug fix: the id field's setValue call omitted shouldValidate, so RHF's
+    // internal error state for this field never actually cleared once a
+    // corrected value was entered - re-saving kept reopening the exact same
+    // stale "Invalid ORCID ID" dialog even though the id was now a valid,
+    // recognised ISNI.
+    await contributorSection.fillOrcidId(0, ISNI_URL);
+    await formPage.save();
+    await expect(page.locator("text=Invalid ORCID ID").first()).not.toBeVisible({
+      timeout: 5000,
+    });
   });
 });

--- a/raid-agency-app/e2e/tests/07-contributor-identifier-inference.spec.ts
+++ b/raid-agency-app/e2e/tests/07-contributor-identifier-inference.spec.ts
@@ -27,6 +27,11 @@ const EMBARGOED_LABEL = "Embargoed Access";
 const ACCESS_STATEMENT = "Embargoed for contributor-identifier inference e2e testing";
 const EMBARGO_EXPIRY = validEmbargoExpiry();
 const ISNI_URL = "https://isni.org/0000000121032683";
+// This ISNI has a matching expectation in the local mockserver
+// (docker-compose/mockserver/expectations.json), so unlike ISNI_URL above it
+// resolves and saves successfully end to end in local/dev - needed for the
+// view-page test below, which must get past a real save to render.
+const MOCKED_ISNI_URL = "https://isni.org/0000000078519858";
 const ORCID_URL = "https://sandbox.orcid.org/0009-0002-5128-5184";
 
 interface ContributorPayload {
@@ -133,5 +138,29 @@ test.describe("Contributor identifier auto-detect", { tag: "@local" }, () => {
 
     await formPage.save();
     await formPage.waitForSuccessfulSave();
+
+    // Regression guard: the view page must keep showing ORCID's own
+    // authenticated/unauthenticated icon and label for an ORCID contributor.
+    await expect(page.getByAltText(/authenticated/i)).toBeVisible();
+    await expect(page.getByText("ORCID", { exact: true }).first()).toBeVisible();
+  });
+
+  test("RAiD view page hides the ORCID icon and authenticated/unauthenticated text for an ISNI contributor", async ({
+    page,
+  }) => {
+    const { formPage, contributorSection } = await setUpFormWithContributorRow(page);
+
+    await contributorSection.fillOrcidId(0, MOCKED_ISNI_URL);
+    await formPage.save();
+    await formPage.waitForSuccessfulSave();
+
+    // Bug fix: the ORCID authenticated/unauthenticated icon and status text
+    // don't apply to ISNI (no OAuth flow), and the "ORCID" label is wrong
+    // for an ISNI value - the view page must not show any of them.
+    await expect(page.getByAltText(/authenticated/i)).not.toBeVisible();
+    await expect(page.getByText(/unauthenticated/i)).not.toBeVisible();
+    await expect(page.getByText("ISNI", { exact: true })).toBeVisible();
+    await expect(page.getByText("ORCID", { exact: true })).not.toBeVisible();
+    await expect(page.getByText(MOCKED_ISNI_URL).first()).toBeVisible();
   });
 });

--- a/raid-agency-app/e2e/tests/07-contributor-identifier-inference.spec.ts
+++ b/raid-agency-app/e2e/tests/07-contributor-identifier-inference.spec.ts
@@ -60,6 +60,15 @@ test.describe("Contributor identifier auto-detect", { tag: "@local" }, () => {
   }) => {
     const { formPage, contributorSection } = await setUpFormWithContributorRow(page);
 
+    // bug/isni-helpertext: the helper-text row must reserve enough height
+    // for the longer ISNI copy up front, so switching from the ORCID
+    // helper text to the ISNI one doesn't shift the rest of the form down.
+    const helperTextRow = page
+      .locator("#contributor")
+      .getByText(/Use the ORCID sandbox|Enter a valid ORCID iD|Enter a valid ISNI URL/)
+      .locator("..");
+    const heightBefore = (await helperTextRow.boundingBox())?.height;
+
     await contributorSection.fillOrcidId(0, ISNI_URL);
 
     // Plain-field UI for ISNI: the name-line row stays mounted (avoids a
@@ -77,6 +86,7 @@ test.describe("Contributor identifier auto-detect", { tag: "@local" }, () => {
     // identifier field's own tooltip, rendered after it.
     const contributorTooltipButton = page.locator("#contributor #tooltip-button").last();
     await expect(page.getByText(/Enter a valid ISNI URL/)).toBeVisible();
+    expect((await helperTextRow.boundingBox())?.height).toBe(heightBefore);
     await expect(page.getByText(/Enter a valid ORCID iD/)).not.toBeVisible();
     await contributorTooltipButton.click();
     await expect(page.getByText("ISNI Info")).toBeVisible();

--- a/raid-agency-app/public/app-config.json
+++ b/raid-agency-app/public/app-config.json
@@ -27,7 +27,7 @@
   },
   "app": {
     "orcid": {
-      "placeholder": "Enter valid sandbox ORCID iD",
+      "placeholder": "Enter valid sandbox ORCID iD or ISNI",
       "helpText": "Use the ORCID sandbox (https://orcid.org/sandbox)"
     }
   },

--- a/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
+++ b/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
@@ -280,7 +280,11 @@ export default function ORCIDLookup({
     defaultValue?: string;
   }) {
   const [searchMode, setSearchMode] = useState<'lookup' | 'search'>('lookup');
-  const [searchValue, setSearchValue] = useState('');
+  // Bug fix: the input never pre-filled from an existing saved id - harmless
+  // while this widget only ever rendered for brand-new (empty) contributors,
+  // but now that ISNI contributors stay editable after a status exists too,
+  // this needs to actually show the value being edited.
+  const [searchValue, setSearchValue] = useState(defaultValue || '');
   const [searchText, clearSearchText] = useState(false);
   const [dropBox, setDropBox] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -299,6 +303,9 @@ export default function ORCIDLookup({
   // Resolve display name on mount when a default ORCID value is already present (validation-only mode)
   React.useEffect(() => {
     if (mode !== 'validation-only' || !defaultValue) return;
+    // Bug fix: ISNI has no name lookup - don't fire a pointless ORCID API
+    // call with an ISNI value.
+    if (detectContributorIdentifierType(defaultValue) === 'isni') return;
     const normalised = normalizeOrcidId(defaultValue);
     fetchFromOrcidPublicApi(normalised)
       .then((data) => {
@@ -531,7 +538,12 @@ export default function ORCIDLookup({
     const value = (event.target as HTMLInputElement).value || '';
     setSearchValue(value);
     setVerifiedORCID(value === '' && false);
-    formMethods?.setValue?.(fieldName, value);
+    // Bug fix: this setValue call previously omitted shouldValidate, so a
+    // stale validation error on the id field never cleared as the user
+    // typed a corrected value - for ORCID it happened to clear anyway once
+    // a result was selected (selectOrcid does pass shouldValidate), but
+    // ISNI has no such follow-up step, so it never cleared at all.
+    formMethods?.setValue?.(fieldName, value, { shouldValidate: true });
     const orcid = value.trim().replace(getOrcidReplaceText(), '').match(/^\d{4}-?\d{4}-?\d{4}-?\d{3}[0-9X]$/);
     if (orcid) {
       setSearchMode('lookup');

--- a/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
+++ b/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
@@ -394,6 +394,18 @@ export default function ORCIDLookup({
     genericPlaceholder: `You can search by full ORCID iD or by contributor name (e.g., John Smith).`
   };
 
+  // RAID-861 bug fix: the helper text and tooltip below the search bar were
+  // always ORCID-specific, even once a valid ISNI had been entered - ISNI has
+  // no name lookup, so the ORCID copy (Credit Name, visibility settings) is
+  // misleading in that state.
+  const isniHelpText = 'Enter a valid ISNI URL, e.g. https://isni.org/0000000121032683';
+  const isniTooltipTitle = 'ISNI Info';
+  const isniTooltipContent = (
+    <>ISNI (International Standard Name Identifier) is accepted here and is stored
+    exactly as entered - no name lookup is performed.
+    For more information, see <a href="https://isni.org" target="_blank" rel="noopener noreferrer">[ISNI website]</a></>
+  );
+
   const currentConfig = searchConfig[searchMode];
 
   const handleSearch = async (e?: React.SyntheticEvent) => {
@@ -742,13 +754,13 @@ const selectOrcid = (item: OrcidData | SearchPerson) => {
         <Box sx={{mt: 1, mb: 1, display: 'flex', alignItems: 'center', width: '400px', justifyContent: 'space-between' }}>
           <FormHelperText sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
             {mode === 'validation-only'
-              ? (orcid.helpText || 'Enter a valid ORCID iD, e.g. https://orcid.org/0000-0002-1825-0097')
+              ? (isIsni ? isniHelpText : (orcid.helpText || 'Enter a valid ORCID iD, e.g. https://orcid.org/0000-0002-1825-0097'))
               : searchConfig?.genericPlaceholder}
           </FormHelperText>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <CustomStyledTooltip
-              title={"ORCID Lookup Info"}
-              content={searchConfig.tooltipContent}
+              title={isIsni ? isniTooltipTitle : "ORCID Lookup Info"}
+              content={isIsni ? isniTooltipContent : searchConfig.tooltipContent}
               variant="info"
               placement="top"
               tooltipIcon={<InfoOutlinedIcon />}

--- a/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
+++ b/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
@@ -751,7 +751,7 @@ const selectOrcid = (item: OrcidData | SearchPerson) => {
         {mode === 'validation-only' && error && (
           <FormHelperText sx={{ fontSize: '0.875rem', color: 'error.main', mr: 1 }}>{error}</FormHelperText>
         )}
-        <Box sx={{mt: 1, mb: 1, display: 'flex', alignItems: 'center', width: '400px', justifyContent: 'space-between' }}>
+        <Box sx={{mt: 1, mb: 1, display: 'flex', alignItems: 'center', width: '400px', justifyContent: 'space-between', minHeight: '50px' }}>
           <FormHelperText sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
             {mode === 'validation-only'
               ? (isIsni ? isniHelpText : (orcid.helpText || 'Enter a valid ORCID iD, e.g. https://orcid.org/0000-0002-1825-0097'))

--- a/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
+++ b/raid-agency-app/src/containers/orcid-lookup/ORCID.tsx
@@ -379,7 +379,7 @@ export default function ORCIDLookup({
 
   const searchConfig = {
     lookup: {
-      placeholder: orcid.placeholder || 'Enter ORCID iD (e.g., 0000-0002-1825-0097)',
+      placeholder: orcid.placeholder || 'Enter ORCID iD or ISNI (e.g., 0000-0002-1825-0097 or https://isni.org/0000000121032683)',
       endpoint: `https://${getOrcidEnv()}researchdata.ardc.edu.au/api/v2.0/orcid.jsonp/lookup/${encodeURIComponent(searchValue)}/?api_key=public&callback=?`,
       label: 'ORCID ID',
       description: 'Search by unique ORCID identifier',

--- a/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
+++ b/raid-agency-app/src/entities/contributor/forms/contributor-details-form/ContributorDetailsForm.tsx
@@ -2,6 +2,7 @@ import { DisplayItem } from "@/components/display-item";
 import { CheckboxField } from "@/components/fields/CheckboxField";
 import ORCIDLookup from "@/containers/orcid-lookup/ORCID";
 import { Contributor } from "@/generated/raid";
+import { ISNI_SCHEMA_URI } from "@/utils/contributor-utils/contributor-identifier";
 import { IndeterminateCheckBox } from "@mui/icons-material";
 import { Grid, IconButton, Stack, Tooltip, Typography } from "@mui/material";
 import React from "react";
@@ -10,9 +11,14 @@ import { useFormContext } from "react-hook-form";
 
 function FieldGrid({ index, data }: { index: number; data: Contributor[] }) {
   const { setValue, getValues, formState: { errors } } = useFormContext();
+  // Bug fix: ORCID's authentication status (e.g. AWAITING_AUTHENTICATION)
+  // doesn't apply to ISNI - ISNI has no OAuth authentication flow, so there's
+  // no reason to lock its identifier field once a status happens to exist.
+  // Keep it editable and never show the ORCID-specific status text for it.
+  const isIsni = data?.[index]?.schemaUri === ISNI_SCHEMA_URI;
   return (
     <Grid container spacing={2}>
-      {(!data || !data[index] || !Object.hasOwn(data[index], "status")) && (
+      {(!data || !data[index] || !Object.hasOwn(data[index], "status") || isIsni) && (
         <Grid item xs={12}>
           <ORCIDLookup
             mode="validation-only"
@@ -22,7 +28,7 @@ function FieldGrid({ index, data }: { index: number; data: Contributor[] }) {
           />
         </Grid>
       )}
-      {data[index] && Object.hasOwn(data[index], "status") && (
+      {data[index] && Object.hasOwn(data[index], "status") && !isIsni && (
         <DisplayItem
           label="Contributor Status"
           value={"status" in data[index] ? String((data[index] as Contributor).status) : ""}

--- a/raid-agency-app/src/entities/contributor/views/contributor-item-view/ContributorItemView.tsx
+++ b/raid-agency-app/src/entities/contributor/views/contributor-item-view/ContributorItemView.tsx
@@ -5,6 +5,7 @@ import { Contributor } from "@/generated/raid";
 import { Divider, Grid, Skeleton, Stack, Typography } from "@mui/material";
 import { memo } from "react";
 import { OrcidButton } from "@/components/orcid-button";
+import { ISNI_SCHEMA_URI } from "@/utils/contributor-utils/contributor-identifier";
 
 interface ContributorWithStatus extends Contributor {
   uuid: string;
@@ -22,16 +23,23 @@ const ContributorItemView = memo(
     orcidData?: any;
     i: number;
   }) => {
+    // Bug fix: ORCID's authenticated/unauthenticated icon and status text
+    // don't apply to ISNI - ISNI has no OAuth authentication flow, so
+    // showing them for an ISNI contributor is meaningless/misleading.
+    const isIsni = contributor.schemaUri === ISNI_SCHEMA_URI;
+
     return (
       <Stack gap={2}>
         <Typography variant="body1">Contributor #{i + 1}</Typography>
 
-        <Stack direction="row" alignItems="center" gap={1}>
-          <OrcidButton contributor={contributor} orcidData={orcidData} />
-        </Stack>
+        {!isIsni && (
+          <Stack direction="row" alignItems="center" gap={1}>
+            <OrcidButton contributor={contributor} orcidData={orcidData} />
+          </Stack>
+        )}
 
         <Grid container spacing={2}>
-          <DisplayItem label="ORCID" value={contributor.id} width={6} />
+          <DisplayItem label={isIsni ? "ISNI" : "ORCID"} value={contributor.id} width={6} />
 
           <DisplayItem
             label="Leader"


### PR DESCRIPTION
## Summary
- The helper text and info tooltip below the contributor identifier field stayed ORCID-specific (mentioning Credit Name / ORCID visibility settings) even after a valid ISNI had been entered, which is misleading since ISNI has no name lookup at all
- Both now switch to ISNI-specific copy once an ISNI is detected (helper text: "Enter a valid ISNI URL, e.g. https://isni.org/0000000121032683"; tooltip: "ISNI Info" explaining the ID is stored as entered with no name lookup)
- ORCID's existing helper text and tooltip ("ORCID Lookup Info") are unaffected

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run` — full suite green (169 tests)
- [x] `npx playwright test --project=chromium` — full suite green (31 tests), extended `07-contributor-identifier-inference.spec.ts` to cover the new helper text/tooltip behaviour for both ISNI and the ORCID regression guard