### PR TITLE
RAID-884: provision scoped service-point-admin roles at Keycloak boot

### DIFF
--- a/doc/adr/2026-09-11_boot-time-role-provisioning-via-postmigrationevent.md
+++ b/doc/adr/2026-09-11_boot-time-role-provisioning-via-postmigrationevent.md
@@ -1,0 +1,105 @@
+### Provision realm state at Keycloak boot via a PostMigrationEvent listener in the IAM SPI
+
+* Status: final
+* Who: proposed and finalised by RL
+* When: 2026-09-11
+* Related: RAID-884 (this ADR and its implementation), RAID-711 (epic),
+  RAID-712 (scoped service-point-admin roles), RAID-721 (the migration endpoint
+  this replaces as a mechanism), RAID-827 (the feature left inert by the gap),
+  RAID-836 (spike that proposed this mechanism)
+
+
+# Context
+
+RAiD has a hard non-functional requirement, set by the product owner, that a
+deployment must need no manual steps during or after it. Anything a deployment
+requires in order to function must provision itself automatically and
+idempotently.
+
+Registration Agencies deploy the RAiD Service onto infrastructure ARDC does not
+control and cannot inspect: AWS, plain Docker, Kubernetes, or something else per
+agency. ARDC controls exactly one artifact that every agency runs regardless of
+platform: `raid-iam.jar`, loaded into their Keycloak container.
+
+Until now the scoped `service-point-admin:<groupId>` realm roles were provisioned
+in deployed environments by an operator calling
+`POST /realms/raid/group/migrate-service-point-admins` by hand, a step written
+down in `iam/doc/role-permissions.md`. Documenting a manual step does not satisfy
+the NFR, and the predictable happened: the step was never performed in ARDC's own
+production, so the RAID-827 self-serve credential feature was inert there from the
+day it shipped. Zero of 18 production clients carried a scoped credential.
+
+Realm import is not an answer. `iam/realms/raid-realm.json` is imported on first
+boot of a local dev stack only; it is not a deployment mechanism for any
+environment and must not be cited as one.
+
+The RAID-836 spike proposed Keycloak's `PostMigrationEvent`, registered from the
+`postInit` hook that every `RealmResourceProviderFactory` in the SPI already has
+and none of them used. It flagged one open risk: nobody had confirmed the event
+actually fires in this Keycloak version and configuration, and in particular
+whether it fires on a boot with no pending schema migration - which the name
+suggests it might not.
+
+
+# Decision
+
+Provision boot-time realm state from a `PostMigrationEvent` listener registered in
+the IAM SPI's `postInit` hook. The logic lives in the app codebase, in the jar
+every agency already runs, not in deployment tooling.
+
+The open risk was closed empirically before building on it, against
+`quay.io/keycloak/keycloak:26.6.2` (Quarkus) on Postgres. The event:
+
+* fires on first boot, and
+* fires again on every subsequent restart with no schema migration pending, and
+* fires **after** realm import completes and before the server accepts traffic.
+
+The third property matters as much as the first two: a hook that ran before
+import would find no realm to provision into.
+
+Three constraints on anything using this hook:
+
+1. **Idempotent.** It runs on every boot, not once. Create-if-absent, grant-if-absent.
+2. **Failures are contained and swallowed, per realm.** Boot-time provisioning must
+   never stop Keycloak starting. A realm that fails is logged and left exactly as it
+   was; other realms still run, each in its own transaction.
+3. **No realm name is configured.** Every realm is visited, and a realm without the
+   state the provisioner keys off (here, the flat `group-admin` role) is a no-op.
+   Hard-coding `raid` would be one more thing an agency could get wrong.
+
+The `migrate-service-point-admins` endpoint is retained, delegating to the same
+shared code, but demoted to a redundant safety net: a lever for an operator to
+re-run the backfill without a restart. It is deliberately not part of any
+deployment procedure.
+
+Provisioning breadth is unchanged from the endpoint it replaces. A flat
+`group-admin` who is an approved member of several groups still gains the scoped
+role for all of them. That over-grant is real and tracked separately; narrowing it
+is a decision about who should administer what, and must not ride along
+unannounced inside a mechanism change.
+
+
+# Consequences
+
+Good:
+
+* The scoped roles exist wherever the RAiD Service runs, with no operator action,
+  on any platform. Verified end to end: scoped roles deleted from a seeded realm
+  were restored exactly - same roles, same holders - by a restart alone, and a
+  third boot changed nothing.
+* Any future "must exist before this feature works" realm state has an established,
+  verified home. RAID-836's federation-harvest client is the next candidate, and
+  can reuse the mechanism rather than re-litigating it.
+* The endpoint and the boot hook share one implementation
+  (`ServicePointAdminRoleProvisioner`), so they cannot drift.
+
+Costs and risks:
+
+* Every boot does a small amount of realm work. It is a no-op read when there is
+  nothing to do, but it is not free, and it scales with the number of flat
+  `group-admin` holders.
+* Provisioning that fails at boot fails quietly, by design. Its log line is the
+  only signal, so anything added here needs a log message an operator can actually
+  act on.
+* `PostMigrationEvent` is verified for Keycloak 26.6.2. A Keycloak major upgrade
+  should re-verify it rather than assume it, since the whole mechanism rests on it.

--- a/documentation/20260911-raid-884-boot-time-service-point-admin-provisioning.md
+++ b/documentation/20260911-raid-884-boot-time-service-point-admin-provisioning.md
@@ -1,0 +1,101 @@
+# RAID-884: Provision scoped service-point-admin roles at boot, not by a manual operator call
+
+- **Ticket:** [RAID-884](https://ardc.atlassian.net/browse/RAID-884) (Bug)
+- **Related:** [RAID-827](https://ardc.atlassian.net/browse/RAID-827) (feature left inert), [RAID-721](https://ardc.atlassian.net/browse/RAID-721) (introduced the migration endpoint), [RAID-712](https://ardc.atlassian.net/browse/RAID-712) (scoped roles), [RAID-836](https://ardc.atlassian.net/browse/RAID-836) (spike that proposed the mechanism), [RAID-711](https://ardc.atlassian.net/browse/RAID-711) (epic)
+- **ADR:** [`doc/adr/2026-09-11_boot-time-role-provisioning-via-postmigrationevent.md`](../doc/adr/2026-09-11_boot-time-role-provisioning-via-postmigrationevent.md)
+- **Date:** 11 September 2026
+- **Author:** Rob Leney
+
+## Why
+
+The scoped `service-point-admin:<groupId>` realm roles that authorise the RAID-827 self-serve
+credential feature were provisioned in deployed environments only by an operator calling
+`POST /realms/raid/group/migrate-service-point-admins` by hand. That step was documented in
+`iam/doc/role-permissions.md`, which does not satisfy the hard no-manual-deployment-steps NFR, and
+the predictable happened: it was never performed in ARDC's production, so the feature was inert
+there from the day it shipped.
+
+Registration Agencies deploy the RAiD Service onto platforms ARDC does not control, so any human
+step in the sequence will be skipped somewhere. The one artifact every agency runs regardless of
+platform is `raid-iam.jar`, so the provisioning has to live there.
+
+## What changed
+
+**`ServicePointAdminRoleProvisioner`** (new) holds the backfill logic lifted verbatim out of
+`GroupController.migrateServicePointAdmins`, plus the role-name, create-if-absent and
+approved-membership helpers. Both callers now share it, so they cannot drift.
+
+**`ServicePointAdminRoleBootstrapper`** (new) registers a `PostMigrationEvent` listener from
+`GroupControllerResourceProviderFactory.postInit`, which was an empty no-op. On the event it runs
+the backfill against every realm, each in its own transaction. Per-realm failures are logged and
+swallowed: boot-time provisioning must never stop Keycloak starting.
+
+No realm name is configured. A realm with no flat `group-admin` role (`master`, or anything an
+agency runs alongside RAiD) is a no-op, so nothing has to be told which realm is the RAiD one.
+
+**`GroupController.migrateServicePointAdmins`** keeps its operator-only authorisation and its
+response shape, but its body is now a delegation to the shared provisioner. It is demoted in the
+docs to a redundant safety net, for an operator who needs to re-run the backfill without a restart.
+It is deliberately not part of any deployment procedure.
+
+**`iam/doc/role-permissions.md`** section 9's deployment note no longer describes a manual step as
+the deployed-environment mechanism.
+
+## The open risk, closed
+
+RAID-836 proposed this mechanism but flagged that nobody had confirmed `PostMigrationEvent`
+actually fires in this Keycloak version and configuration - in particular whether it fires on a
+boot with no pending schema migration, which the name suggests it might not.
+
+Verified empirically against `quay.io/keycloak/keycloak:26.6.2` (Quarkus) on Postgres, with a
+throwaway probe before any real code was written. The event fires on first boot; fires again on
+every restart with no migration pending; and fires **after** realm import completes and before the
+server accepts traffic. The last property matters as much as the others - a hook running before
+import would find no realm to provision into.
+
+## Verification
+
+Unit tests: 190 pass, 0 fail (`./gradlew :iam:test`). Six new tests cover the bootstrapper
+(non-migration events ignored, grants applied across realms, no-op for a realm without the flat
+role, idempotency, one failing realm neither aborting the others nor propagating, and a realm-listing
+failure not propagating). One new test asserts `postInit` registers the listener. The 30 pre-existing
+`GroupController` migration tests pass unchanged over the refactored code, which is the regression
+evidence for the extraction.
+
+End to end, in an isolated Keycloak container seeded from `raid-realm.json`, reproducing the
+production state:
+
+1. Deleted both scoped roles from the `raid` realm - 0 remaining, matching production.
+2. Restarted Keycloak. No operator action of any kind.
+3. Both roles were recreated and re-granted to exactly their previous holders
+   (`raid-au-group-admin`, `rob`). Log: `realm 'raid' - 3 flat group-admin user(s), 2 scoped
+   role(s) created, 3 grant(s) added, 0 already present`.
+4. `raid-au-unapproved-admin`, a flat `group-admin` who was never approved for their group,
+   correctly received nothing - the RAiD-608 / HELP-2844 exclusion survives the move.
+5. A third restart changed nothing: `already up to date`, still exactly 2 roles.
+6. The `master` realm was a no-op on every boot.
+
+## Deliberately not done
+
+**Roles are not created for groups with no flat `group-admin` member.** The ticket's AC 1 reads
+"roles exist for every service point group". Such a role would have no holders and grant nothing,
+and groups created through the SPI get theirs at creation time, so this was left alone rather than
+widening the change. Flagged rather than silently decided.
+
+**The backfill's breadth is unchanged.** A flat `group-admin` who is an approved member of several
+groups still gains the scoped role for all of them, exactly as the endpoint did. Narrowing it is a
+decision about who should administer what and must not ride along inside a mechanism change.
+Pruning is still untracked: the code comment that deferred it pointed at RAID-712, which is closed
+as Done while its AC 1 is not satisfied for three production users
+(`simon.gallant@dcceew.gov.au`, `kate.croker@uwa.edu.au`, `katina.toufexis@uwa.edu.au`). That needs
+a reopen of RAID-712 or a new ticket.
+
+## Deployment note
+
+No deployment step. The behaviour ships with the IAM image and takes effect the next time Keycloak
+starts in each environment. Production already had the backfill run manually on 2026-09-11, so the
+first boot there will report `already up to date`.
+
+## PR
+
+<!-- filled in on PR creation -->

--- a/documentation/20260911-raid-884-boot-time-service-point-admin-provisioning.md
+++ b/documentation/20260911-raid-884-boot-time-service-point-admin-provisioning.md
@@ -98,4 +98,4 @@ first boot there will report `already up to date`.
 
 ## PR
 
-<!-- filled in on PR creation -->
+[PR #665](https://github.com/au-research/raid-au/pull/665)

--- a/iam/doc/role-permissions.md
+++ b/iam/doc/role-permissions.md
@@ -103,10 +103,21 @@ Dynamic realm roles named `service-point-admin:<groupId>`, where `<groupId>` is 
 **Lifecycle:**
 - Created automatically (create-if-absent) when a group is created via the IAM group SPI; the creating user is granted the scoped role
 - Granted/revoked alongside the flat `group-admin` role (dual-write) while the transition to scoped roles is in progress
+- Backfilled automatically at every Keycloak boot for existing holders of the flat `group-admin` role (RAID-884, see the deployment note below)
 
 **Relationship to the legacy `group-admin` role:** the flat `group-admin` realm role historically made a user an admin of *every* group they belonged to. During the transition, the SPI honours the flat role as a fallback (flat `group-admin` + group membership) when the `flat-group-admin-fallback` setting is enabled. Once the RAiD app consumes scoped roles, the fallback will be disabled and the flat role removed.
 
-**Deployment note:** `iam/realms/raid-realm.json` seeds the scoped roles for the two local dev groups only, and the realm JSON is imported on first boot only. In deployed environments (test/stage/prod) the scoped roles are backfilled with the operator-only idempotent migration endpoint `POST /realms/raid/group/migrate-service-point-admins` (RAID-721), which grants `service-point-admin:<groupId>` for every group each flat `group-admin` user belongs to (preserving current effective access).
+**Deployment note:** the scoped roles are provisioned automatically, with no operator action, on every Keycloak boot (RAID-884). `ServicePointAdminRoleBootstrapper` registers a listener for Keycloak's `PostMigrationEvent` from the group SPI's `postInit` hook; the listener runs the idempotent backfill against every realm, granting `service-point-admin:<groupId>` for each group a flat `group-admin` user is an *approved* member of (preserving current effective access). Realms with no flat `group-admin` role, such as `master`, are a no-op.
+
+Because this ships inside `raid-iam.jar`, it runs identically on any platform a Registration Agency deploys onto, which is what the no-manual-deployment-steps NFR requires. There is nothing to run by hand, and nothing in any deployment procedure should depend on the migration endpoint.
+
+Two things it does *not* do, both deliberate:
+- It does not create a scoped role for a service point group that has no flat `group-admin` member. Such a role would have no holders and grant nothing; groups created through the SPI get theirs at creation time.
+- It does not narrow the breadth of the backfill. A flat `group-admin` who is an approved member of several groups gains the scoped role for all of them, exactly as the flat role already allowed. Pruning that over-grant is separate work and must not happen as a side effect of a boot-time backfill.
+
+`POST /realms/raid/group/migrate-service-point-admins` (RAID-721) still exists and runs the same shared code, but it is now a **redundant safety net** for an operator who needs to re-run the backfill without a restart, not the provisioning mechanism. Relying on it as the mechanism was the bug fixed by RAID-884: the step was documented but never performed in ARDC's production, leaving the RAID-827 self-serve credential feature inert there.
+
+`iam/realms/raid-realm.json` seeds the scoped roles for the two local dev groups, but it is imported on first boot of a local dev stack only and is not a deployment mechanism for any environment.
 
 ## Special Authorization Cases
 

--- a/iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/group/GroupController.java
@@ -25,12 +25,13 @@ import java.util.List;
 @Provider
 public class GroupController {
     private static final String OPERATOR_ROLE_NAME = "operator";
-    private static final String GROUP_ADMIN_ROLE_NAME = "group-admin";
-    private static final String SERVICE_POINT_USER_ROLE = "service-point-user";
+    private static final String GROUP_ADMIN_ROLE_NAME = ServicePointAdminRoleProvisioner.GROUP_ADMIN_ROLE_NAME;
+    private static final String SERVICE_POINT_USER_ROLE = ServicePointAdminRoleProvisioner.SERVICE_POINT_USER_ROLE;
     // Scoped role name format: "service-point-admin:<groupId>". Granted alongside the flat
     // GROUP_ADMIN_ROLE_NAME on group creation and group-admin grant (dual-write), and enforced as
     // the primary authorization check in isGroupAdminOf below.
-    private static final String SERVICE_POINT_ADMIN_ROLE_PREFIX = "service-point-admin";
+    private static final String SERVICE_POINT_ADMIN_ROLE_PREFIX =
+            ServicePointAdminRoleProvisioner.SERVICE_POINT_ADMIN_ROLE_PREFIX;
     // Config flag controlling whether the legacy flat GROUP_ADMIN_ROLE_NAME (plus group
     // membership) still authorises group-admin operations. Keycloak's Config.Scope isn't wired
     // through to this per-request resource today (GroupControllerResourceProviderFactory#init is
@@ -455,24 +456,12 @@ public class GroupController {
     }
 
     private boolean isGroupMember(final UserModel user, final String groupId) {
-        return !user.getGroupsStream()
-                .filter(g -> g.getId().equals(groupId))
-                .toList().isEmpty();
+        return ServicePointAdminRoleProvisioner.isGroupMember(user, groupId);
     }
 
-    /**
-     * A user is an approved member of a group if they are a Keycloak group member AND hold the
-     * service-point-user role for that membership to mean anything - service-point-user is only
-     * ever granted via an explicit grant() approval, never automatically. This distinguishes a
-     * legitimate, approved service point affiliation from a raw, unapproved self-join via
-     * /group/join (see RAiD-608 / HELP-2844: a self-joined-but-never-approved membership was
-     * previously enough to satisfy the flat group-admin fallback).
-     */
+    /** See {@link ServicePointAdminRoleProvisioner#isApprovedGroupMember}. */
     private boolean isApprovedGroupMember(final UserModel user, final String groupId) {
-        return isGroupMember(user, groupId) &&
-                !user.getRoleMappingsStream()
-                        .filter(r -> r.getName().equals(SERVICE_POINT_USER_ROLE))
-                        .toList().isEmpty();
+        return ServicePointAdminRoleProvisioner.isApprovedGroupMember(user, groupId);
     }
 
     private boolean isOperator(final UserModel user) {
@@ -481,26 +470,13 @@ public class GroupController {
                 .toList().isEmpty();
     }
 
-    /**
-     * Looks up the realm role scoped to a single service point group
-     * ("service-point-admin:<groupId>"), creating it if it does not already exist.
-     */
+    /** See {@link ServicePointAdminRoleProvisioner#getOrCreateServicePointAdminRole}. */
     private RoleModel getOrCreateServicePointAdminRole(final RealmModel realm, final String groupId) {
-        final var roleName = servicePointAdminRoleName(groupId);
-        final var existingRole = realm.getRole(roleName);
-        if (existingRole != null) {
-            return existingRole;
-        }
-
-        // Note: RoleContainerModel#addRole(String, String) is (id, name) - not (name, description).
-        // Use the single-arg overload (generated id, given name) and set the description separately.
-        final var role = realm.addRole(roleName);
-        role.setDescription("Service point admin for group " + groupId);
-        return role;
+        return ServicePointAdminRoleProvisioner.getOrCreateServicePointAdminRole(realm, groupId);
     }
 
     private static String servicePointAdminRoleName(final String groupId) {
-        return SERVICE_POINT_ADMIN_ROLE_PREFIX + ":" + groupId;
+        return ServicePointAdminRoleProvisioner.servicePointAdminRoleName(groupId);
     }
 
     @OPTIONS
@@ -674,24 +650,18 @@ public class GroupController {
     }
 
     /**
-     * One-off, idempotent backfill for RAID-712: grants the scoped
-     * "service-point-admin:&lt;groupId&gt;" realm role to every current holder of the legacy flat
-     * GROUP_ADMIN_ROLE_NAME, for each group they are an approved member of (see
-     * isApprovedGroupMember). This preserves each flat group-admin's existing *legitimate*
-     * effective access while service points transition onto scoped roles (see
-     * role-permissions.md section 9).
+     * Operator-only manual trigger for the same idempotent backfill that
+     * {@link ServicePointAdminRoleBootstrapper} now runs unattended at every boot (RAID-884).
      *
-     * <p>Operator-only. Safe to re-run: users who already hold the scoped role for a group are
-     * counted as skipped rather than re-granted, and existing scoped roles are reused rather than
-     * recreated.
+     * <p>Since RAID-884 this endpoint is a <em>redundant safety net</em>, not the provisioning
+     * mechanism. It is retained as a recovery lever - for an operator to re-run the backfill
+     * without a restart, or if the boot-time hook is ever prevented from running - and delegates
+     * to {@link ServicePointAdminRoleProvisioner#backfill} so the two paths cannot diverge. It is
+     * deliberately <em>not</em> part of any deployment procedure: relying on it was the bug
+     * RAID-884 fixed.
      *
-     * <p>Note: raw/pending memberships (groups the user has self-joined but was never granted
-     * service-point-user for) are deliberately excluded - backfilling those would silently grant
-     * admin authority the user was never approved for (RAiD-608 / HELP-2844). Within a group the
-     * member is genuinely approved for, this may still over-grant relative to what they were
-     * originally intended to administer if they are an approved member of more than one group;
-     * pruning that is deferred to a future RAID-712 follow-up once service points have reviewed
-     * their membership.
+     * <p>See {@link ServicePointAdminRoleProvisioner#backfill} for the idempotency and
+     * over-grant-breadth semantics.
      */
     @POST
     @Path("/migrate-service-point-admins")
@@ -714,67 +684,9 @@ public class GroupController {
         }
 
         final var realm = session.getContext().getRealm();
-        final var flatGroupAdminRole = realm.getRole(GROUP_ADMIN_ROLE_NAME);
-
-        if (flatGroupAdminRole == null) {
-            final var responseBody = new MigrationResult(0, 0, 0, 0,
-                    "Flat group-admin role not present; nothing to migrate");
-            return cors.buildCorsResponse("POST",
-                    Response.ok().entity(objectMapper.writeValueAsString(responseBody)));
-        }
 
         try {
-            var flatGroupAdminUsers = 0;
-            var rolesCreated = 0;
-            var grantsAdded = 0;
-            var grantsSkipped = 0;
-
-            var firstResult = 0;
-            final var pageSize = 100;
-            while (true) {
-                final var page = session.users()
-                        .getRoleMembersStream(realm, flatGroupAdminRole, firstResult, pageSize)
-                        .toList();
-
-                if (page.isEmpty()) {
-                    break;
-                }
-
-                for (final var member : page) {
-                    flatGroupAdminUsers++;
-
-                    // Materialise before granting roles below - member.grantRole mutates this
-                    // user's role mappings, and we must not mutate them while consuming a live
-                    // stream over the same underlying data. Only backfill groups the member is
-                    // an approved (not merely raw/pending self-joined) member of - see
-                    // isApprovedGroupMember and RAiD-608 / HELP-2844.
-                    final var groups = member.getGroupsStream()
-                            .filter(g -> isApprovedGroupMember(member, g.getId()))
-                            .toList();
-
-                    for (final var group : groups) {
-                        final var roleName = servicePointAdminRoleName(group.getId());
-                        final var existed = realm.getRole(roleName) != null;
-                        final var scopedRole = getOrCreateServicePointAdminRole(realm, group.getId());
-
-                        if (!existed) {
-                            rolesCreated++;
-                        }
-
-                        if (member.hasDirectRole(scopedRole)) {
-                            grantsSkipped++;
-                        } else {
-                            member.grantRole(scopedRole);
-                            grantsAdded++;
-                        }
-                    }
-                }
-
-                firstResult += pageSize;
-            }
-
-            final var responseBody = new MigrationResult(
-                    flatGroupAdminUsers, rolesCreated, grantsAdded, grantsSkipped, "Migration complete");
+            final var responseBody = ServicePointAdminRoleProvisioner.backfill(session, realm);
 
             return cors.buildCorsResponse("POST",
                     Response.ok().entity(objectMapper.writeValueAsString(responseBody)));
@@ -786,7 +698,4 @@ public class GroupController {
                     .build();
         }
     }
-
-    private record MigrationResult(
-            int flatGroupAdminUsers, int rolesCreated, int grantsAdded, int grantsSkipped, String message) {}
 }

--- a/iam/src/main/java/au/org/raid/iam/provider/group/GroupControllerResourceProviderFactory.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/group/GroupControllerResourceProviderFactory.java
@@ -24,9 +24,14 @@ public class GroupControllerResourceProviderFactory implements RealmResourceProv
 
     }
 
+    /**
+     * Provisions the scoped service-point-admin roles at boot (RAID-884), replacing the manual
+     * operator call to /group/migrate-service-point-admins that the deployment procedure used to
+     * depend on. See {@link ServicePointAdminRoleBootstrapper}.
+     */
     @Override
     public void postInit(final KeycloakSessionFactory factory) {
-
+        ServicePointAdminRoleBootstrapper.register(factory);
     }
 
     @Override

--- a/iam/src/main/java/au/org/raid/iam/provider/group/ServicePointAdminRoleBootstrapper.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/group/ServicePointAdminRoleBootstrapper.java
@@ -1,0 +1,107 @@
+package au.org.raid.iam.provider.group;
+
+import lombok.extern.slf4j.Slf4j;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.models.utils.PostMigrationEvent;
+
+import java.util.ArrayList;
+
+/**
+ * Runs the scoped service-point-admin backfill unattended at every Keycloak boot (RAID-884).
+ *
+ * <p>Before this existed, the only way to provision the scoped
+ * "service-point-admin:&lt;groupId&gt;" roles in a deployed environment was for an operator to call
+ * POST /realms/raid/group/migrate-service-point-admins by hand. That violated the hard
+ * no-manual-deployment-steps NFR, and in ARDC's own production the step was never performed, so
+ * the RAID-827 self-serve credential feature was inert there. Registration Agencies deploy the
+ * RAiD Service onto platforms ARDC does not control, so any human step in the sequence will be
+ * skipped somewhere.
+ *
+ * <p>This listens for Keycloak's {@link PostMigrationEvent}, which is the platform's standard
+ * "run once, unattended, after the realm and database are ready" hook. Verified empirically on
+ * Keycloak 26.6.2 (Quarkus): it fires on first boot <em>and</em> on every subsequent restart when
+ * no schema migration is pending, after realm import completes and before the server accepts
+ * traffic.
+ *
+ * <p>Every realm is visited, not just the RaiD one. Realms without the legacy flat group-admin
+ * role - master, and any realm an agency runs alongside RAiD - are a no-op inside
+ * {@link ServicePointAdminRoleProvisioner#backfill}, so no realm name needs configuring. This
+ * keeps the mechanism deployment-agnostic, which is the whole point of putting it in the SPI jar.
+ *
+ * <p>Failures are logged and swallowed per realm. Boot-time provisioning must never stop Keycloak
+ * from starting: a realm that fails to backfill leaves that realm exactly as it was before, and the
+ * operator endpoint remains available as a recovery lever.
+ */
+@Slf4j
+public final class ServicePointAdminRoleBootstrapper {
+
+    private ServicePointAdminRoleBootstrapper() {
+    }
+
+    /**
+     * Registers the boot-time backfill. Call from a
+     * {@code RealmResourceProviderFactory#postInit(KeycloakSessionFactory)} hook.
+     */
+    public static void register(final KeycloakSessionFactory factory) {
+        factory.register(event -> {
+            if (event instanceof PostMigrationEvent) {
+                runForAllRealms(factory);
+            }
+        });
+    }
+
+    private static void runForAllRealms(final KeycloakSessionFactory factory) {
+        // Collect realm ids in their own transaction, then back each realm's backfill with a
+        // separate transaction, so one failing realm cannot roll back another's grants.
+        final var realmIds = new ArrayList<String>();
+        try {
+            KeycloakModelUtils.runJobInTransaction(factory, session ->
+                    session.realms().getRealmsStream().forEach(realm -> realmIds.add(realm.getId())));
+        } catch (Exception e) {
+            log.error("RAID-884 boot-time service-point-admin backfill could not list realms; " +
+                    "skipping. Keycloak startup continues.", e);
+            return;
+        }
+
+        for (final var realmId : realmIds) {
+            runForRealm(factory, realmId);
+        }
+    }
+
+    private static void runForRealm(final KeycloakSessionFactory factory, final String realmId) {
+        try {
+            KeycloakModelUtils.runJobInTransaction(factory, session -> backfill(session, realmId));
+        } catch (Exception e) {
+            log.error("RAID-884 boot-time service-point-admin backfill failed for realm id {}; " +
+                    "that realm is unchanged and Keycloak startup continues. The operator endpoint " +
+                    "POST /realms/<realm>/group/migrate-service-point-admins can be used to recover.",
+                    realmId, e);
+        }
+    }
+
+    private static void backfill(final KeycloakSession session, final String realmId) {
+        final var realm = session.realms().getRealm(realmId);
+        if (realm == null) {
+            return;
+        }
+
+        // The provisioner reads the realm it is handed rather than the session context, but
+        // UserProvider lookups still expect a realm on the context.
+        session.getContext().setRealm(realm);
+
+        final var result = ServicePointAdminRoleProvisioner.backfill(session, realm);
+
+        if (result.rolesCreated() == 0 && result.grantsAdded() == 0) {
+            log.debug("RAID-884 boot-time service-point-admin backfill: realm '{}' already up to date ({})",
+                    realm.getName(), result.message());
+            return;
+        }
+
+        log.info("RAID-884 boot-time service-point-admin backfill: realm '{}' - {} flat group-admin " +
+                        "user(s), {} scoped role(s) created, {} grant(s) added, {} already present",
+                realm.getName(), result.flatGroupAdminUsers(), result.rolesCreated(),
+                result.grantsAdded(), result.grantsSkipped());
+    }
+}

--- a/iam/src/main/java/au/org/raid/iam/provider/group/ServicePointAdminRoleProvisioner.java
+++ b/iam/src/main/java/au/org/raid/iam/provider/group/ServicePointAdminRoleProvisioner.java
@@ -1,0 +1,151 @@
+package au.org.raid.iam.provider.group;
+
+import lombok.extern.slf4j.Slf4j;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+
+/**
+ * Provisioning of the scoped "service-point-admin:&lt;groupId&gt;" realm roles.
+ *
+ * <p>Extracted from {@link GroupController} for RAID-884 so the same backfill can run
+ * unattended at boot ({@link ServicePointAdminRoleBootstrapper}) as well as from the
+ * operator-only endpoint that used to be the only way to run it. The two callers share this
+ * code so they cannot drift apart.
+ */
+@Slf4j
+public final class ServicePointAdminRoleProvisioner {
+    public static final String GROUP_ADMIN_ROLE_NAME = "group-admin";
+    public static final String SERVICE_POINT_USER_ROLE = "service-point-user";
+    public static final String SERVICE_POINT_ADMIN_ROLE_PREFIX = "service-point-admin";
+
+    private static final int PAGE_SIZE = 100;
+
+    private ServicePointAdminRoleProvisioner() {
+    }
+
+    public static String servicePointAdminRoleName(final String groupId) {
+        return SERVICE_POINT_ADMIN_ROLE_PREFIX + ":" + groupId;
+    }
+
+    /**
+     * Looks up the realm role scoped to a single service point group
+     * ("service-point-admin:&lt;groupId&gt;"), creating it if it does not already exist.
+     */
+    public static RoleModel getOrCreateServicePointAdminRole(final RealmModel realm, final String groupId) {
+        final var roleName = servicePointAdminRoleName(groupId);
+        final var existingRole = realm.getRole(roleName);
+        if (existingRole != null) {
+            return existingRole;
+        }
+
+        // Note: RoleContainerModel#addRole(String, String) is (id, name) - not (name, description).
+        // Use the single-arg overload (generated id, given name) and set the description separately.
+        final var role = realm.addRole(roleName);
+        role.setDescription("Service point admin for group " + groupId);
+        return role;
+    }
+
+    public static boolean isGroupMember(final UserModel user, final String groupId) {
+        return user.getGroupsStream().anyMatch(g -> g.getId().equals(groupId));
+    }
+
+    /**
+     * A user is an approved member of a group if they are a Keycloak group member AND hold the
+     * service-point-user role for that membership to mean anything - service-point-user is only
+     * ever granted via an explicit grant() approval, never automatically. This distinguishes a
+     * legitimate, approved service point affiliation from a raw, unapproved self-join via
+     * /group/join (see RAiD-608 / HELP-2844: a self-joined-but-never-approved membership was
+     * previously enough to satisfy the flat group-admin fallback).
+     */
+    public static boolean isApprovedGroupMember(final UserModel user, final String groupId) {
+        return isGroupMember(user, groupId) &&
+                user.getRoleMappingsStream().anyMatch(r -> r.getName().equals(SERVICE_POINT_USER_ROLE));
+    }
+
+    /**
+     * Idempotent backfill (RAID-712): grants the scoped "service-point-admin:&lt;groupId&gt;" realm
+     * role to every current holder of the legacy flat {@value #GROUP_ADMIN_ROLE_NAME} role, for each
+     * group they are an approved member of (see {@link #isApprovedGroupMember}). This preserves each
+     * flat group-admin's existing <em>legitimate</em> effective access while service points
+     * transition onto scoped roles (see role-permissions.md section 9).
+     *
+     * <p>Safe to re-run: users who already hold the scoped role for a group are counted as skipped
+     * rather than re-granted, and existing scoped roles are reused rather than recreated. A realm
+     * with no flat group-admin role - any realm other than the RAiD one, including master - is a
+     * no-op.
+     *
+     * <p>Note: raw/pending memberships (groups the user has self-joined but was never granted
+     * service-point-user for) are deliberately excluded - backfilling those would silently grant
+     * admin authority the user was never approved for (RAiD-608 / HELP-2844). Within a group the
+     * member is genuinely approved for, this may still over-grant relative to what they were
+     * originally intended to administer if they are an approved member of more than one group.
+     * That breadth is deliberate and unchanged from the endpoint this replaces (RAID-884): it
+     * preserves current effective access, since the flat group-admin role was itself unscoped.
+     * Pruning it is tracked separately and must not be done as a side effect of this backfill.
+     */
+    public static MigrationResult backfill(final KeycloakSession session, final RealmModel realm) {
+        final var flatGroupAdminRole = realm.getRole(GROUP_ADMIN_ROLE_NAME);
+
+        if (flatGroupAdminRole == null) {
+            return new MigrationResult(0, 0, 0, 0,
+                    "Flat group-admin role not present; nothing to migrate");
+        }
+
+        var flatGroupAdminUsers = 0;
+        var rolesCreated = 0;
+        var grantsAdded = 0;
+        var grantsSkipped = 0;
+
+        var firstResult = 0;
+        while (true) {
+            final var page = session.users()
+                    .getRoleMembersStream(realm, flatGroupAdminRole, firstResult, PAGE_SIZE)
+                    .toList();
+
+            if (page.isEmpty()) {
+                break;
+            }
+
+            for (final var member : page) {
+                flatGroupAdminUsers++;
+
+                // Materialise before granting roles below - member.grantRole mutates this user's
+                // role mappings, and we must not mutate them while consuming a live stream over
+                // the same underlying data. Only backfill groups the member is an approved (not
+                // merely raw/pending self-joined) member of - see isApprovedGroupMember and
+                // RAiD-608 / HELP-2844.
+                final var groups = member.getGroupsStream()
+                        .filter(g -> isApprovedGroupMember(member, g.getId()))
+                        .toList();
+
+                for (final var group : groups) {
+                    final var roleName = servicePointAdminRoleName(group.getId());
+                    final var existed = realm.getRole(roleName) != null;
+                    final var scopedRole = getOrCreateServicePointAdminRole(realm, group.getId());
+
+                    if (!existed) {
+                        rolesCreated++;
+                    }
+
+                    if (member.hasDirectRole(scopedRole)) {
+                        grantsSkipped++;
+                    } else {
+                        member.grantRole(scopedRole);
+                        grantsAdded++;
+                    }
+                }
+            }
+
+            firstResult += PAGE_SIZE;
+        }
+
+        return new MigrationResult(
+                flatGroupAdminUsers, rolesCreated, grantsAdded, grantsSkipped, "Migration complete");
+    }
+
+    public record MigrationResult(
+            int flatGroupAdminUsers, int rolesCreated, int grantsAdded, int grantsSkipped, String message) {
+    }
+}

--- a/iam/src/test/java/au/org/raid/iam/provider/group/GroupControllerResourceProviderFactoryTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/group/GroupControllerResourceProviderFactoryTest.java
@@ -2,10 +2,13 @@ package au.org.raid.iam.provider.group;
 
 import org.junit.jupiter.api.Test;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class GroupControllerResourceProviderFactoryTest {
 
@@ -21,5 +24,18 @@ class GroupControllerResourceProviderFactoryTest {
         var session = mock(KeycloakSession.class);
         var provider = factory.create(session);
         assertThat(provider, is(notNullValue()));
+    }
+
+    /**
+     * RAID-884: postInit must register the boot-time backfill listener. Without this the scoped
+     * service-point-admin roles are only ever created by a manual operator call, which is the bug.
+     */
+    @Test
+    void postInit_registersBootstrapListener() {
+        var sessionFactory = mock(KeycloakSessionFactory.class);
+
+        factory.postInit(sessionFactory);
+
+        verify(sessionFactory).register(notNull());
     }
 }

--- a/iam/src/test/java/au/org/raid/iam/provider/group/ServicePointAdminRoleBootstrapperTest.java
+++ b/iam/src/test/java/au/org/raid/iam/provider/group/ServicePointAdminRoleBootstrapperTest.java
@@ -1,0 +1,238 @@
+package au.org.raid.iam.provider.group;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.models.*;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.models.utils.PostMigrationEvent;
+import org.keycloak.provider.ProviderEvent;
+import org.keycloak.provider.ProviderEventListener;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * RAID-884: the scoped service-point-admin roles must be provisioned unattended at boot rather
+ * than by an operator calling the migration endpoint by hand.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ServicePointAdminRoleBootstrapperTest {
+
+    @Mock private KeycloakSessionFactory sessionFactory;
+    @Mock private KeycloakSession session;
+    @Mock private KeycloakContext context;
+    @Mock private RealmProvider realmProvider;
+    @Mock private UserProvider userProvider;
+
+    private ProviderEventListener registerAndCaptureListener() {
+        ServicePointAdminRoleBootstrapper.register(sessionFactory);
+        var captor = ArgumentCaptor.forClass(ProviderEventListener.class);
+        verify(sessionFactory).register(captor.capture());
+        return captor.getValue();
+    }
+
+    /**
+     * Stands in for Keycloak's transaction plumbing: every runJobInTransaction call is executed
+     * immediately against the mock session, so the test exercises the real backfill logic.
+     */
+    private static void runTasksInline(org.mockito.MockedStatic<KeycloakModelUtils> mocked,
+                                       KeycloakSession session) {
+        mocked.when(() -> KeycloakModelUtils.runJobInTransaction(any(), any()))
+                .thenAnswer(invocation -> {
+                    KeycloakSessionTask task = invocation.getArgument(1);
+                    task.run(session);
+                    return null;
+                });
+    }
+
+    private RealmModel realmWithFlatAdmins(final String id, final String name,
+                                           final List<UserModel> flatAdmins) {
+        var realm = mock(RealmModel.class);
+        when(realm.getId()).thenReturn(id);
+        when(realm.getName()).thenReturn(name);
+
+        var flatRole = mock(RoleModel.class);
+        when(realm.getRole(ServicePointAdminRoleProvisioner.GROUP_ADMIN_ROLE_NAME)).thenReturn(flatRole);
+        when(userProvider.getRoleMembersStream(eq(realm), eq(flatRole), anyInt(), anyInt()))
+                .thenAnswer(inv -> (int) inv.getArgument(2) == 0 ? flatAdmins.stream() : Stream.empty());
+
+        return realm;
+    }
+
+    private UserModel approvedAdminOf(final GroupModel... groups) {
+        var user = mock(UserModel.class);
+        var servicePointUser = mock(RoleModel.class);
+        when(servicePointUser.getName()).thenReturn(ServicePointAdminRoleProvisioner.SERVICE_POINT_USER_ROLE);
+        when(user.getRoleMappingsStream()).thenAnswer(inv -> Stream.of(servicePointUser));
+        when(user.getGroupsStream()).thenAnswer(inv -> Stream.of(groups));
+        when(user.hasDirectRole(any())).thenReturn(false);
+        return user;
+    }
+
+    private static GroupModel group(final String id) {
+        var group = mock(GroupModel.class);
+        when(group.getId()).thenReturn(id);
+        return group;
+    }
+
+    @Test
+    void ignoresEventsOtherThanPostMigration() {
+        var listener = registerAndCaptureListener();
+
+        try (var mocked = mockStatic(KeycloakModelUtils.class)) {
+            listener.onEvent(mock(ProviderEvent.class));
+
+            mocked.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    void onPostMigration_grantsScopedRoleToFlatAdminsOfEveryRealm() {
+        when(session.getContext()).thenReturn(context);
+        when(session.realms()).thenReturn(realmProvider);
+        when(session.users()).thenReturn(userProvider);
+
+        var groupA = group("group-a");
+        var admin = approvedAdminOf(groupA);
+        var realm = realmWithFlatAdmins("realm-1", "raid", List.of(admin));
+
+        var createdRole = mock(RoleModel.class);
+        when(realm.getRole("service-point-admin:group-a")).thenReturn(null);
+        when(realm.addRole("service-point-admin:group-a")).thenReturn(createdRole);
+
+        when(realmProvider.getRealmsStream()).thenAnswer(inv -> Stream.of(realm));
+        when(realmProvider.getRealm("realm-1")).thenReturn(realm);
+
+        var listener = registerAndCaptureListener();
+
+        try (var mocked = mockStatic(KeycloakModelUtils.class)) {
+            runTasksInline(mocked, session);
+
+            listener.onEvent(new PostMigrationEvent(sessionFactory));
+        }
+
+        verify(realm).addRole("service-point-admin:group-a");
+        verify(admin).grantRole(createdRole);
+        verify(context).setRealm(realm);
+    }
+
+    @Test
+    void onPostMigration_isNoOpForRealmWithoutFlatGroupAdminRole() {
+        when(session.getContext()).thenReturn(context);
+        when(session.realms()).thenReturn(realmProvider);
+        when(session.users()).thenReturn(userProvider);
+
+        // e.g. the master realm, or any realm an agency runs alongside RAiD
+        var realm = mock(RealmModel.class);
+        when(realm.getId()).thenReturn("realm-master");
+        when(realm.getName()).thenReturn("master");
+        when(realm.getRole(anyString())).thenReturn(null);
+
+        when(realmProvider.getRealmsStream()).thenAnswer(inv -> Stream.of(realm));
+        when(realmProvider.getRealm("realm-master")).thenReturn(realm);
+
+        var listener = registerAndCaptureListener();
+
+        try (var mocked = mockStatic(KeycloakModelUtils.class)) {
+            runTasksInline(mocked, session);
+
+            listener.onEvent(new PostMigrationEvent(sessionFactory));
+        }
+
+        verify(realm, never()).addRole(anyString());
+        verifyNoInteractions(userProvider);
+    }
+
+    @Test
+    void onPostMigration_isIdempotentWhenScopedRoleAlreadyGranted() {
+        when(session.getContext()).thenReturn(context);
+        when(session.realms()).thenReturn(realmProvider);
+        when(session.users()).thenReturn(userProvider);
+
+        var groupA = group("group-a");
+        var admin = approvedAdminOf(groupA);
+        var realm = realmWithFlatAdmins("realm-1", "raid", List.of(admin));
+
+        var existingRole = mock(RoleModel.class);
+        when(realm.getRole("service-point-admin:group-a")).thenReturn(existingRole);
+        when(admin.hasDirectRole(existingRole)).thenReturn(true);
+
+        when(realmProvider.getRealmsStream()).thenAnswer(inv -> Stream.of(realm));
+        when(realmProvider.getRealm("realm-1")).thenReturn(realm);
+
+        var listener = registerAndCaptureListener();
+
+        try (var mocked = mockStatic(KeycloakModelUtils.class)) {
+            runTasksInline(mocked, session);
+
+            listener.onEvent(new PostMigrationEvent(sessionFactory));
+        }
+
+        verify(realm, never()).addRole(anyString());
+        verify(admin, never()).grantRole(any());
+    }
+
+    /**
+     * A realm that cannot be backfilled must not stop Keycloak booting, and must not stop the
+     * remaining realms being backfilled.
+     */
+    @Test
+    void onPostMigration_oneFailingRealmDoesNotStopTheOthersOrPropagate() {
+        when(session.getContext()).thenReturn(context);
+        when(session.realms()).thenReturn(realmProvider);
+        when(session.users()).thenReturn(userProvider);
+
+        var failingRealm = mock(RealmModel.class);
+        when(failingRealm.getId()).thenReturn("realm-bad");
+        when(failingRealm.getRole(anyString())).thenThrow(new RuntimeException("boom"));
+
+        var groupA = group("group-a");
+        var admin = approvedAdminOf(groupA);
+        var healthyRealm = realmWithFlatAdmins("realm-good", "raid", List.of(admin));
+        var createdRole = mock(RoleModel.class);
+        when(healthyRealm.getRole("service-point-admin:group-a")).thenReturn(null);
+        when(healthyRealm.addRole("service-point-admin:group-a")).thenReturn(createdRole);
+
+        when(realmProvider.getRealmsStream()).thenAnswer(inv -> Stream.of(failingRealm, healthyRealm));
+        when(realmProvider.getRealm("realm-bad")).thenReturn(failingRealm);
+        when(realmProvider.getRealm("realm-good")).thenReturn(healthyRealm);
+
+        var listener = registerAndCaptureListener();
+
+        try (var mocked = mockStatic(KeycloakModelUtils.class)) {
+            runTasksInline(mocked, session);
+
+            listener.onEvent(new PostMigrationEvent(sessionFactory));
+        }
+
+        verify(admin).grantRole(createdRole);
+    }
+
+    @Test
+    void onPostMigration_failureListingRealmsDoesNotPropagate() {
+        when(session.realms()).thenReturn(realmProvider);
+        when(realmProvider.getRealmsStream()).thenThrow(new RuntimeException("db down"));
+
+        var listener = registerAndCaptureListener();
+
+        try (var mocked = mockStatic(KeycloakModelUtils.class)) {
+            runTasksInline(mocked, session);
+
+            // Must not propagate: a thrown exception here would abort Keycloak startup.
+            assertDoesNotThrow(() -> listener.onEvent(new PostMigrationEvent(sessionFactory)));
+
+            // The realm listing is the only transaction attempted; no per-realm work follows.
+            mocked.verify(() -> KeycloakModelUtils.runJobInTransaction(any(), any()), times(1));
+        }
+    }
+}


### PR DESCRIPTION
[RAID-884](https://ardc.atlassian.net/browse/RAID-884)

## Why

The scoped `service-point-admin:<groupId>` realm roles that authorise the RAID-827 self-serve credential feature were provisioned in deployed environments only by an operator calling `POST /realms/raid/group/migrate-service-point-admins` by hand. A documented manual step does not satisfy the no-manual-deployment-steps NFR, and the step was never performed in ARDC's production, so the feature was inert there from the day it shipped.

Registration Agencies deploy onto platforms ARDC does not control, so any human step will be skipped somewhere. `raid-iam.jar` is the one artifact every agency runs regardless of platform, so the provisioning belongs there.

## What changed

- **`ServicePointAdminRoleProvisioner`** (new) — the backfill logic lifted out of `GroupController.migrateServicePointAdmins`, plus the role-name / create-if-absent / approved-membership helpers. Both callers now share it so they cannot drift.
- **`ServicePointAdminRoleBootstrapper`** (new) — registers a `PostMigrationEvent` listener from `GroupControllerResourceProviderFactory.postInit`, which was an empty no-op. Runs the backfill against every realm at every boot, each realm in its own transaction, failures logged and swallowed so provisioning can never stop Keycloak starting. Realms without the flat `group-admin` role (`master`, anything an agency runs alongside RAiD) are a no-op, so no realm name is configured.
- **`GroupController.migrateServicePointAdmins`** — same operator-only check and response shape, body now delegates. Demoted in the docs to a redundant safety net, deliberately not part of any deployment procedure.
- **`iam/doc/role-permissions.md`** section 9 — deployment note no longer describes a manual step as the mechanism.
- **ADR** `doc/adr/2026-09-11_boot-time-role-provisioning-via-postmigrationevent.md`.

## The open risk RAID-836 flagged, closed

Nobody had confirmed `PostMigrationEvent` actually fires here, particularly on a boot with no pending migration. Verified with a throwaway probe against `quay.io/keycloak/keycloak:26.6.2` (Quarkus) on Postgres **before** any real code was written. It fires on first boot; fires again on every restart with no migration pending; and fires **after** realm import and before the server takes traffic — the last matters as much as the others, since a hook running before import would find no realm.

## Verification

`./gradlew :iam:test` — **190 pass, 0 fail**. Six new bootstrapper tests (non-migration events ignored, grants across realms, no-op realm, idempotency, one failing realm neither aborting the others nor propagating, realm-listing failure not propagating) and one asserting `postInit` registers the listener. The **30 pre-existing `GroupController` migration tests pass unchanged** over the refactored code — that's the regression evidence for the extraction.

End to end, in an isolated Keycloak container, reproducing the production state:

1. Deleted both scoped roles from the seeded `raid` realm — 0 remaining, matching production.
2. Restarted Keycloak. **No operator action of any kind.**
3. Both roles recreated and re-granted to exactly their previous holders. Log: `realm 'raid' - 3 flat group-admin user(s), 2 scoped role(s) created, 3 grant(s) added, 0 already present`.
4. `raid-au-unapproved-admin` — a flat `group-admin` never approved for their group — correctly got nothing. The RAiD-608 / HELP-2844 exclusion survives the move.
5. Third restart changed nothing: `already up to date`, still exactly 2 roles.
6. `master` realm a no-op on every boot.

## Deliberately not done

- **No role for a group with no flat `group-admin` member.** AC 1 reads "every service point group"; such a role would have no holders and grant nothing, and SPI-created groups get theirs at creation. Flagged rather than silently widened.
- **Breadth unchanged.** A flat `group-admin` approved for several groups still gains the scoped role for all of them, exactly as the endpoint did. Narrowing it is a decision about who administers what and must not ride along inside a mechanism change. Pruning remains untracked — the deferring comment pointed at RAID-712, which is closed as Done while its AC 1 is unsatisfied for three production users. Needs a reopen or a new ticket.

## Deployment

No deployment step. Ships with the IAM image, takes effect on the next Keycloak start per environment. Production had the backfill run manually on 2026-09-11, so its first boot will report `already up to date`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)